### PR TITLE
pub year facet field with and without approx values included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .byebug_history
 /coverage
 .env
+.pry_history

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'blacklight', '~> 5.16'
 gem 'blacklight-gallery', '~> 0.3'
 gem 'blacklight-maps', '0.2.0'
 gem 'blacklight-spotlight', '~> 0.14'
-gem 'spotlight-dor-resources', '~> 0.3'
+gem 'spotlight-dor-resources', '~> 0.4' # get new pub year fields
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 gem 'devise-remote-user'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     dotenv (2.0.2)
     erubis (2.7.0)
     execjs (2.6.0)
-    exhibits_solr_conf (0.0.5.1)
+    exhibits_solr_conf (0.0.6)
     extlib (0.9.16)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -233,14 +233,14 @@ GEM
     ffi (1.9.10)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
-    gdor-indexer (0.3.0)
+    gdor-indexer (0.4.1)
       activesupport
       harvestdor-indexer
       hooks
       mail
       nokogiri
       rsolr
-      stanford-mods
+      stanford-mods (>= 1.3.4)
       trollop
     github-markup (1.4.0)
     globalid (0.3.6)
@@ -486,15 +486,14 @@ GEM
       nokogiri
       stomp
       xml-simple
-    spotlight-dor-resources (0.3.3)
+    spotlight-dor-resources (0.4.1)
       blacklight-spotlight (~> 0.6)
       faraday
-      gdor-indexer
+      gdor-indexer (>= 0.4.1)
       harvestdor-indexer (~> 2.3)
       parallel
       rails
       solrizer
-      stanford-mods (>= 1.3.0)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -510,7 +509,8 @@ GEM
     sshkit (1.8.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (1.3.3)
+    stanford-mods (1.3.4)
+      activesupport
       mods (~> 2.0.2)
     stomp (1.3.4)
     sul_styles (0.5.1)
@@ -606,7 +606,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   sitemap_generator
   social-share-button
-  spotlight-dor-resources (~> 0.3)
+  spotlight-dor-resources (~> 0.4)
   sqlite3
   squash_rails
   squash_ruby

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,7 +85,8 @@ class CatalogController < ApplicationController
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
     config.add_facet_field 'format_main_ssim', label: 'Resource type', limit: true
-    config.add_facet_field 'pub_date', label: 'Date', limit: true
+    config.add_facet_field 'pub_year_w_approx_isi', label: 'Date', limit: true
+    config.add_facet_field 'pub_year_no_approx_isi', label: 'Date (no approx)', limit: true
     config.add_facet_field 'language', label: 'Language', limit: true
     config.add_facet_field 'author_person_facet', label: 'Author', limit: true # includes Collectors
     config.add_facet_field 'author_no_collector_ssim', label: 'Author (no Collectors)', limit: true
@@ -127,7 +128,8 @@ class CatalogController < ApplicationController
     config.add_index_field 'language', label: 'Language'
     config.add_index_field 'physical', label: 'Physical Description'
     config.add_index_field 'pub_display', label: 'Publication Info'
-    config.add_index_field 'pub_date', label: 'Date'
+    config.add_index_field 'pub_year_w_approx_isi', label: 'Date'
+    config.add_index_field 'pub_year_no_approx_isi', label: 'Date (no approx)'
     config.add_index_field 'imprint_display', label: 'Imprint'
     config.add_index_field 'genre_ssim', label: 'Genre'
     config.add_index_field 'series_ssi', label: 'Series'

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -1,1 +1,2414 @@
-[{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"hj066rn6500","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea</title>\n  </titleInfo>\n  <name type=\"personal\">\n    <namePart>Chias, Benito.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">sp</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Barcelona</placeTerm>\n    </place>\n    <publisher>Editorial Martin</publisher>\n    <dateIssued>[194-?]</dateIssued>\n    <dateIssued encoding=\"marc\">194u</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">spa</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>2 maps on 1 sheet : col. ; 23 x 15 cm. and 23 x 15 cm., sheet 38 x 27 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">Benito Chias.</note>\n  <note>Relief shown by hachures and spot heights.</note>\n  <note>Includes four insets, Islas Elobey, Guines Éspānola, Isla De Corsico and Isla de Annobon.</note>\n  <note>Scale [ca. 1:250,000], 1:7,000,000 and 1:140,000.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f------</geographicCode>\n    <geographicCode authority=\"marcgac\">e-sp---</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:250,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Spain</geographic>\n    <topic>Colonies</topic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110510</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8836435</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Posesiones españolas en Africa Costa Occidental Golfo de Guinea","title_245a_display":"Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea","title_display":"Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea","title_full_display":"Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea.","author_person_facet":["Chias, Benito."],"author_sort":"Chias BenitoPosesiones españolas en Africa Costa Occidental  Golfo de Guinea","author_person_display":["Chias, Benito."],"author_person_full_display":["Chias, Benito."],"topic_display":["map","Colonies"],"topic_facet":["Colonies"],"geographic_facet":["Africa","Spain"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["Spanish"],"physical":["2 maps on 1 sheet : col. ; 23 x 15 cm. and 23 x 15 cm., sheet 38 x 27 cm."],"pub_display":["sp","Barcelona"],"pub_date_sort":"1940","imprint_display":["[194-?]"],"pub_date":"1940","pub_date_display":"[194-?]","pub_year_tisim":[1940],"publication_year_isi":1940,"druid":"hj066rn6500","url_fulltext":["http://purl.stanford.edu/hj066rn6500"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["hj066rn6500_00_0001"],"content_metadata_first_image_width_ssm":["9310"],"content_metadata_first_image_height_ssm":["6523"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/hj066rn6500%2Fhj066rn6500_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_full"],"coordinates_tesim":["(W18°--E51°/N37°--S35°)."],"last_updated":"2015-02-09T03:02:42Z","created":"2015-02-09T03:02:42Z","timestamp":"2015-02-09T03:02:42.205Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"wd297xz1362","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Gambia</title>\n  </titleInfo>\n  <name type=\"corporate\">\n    <namePart>Great Britain</namePart>\n    <namePart>War Office.</namePart>\n    <namePart>General Staff.</namePart>\n    <namePart>Geographical Section.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London</placeTerm>\n    </place>\n    <publisher>War Office</publisher>\n    <dateIssued>1928]</dateIssued>\n    <dateIssued encoding=\"marc\">1928</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : col.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <subject>\n    <cartographics>\n      <scale>Scale 1:500,000</scale>\n      <coordinates>(W16°--E28°/N13°--S15°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <relatedItem type=\"series\">\n    <titleInfo>\n      <title>GSGS ; 2447</title>\n    </titleInfo>\n  </relatedItem>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">NLE</recordContentSource>\n    <recordCreationDate encoding=\"marc\">091221</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8881439</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Gambia","title_245a_display":"Gambia","title_display":"Gambia","title_full_display":"Gambia.","author_other_facet":["Great Britain War Office. General Staff. Geographical Section."],"author_sort":"Great Britain War Office General Staff Geographical SectionGambia","author_corp_display":["Great Britain War Office. General Staff. Geographical Section."],"topic_display":["map"],"geographic_facet":["Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : col."],"pub_display":["enk","[London"],"pub_date_sort":"1928","imprint_display":["1928]"],"pub_date":"1928","pub_date_display":"1928]","pub_year_tisim":[1928],"publication_year_isi":1928,"druid":"wd297xz1362","url_fulltext":["http://purl.stanford.edu/wd297xz1362"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["wd297xz1362_00_0001"],"content_metadata_first_image_width_ssm":["18000"],"content_metadata_first_image_height_ssm":["8400"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/wd297xz1362%2Fwd297xz1362_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_full"],"coordinates_tesim":["(W16°--E28°/N13°--S15°)."],"last_updated":"2015-02-09T03:04:29Z","created":"2015-02-09T03:04:29Z","timestamp":"2015-02-09T03:04:29.629Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"xy658qf4887","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Atlas Vidal. Lablache</title>\n  </titleInfo>\n  <name type=\"personal\">\n    <namePart>Vidal de La Blache, Paul</namePart>\n    <namePart type=\"date\">1845-1918</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">fr</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Paris</placeTerm>\n    </place>\n    <publisher>A. Colin</publisher>\n    <dateIssued>1921</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">fre</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>Flles : col. ; 44 x 29 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>123. Carte Physique de l'Afrique. 1:40,000,000 Cartouche : Régions naturelles 1:90,000.</note>\n  <note>124-125. Afrique. Carte politique 1:30,000,000 Cartouches : Explorations en Afrique. 1:60,000,000. - Essai de carte économique. 1:60,000,000. - Basse-Egypte et Fayoum. 1:4,000.000.</note>\n  <note>126. Amérique. Carte physique. 1/55.000.000e. Cartouche. Petites Autriches (îles en Vent) 1:6,000,000.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:30,000,000]</scale>\n      <coordinates>(W35°--E63°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"\">\n    <geographic>World</geographic>\n    <topic>Atlas</topic>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110630</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8925402</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Atlas Vidal Lablache","title_245a_display":"Atlas Vidal. Lablache","title_display":"Atlas Vidal. Lablache","title_full_display":"Atlas Vidal. Lablache.","author_person_facet":["Vidal de La Blache, Paul, 1845-1918"],"author_sort":"Vidal de La Blache Paul 18451918Atlas Vidal Lablache","author_person_display":["Vidal de La Blache, Paul, 1845-1918"],"author_person_full_display":["Vidal de La Blache, Paul, 1845-1918"],"topic_display":["map","Atlas"],"topic_facet":["Atlas"],"geographic_facet":["World","Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["French"],"physical":["Flles : col. ; 44 x 29 cm."],"pub_display":["fr","Paris"],"pub_date_sort":"1921","imprint_display":["1921"],"pub_date":"1921","pub_date_display":"1921","pub_year_tisim":[1921],"publication_year_isi":1921,"druid":"xy658qf4887","url_fulltext":["http://purl.stanford.edu/xy658qf4887"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["xy658qf4887_00_0001"],"content_metadata_first_image_width_ssm":["13088"],"content_metadata_first_image_height_ssm":["9214"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/xy658qf4887%2Fxy658qf4887_00_0001/info.json","https://stacks.stanford.edu/image/iiif/xy658qf4887%2Fxy658qf4887_00_0002/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_square","https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_thumb","https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_large","https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_full","https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_full"],"coordinates_tesim":["(W35°--E63°/N37°--S35°)."],"last_updated":"2015-02-09T03:04:56Z","created":"2015-02-09T03:04:56Z","timestamp":"2015-02-09T03:04:56.547Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"wk210cf6868","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Africa: Industries and Communications</title>\n  </titleInfo>\n  <typeOfResource>cartographic</typeOfResource>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">xx</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">London : George Phillip and Son</placeTerm>\n    </place>\n    <dateIssued encoding=\"marc\">1906</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : col. ; 35 x 47 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>\"The Amalgamated Press Limited, London.\"</note>\n  <note>Lower right: \"136.\" Upper right: \"135.\"</note>\n  <note>\"The London Geographical Institute.\"</note>\n  <note>On verso: The Harmsworth Universal Atlas. Nos. 135-136. Africa: Industries and Communications. Index to the Commerical maps of the of the continents</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:20,000,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"blmlsh\">\n    <geographic>WORLD</geographic>\n    <topic>Industries and Communications-</topic>\n    <genre>Atlases</genre>\n    <temporal>1906-1908</temporal>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">Cst-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110222</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8940662</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Africa Industries and Communications","title_245a_display":"Africa: Industries and Communications","title_display":"Africa: Industries and Communications","title_full_display":"Africa: Industries and Communications.","author_sort":"􏿿 Africa Industries and Communications","topic_display":["Industries and Communications-"],"topic_facet":["Industries and Communications-"],"geographic_facet":["Africa","WORLD"],"era_facet":["1906-1908"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : col. ; 35 x 47 cm."],"pub_display":["xx","London : George Phillip and Son"],"pub_date_sort":"1906","imprint_display":["1906"],"pub_date":"1906","pub_date_display":"1906","pub_year_tisim":[1906],"publication_year_isi":1906,"druid":"wk210cf6868","url_fulltext":["http://purl.stanford.edu/wk210cf6868"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["wk210cf6868_00_0001"],"content_metadata_first_image_width_ssm":["9613"],"content_metadata_first_image_height_ssm":["12623"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/wk210cf6868%2Fwk210cf6868_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_full"],"coordinates_tesim":["(W18°--E51°/N37°--S35°)."],"last_updated":"2015-02-09T03:04:35Z","created":"2015-02-09T03:04:35Z","timestamp":"2015-02-09T03:04:35.169Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"hx676nr2846","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Ruwenzori</title>\n    <subTitle>to illustrate a paper by G.F. Scott-Elliot</subTitle>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Ravenstein, Ernst Georg</namePart>\n    <namePart type=\"date\">1834-1913</namePart>\n  </name>\n  <name type=\"corporate\">\n    <namePart>Royal Geographical Society (Great Britain)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London]</placeTerm>\n    </place>\n    <publisher>Royal Geographical Society</publisher>\n    <dateIssued>1895</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 27 x 25 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Relief shown by shading and spot heights.</note>\n  <note>Includes inset.</note>\n  <note>\"The geographical journal, 1895.\"</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f-ug---</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca: 1:500,000</scale>\n      <coordinates>(E29°--E31°/N1°--N0°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <name type=\"personal\">\n      <namePart>Elliot, G. F. Scott (George Francis Scott)</namePart>\n      <namePart type=\"date\">1862-1934</namePart>\n    </name>\n    <topic>Travel</topic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Ruwenzori Mountains (Congo and Uganda)</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Ruwenzori Mountains (Congo and Uganda)</geographic>\n    <topic>Discovery and exploration</topic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CGU</recordContentSource>\n    <recordCreationDate encoding=\"marc\">070501</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8837545</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n    <languageOfCataloging>\n      <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n    </languageOfCataloging>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Ruwenzori to illustrate a paper by GF ScottElliot","title_245a_display":"Ruwenzori","title_display":"Ruwenzori : to illustrate a paper by G.F. Scott-Elliot","title_full_display":"Ruwenzori : to illustrate a paper by G.F. Scott-Elliot.","author_person_facet":["Ravenstein, Ernst Georg, 1834-1913"],"author_other_facet":["Royal Geographical Society (Great Britain)"],"author_sort":"Ravenstein Ernst Georg 18341913Ruwenzori to illustrate a paper by GF ScottElliot","author_corp_display":["Royal Geographical Society (Great Britain)"],"author_person_display":["Ravenstein, Ernst Georg, 1834-1913"],"author_person_full_display":["Ravenstein, Ernst Georg, 1834-1913"],"topic_display":["map","Travel","Discovery and exploration"],"subject_other_display":["Elliot, G. F. Scott (George Francis Scott), 1862-1934"],"topic_facet":["Travel","Discovery and exploration","Elliot, G. F. Scott (George Francis Scott), 1862-1934"],"geographic_facet":["Ruwenzori Mountains (Congo and Uganda)","Ruwenzori Mountains (Congo and Uganda)"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : col. ; 27 x 25 cm."],"pub_display":["enk","[London]"],"pub_date_sort":"1895","imprint_display":["1895"],"pub_date":"1895","pub_date_display":"1895","pub_year_tisim":[1895],"publication_year_isi":1895,"druid":"hx676nr2846","url_fulltext":["http://purl.stanford.edu/hx676nr2846"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["hx676nr2846_00_0001"],"content_metadata_first_image_width_ssm":["6998"],"content_metadata_first_image_height_ssm":["5742"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/hx676nr2846%2Fhx676nr2846_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_full"],"coordinates_tesim":["(E29°--E31°/N1°--N0°)."],"last_updated":"2015-02-09T03:04:04Z","created":"2015-02-09T03:04:04Z","timestamp":"2015-02-09T03:04:04.543Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"nz926xc1513","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0204</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Map of South Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1892</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Unknown</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Rand, McNally Co.</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>48.5 x 66.5 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in statute miles and kilometers</mods:scale>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001653\">Southern Africa</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:note>Historic sites are illustrated, such as the diamond fields of Griqualand West. Title across top: Rand, McNally &amp; Company's Indexed Atlas of the World. Top left: 138. Top right: 139; Prime meridian through Greenwich.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0204, p. 230</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_sort":"Map of South Africa","title_245a_display":"Map of South Africa.","title_display":"Map of South Africa","title_full_display":"Map of South Africa.","author_sort":"􏿿 Map of South Africa","topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps","Southern Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["48.5 x 66.5 cm"],"pub_display":["Unknown"],"pub_date_sort":"1892","imprint_display":["1892"],"pub_date":"1892","pub_date_display":"1892","pub_year_tisim":[1892],"creation_year_isi":1892,"druid":"nz926xc1513","url_fulltext":["http://purl.stanford.edu/nz926xc1513"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_0256"],"content_metadata_first_image_width_ssm":["12599"],"content_metadata_first_image_height_ssm":["9706"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/nz926xc1513%2FAM_0256/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/nz926xc1513/AM_0256_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/nz926xc1513/AM_0256_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/nz926xc1513/AM_0256_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/nz926xc1513/AM_0256_full"],"last_updated":"2015-02-09T03:08:16Z","created":"2015-02-09T03:08:16Z","timestamp":"2015-02-09T03:08:16.477Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"gk885tn1705","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0148</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Afrique Physique.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1891</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Paris</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Migeon, J.</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>31 x 42 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in kilometers</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2010043385\">\n    <mods:namePart>Migeon, J.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2013137479\">\n    <mods:namePart>Lorsignol, G.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:titleInfo type=\"translated\">\n    <mods:title>Physical map of Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:note>Insets: Engraving of diamond fields by Fillatreau and Soudain. Heights of peaks and depths of lakes in Africa.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0148, p. 167</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_variant_display":["Physical map of Africa."],"title_sort":"Afrique Physique","title_245a_display":"Afrique Physique.","title_display":"Afrique Physique","title_full_display":"Afrique Physique.","author_person_facet":["Migeon, J.","Lorsignol, G."],"author_sort":"􏿿 Afrique Physique","author_person_display":["Migeon, J.","Lorsignol, G."],"author_person_full_display":["Migeon, J.","Lorsignol, G."],"topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["31 x 42 cm"],"pub_display":["Paris"],"pub_date_sort":"1891","imprint_display":["1891"],"pub_date":"1891","pub_date_display":"1891","pub_year_tisim":[1891],"creation_year_isi":1891,"druid":"gk885tn1705","url_fulltext":["http://purl.stanford.edu/gk885tn1705"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_0098"],"content_metadata_first_image_width_ssm":["11592"],"content_metadata_first_image_height_ssm":["9207"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/gk885tn1705%2FAM_0098/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/gk885tn1705/AM_0098_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/gk885tn1705/AM_0098_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/gk885tn1705/AM_0098_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/gk885tn1705/AM_0098_full"],"coordinates_tesim":["(W 18°--E 51°/N 37°--S 35°)"],"point_bbox":["-18.0 -35.0 51.0 37.0"],"last_updated":"2015-02-09T03:09:57Z","created":"2015-02-09T03:09:57Z","timestamp":"2015-02-09T03:09:57.15Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"zm589dr6916","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:physicalDescription>\n    <mods:form authority=\"smd\"/>\n    <mods:internetMediaType/>\n    <mods:extent>34 x 41 cm</mods:extent>\n    <mods:digitalOrigin/>\n  </mods:physicalDescription>\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 1011</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Kaart van Zuid-Afrika.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"approximate\" point=\"start\">1890</mods:dateCreated>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"no\" qualifier=\"approximate\" point=\"end\">1899</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Amsterdam</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>J. H. de Bussy</mods:publisher>\n  </mods:originInfo>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale/>\n      <mods:coordinates>(E 14°--E 34°/S 21°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001653\">Africa, Southern</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2013125962\">\n    <mods:namePart>Bussy, J. H. de</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_sort":"Kaart van ZuidAfrika","title_245a_display":"Kaart van Zuid-Afrika.","title_display":"Kaart van Zuid-Afrika","title_full_display":"Kaart van Zuid-Afrika.","author_person_facet":["Bussy, J. H. de"],"author_sort":"􏿿 Kaart van ZuidAfrika","author_person_display":["Bussy, J. H. de"],"author_person_full_display":["Bussy, J. H. de"],"topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps","Africa, Southern"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["34 x 41 cm"],"pub_display":["Amsterdam"],"pub_date_sort":"1890","imprint_display":["1890"],"pub_date":"1890","pub_date_display":"1890","pub_year_tisim":[1890],"creation_year_isi":1890,"druid":"zm589dr6916","url_fulltext":["http://purl.stanford.edu/zm589dr6916"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_0500"],"content_metadata_first_image_width_ssm":["10513"],"content_metadata_first_image_height_ssm":["8963"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/zm589dr6916%2FAM_0500/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/zm589dr6916/AM_0500_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/zm589dr6916/AM_0500_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/zm589dr6916/AM_0500_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/zm589dr6916/AM_0500_full"],"coordinates_tesim":["(E 14°--E 34°/S 21°--S 35°)"],"point_bbox":["14.0 -35.0 34.0 -21.0"],"last_updated":"2015-02-09T03:08:36Z","created":"2015-02-09T03:08:36Z","timestamp":"2015-02-09T03:08:36.73Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"by513wd0839","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa &amp; Upper Zambezi Rivers</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Shawe, W.</namePart>\n  </name>\n  <name type=\"corporate\">\n    <namePart>Royal Geographical Society (Great Britain)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London]</placeTerm>\n    </place>\n    <publisher>Royal Geographical Society</publisher>\n    <dateIssued>1890</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 21 x 21 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">W. Shawe.</note>\n  <note>Relief shown by hachures and spot heights.</note>\n  <note>Includes: \"Section from the Loangwa River in 13⁰45' S. Lat. to Lake Nyassa (Leopard Bay).\"</note>\n  <note>\"Published for the Proceedings of the Royal Geographical Society, 1890\"--In lower margin.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f-za---</geographicCode>\n    <geographicCode authority=\"marcgac\">f-mw---</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca: 1:2,700,000]</scale>\n      <coordinates>(E29°--E35/°S12°--S16°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <name type=\"personal\">\n      <namePart>Sharpe, Alfred</namePart>\n      <namePart type=\"date\">1853-1935</namePart>\n    </name>\n    <topic>Travel</topic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Zambia</geographic>\n    <topic>Discovery and exploration</topic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Malawi</geographic>\n    <topic>Discovery and exploration</topic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CGU</recordContentSource>\n    <recordCreationDate encoding=\"marc\">060425</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8832727</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n    <languageOfCataloging>\n      <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n    </languageOfCataloging>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Map illustrating Mr A Sharpes journey from Lake Nyassa to the Loangwa Upper Zambezi Rivers","title_245a_display":"Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers","title_display":"Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers","title_full_display":"Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers.","author_person_facet":["Shawe, W."],"author_other_facet":["Royal Geographical Society (Great Britain)"],"author_sort":"Shawe WMap illustrating Mr A Sharpes journey from Lake Nyassa to the Loangwa  Upper Zambezi Rivers","author_corp_display":["Royal Geographical Society (Great Britain)"],"author_person_display":["Shawe, W."],"author_person_full_display":["Shawe, W."],"topic_display":["map","Travel","Discovery and exploration","Discovery and exploration"],"subject_other_display":["Sharpe, Alfred, 1853-1935"],"topic_facet":["Travel","Discovery and exploration","Discovery and exploration","Sharpe, Alfred, 1853-1935"],"geographic_facet":["Zambia","Malawi"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : col. ; 21 x 21 cm."],"pub_display":["enk","[London]"],"pub_date_sort":"1890","imprint_display":["1890"],"pub_date":"1890","pub_date_display":"1890","pub_year_tisim":[1890],"publication_year_isi":1890,"druid":"by513wd0839","url_fulltext":["http://purl.stanford.edu/by513wd0839"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["by513wd0839_00_0001"],"content_metadata_first_image_width_ssm":["6212"],"content_metadata_first_image_height_ssm":["4155"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/by513wd0839%2Fby513wd0839_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_full"],"coordinates_tesim":["(E29°--E35/°S12°--S16°)."],"last_updated":"2015-02-09T03:02:10Z","created":"2015-02-09T03:02:10Z","timestamp":"2015-02-09T03:02:10.548Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"ht152fg3281","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>East Africa</title>\n    <subTitle>showing the recently-arranged political boundaries</subTitle>\n  </titleInfo>\n  <name type=\"corporate\">\n    <namePart>Royal Geographical Society (Great Britain)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London]</placeTerm>\n    </place>\n    <publisher>Royal Geographical Society</publisher>\n    <dateIssued>1887</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 21 x 25 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Relief shown by spot heights.</note>\n  <note>Shows demarcation between English and German sphere of influence in the Kenya/Tanzania area.</note>\n  <note>Includes insets: Eastern Somal[i]land -- [Zanzibar area].</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">fe-----</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale 1:8,000,000</scale>\n      <coordinates>(E20°--E51°/N37°--S5°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa, Eastern</geographic>\n    <topic>Boundaries</topic>\n    <genre>Maps</genre>\n  </subject>\n  <identifier type=\"oclc\">65468210</identifier>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CGU</recordContentSource>\n    <recordCreationDate encoding=\"marc\">060404</recordCreationDate>\n    <recordChangeDate encoding=\"iso8601\">20110105141829.0</recordChangeDate>\n    <recordIdentifier source=\"OCoLC\">a8832730</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n    <languageOfCataloging>\n      <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n    </languageOfCataloging>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"East Africa showing the recentlyarranged political boundaries","title_245a_display":"East Africa","title_display":"East Africa : showing the recently-arranged political boundaries","title_full_display":"East Africa : showing the recently-arranged political boundaries.","author_other_facet":["Royal Geographical Society (Great Britain)"],"author_sort":"Royal Geographical Society Great BritainEast Africa showing the recentlyarranged political boundaries","author_corp_display":["Royal Geographical Society (Great Britain)"],"topic_display":["map","Boundaries"],"topic_facet":["Boundaries"],"geographic_facet":["Africa, Eastern"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : col. ; 21 x 25 cm."],"pub_display":["enk","[London]"],"pub_date_sort":"1887","imprint_display":["1887"],"pub_date":"1887","pub_date_display":"1887","pub_year_tisim":[1887],"publication_year_isi":1887,"druid":"ht152fg3281","url_fulltext":["http://purl.stanford.edu/ht152fg3281"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["ht152fg3281_00_0001"],"content_metadata_first_image_width_ssm":["6528"],"content_metadata_first_image_height_ssm":["4119"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/ht152fg3281%2Fht152fg3281_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_full"],"coordinates_tesim":["(E20°--E51°/N37°--S5°)."],"last_updated":"2015-02-09T03:02:49Z","created":"2015-02-09T03:02:49Z","timestamp":"2015-02-09T03:02:49.354Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"cx876zn3079","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0345</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Pretoria</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Landmeter Generaal's Kantoor</mods:publisher>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"\">1886</mods:dateCreated>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>12 x 23.5 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>No scale given</mods:scale>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2014012373\">\n    <mods:namePart>Rissik, Johann, 1857-1925</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:titleInfo type=\"translated\">\n    <mods:title>Plan of the proclaimed gold-fields at the Witwatersrand.</mods:title>\n  </mods:titleInfo>\n  <mods:note>Photocopy. \"This diagram is of great historical importance, as it is believed to be the first diagram depicting the location of the village of Johannesburg on government ground, and the first diagram showing the location of Mynpachts, mining right leases on Witwatersrand gold fields ... \". Inset: Lyst van Mynpachten Toegestaan.</mods:note>\n  <mods:note>Uncolored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0345, p. 394</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_variant_display":["Plan of the proclaimed gold-fields at the Witwatersrand."],"title_sort":"Plan van de geproclameerde Goud Velden te Witwatersrand ZAR","title_245a_display":"Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.","title_display":"Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R","title_full_display":"Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.","author_person_facet":["Rissik, Johann, 1857-1925"],"author_sort":"􏿿 Plan van de geproclameerde Goud Velden te Witwatersrand ZAR","author_person_display":["Rissik, Johann, 1857-1925"],"author_person_full_display":["Rissik, Johann, 1857-1925"],"topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["12 x 23.5 cm"],"pub_display":["Pretoria"],"pub_date_sort":"1886","imprint_display":["1886"],"pub_date":"1886","pub_date_display":"1886","pub_year_tisim":[1886],"creation_year_isi":1886,"druid":"cx876zn3079","url_fulltext":["http://purl.stanford.edu/cx876zn3079"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_0261"],"content_metadata_first_image_width_ssm":["10870"],"content_metadata_first_image_height_ssm":["8263"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/cx876zn3079%2FAM_0261/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/cx876zn3079/AM_0261_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/cx876zn3079/AM_0261_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/cx876zn3079/AM_0261_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/cx876zn3079/AM_0261_full"],"last_updated":"2015-02-09T03:09:10Z","created":"2015-02-09T03:09:10Z","timestamp":"2015-02-09T03:09:10.09Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"rn350bb9484","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0201</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>South Africa by Jas Wyld, Geographer to the Queen.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:place>\n      <mods:placeTerm type=\"text\">London</mods:placeTerm>\n    </mods:place>\n    <mods:publisher/>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"\">1886</mods:dateCreated>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>52 x 82 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in miles</mods:scale>\n      <mods:coordinates>(E 6°59′--E 41°44′/S 5°8′--S 37°32′)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001653\">Southern Africa</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n83049169\">\n    <mods:namePart>Wyld, James, 1812-1887</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note>Part of a series of South African maps, (see NOR 0198, NOR 0199, NOR 0200). Verso: 33.</mods:note>\n  <mods:note>Outline color</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0210, p. 227</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_sort":"South Africa by Jas Wyld Geographer to the Queen","title_245a_display":"South Africa by Jas Wyld, Geographer to the Queen.","title_display":"South Africa by Jas Wyld, Geographer to the Queen","title_full_display":"South Africa by Jas Wyld, Geographer to the Queen.","author_person_facet":["Wyld, James, 1812-1887"],"author_sort":"􏿿 South Africa by Jas Wyld Geographer to the Queen","author_person_display":["Wyld, James, 1812-1887"],"author_person_full_display":["Wyld, James, 1812-1887"],"topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps","Southern Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["52 x 82 cm"],"pub_display":["London"],"pub_date_sort":"1886","imprint_display":["1886"],"pub_date":"1886","pub_date_display":"1886","pub_year_tisim":[1886],"creation_year_isi":1886,"druid":"rn350bb9484","url_fulltext":["http://purl.stanford.edu/rn350bb9484"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_604"],"content_metadata_first_image_width_ssm":["14944"],"content_metadata_first_image_height_ssm":["10412"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/rn350bb9484%2FAM_604/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/rn350bb9484/AM_604_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/rn350bb9484/AM_604_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/rn350bb9484/AM_604_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/rn350bb9484/AM_604_full"],"coordinates_tesim":["(E 6°59′--E 41°44′/S 5°8′--S 37°32′)"],"point_bbox":["6.0 -37.0 41.0 -5.0"],"last_updated":"2015-02-09T03:09:04Z","created":"2015-02-09T03:09:04Z","timestamp":"2015-02-09T03:09:04.719Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"rg759wj0953","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Africa</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Bevan, G. Phillips</namePart>\n    <namePart type=\"date\">1829?-1889</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">London</placeTerm>\n    </place>\n    <publisher>G. Philip and Son</publisher>\n    <dateIssued>1885</dateIssued>\n    <edition>3rd ed.</edition>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 col. map. 22 x 26 cm. on sheet 25 x 30 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Found in: Royal relief atlas of all parts of the world :</note>\n  <note>Map is accompanied by a leaf of description on verso.</note>\n  <note>\"No. 26.\" in uppper right corner.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:60,000,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <topic>Relief models</topic>\n  </subject>\n  <subject authority=\"lcsh\">\n    <topic>World maps</topic>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CST-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110412</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a9131116</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Africa","title_245a_display":"Africa","title_display":"Africa","title_full_display":"Africa.","author_person_facet":["Bevan, G. Phillips, 1829?-1889"],"author_sort":"Bevan G Phillips 18291889Africa","author_person_display":["Bevan, G. Phillips, 1829?-1889"],"author_person_full_display":["Bevan, G. Phillips, 1829?-1889"],"topic_display":["map","Relief models","World maps"],"topic_facet":["Relief models","World maps"],"geographic_facet":["Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 col. map. 22 x 26 cm. on sheet 25 x 30 cm."],"pub_display":["enk","London"],"pub_date_sort":"1885","imprint_display":["1885"],"pub_date":"1885","pub_date_display":"1885","pub_year_tisim":[1885],"publication_year_isi":1885,"druid":"rg759wj0953","url_fulltext":["http://purl.stanford.edu/rg759wj0953"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["rg759wj0953_00_0003"],"content_metadata_first_image_width_ssm":["6254"],"content_metadata_first_image_height_ssm":["11236"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_0003/info.json","https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0001/info.json","https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0002/info.json","https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0003/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_square","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_square","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_square","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_thumb","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_thumb","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_thumb","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_large","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_large","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_large","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_full","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_full","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_full","https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_full"],"coordinates_tesim":["(W18°--E51°/N37°--S35°)."],"last_updated":"2015-02-09T03:03:51Z","created":"2015-02-09T03:03:51Z","timestamp":"2015-02-09T03:03:51.387Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:10"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/pb900ct4951"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"pb900ct4951","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Birds eye view of the Soudan and surrounding countries</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Maclure.</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Macdonald.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[S.l.]</placeTerm>\n    </place>\n    <publisher>[s.n.]</publisher>\n    <dateIssued>1884</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : col.</extent>\n  </physicalDescription>\n  <tableOfContents>With portraits of General Gordon and Colonel Stewart, and four inset views of Khartoum and other notable sites.</tableOfContents>\n  <tableOfContents>With tables giving distances between most important towns.</tableOfContents>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Scale not give. Scale and coordinates determined from other sources.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:8,000,000]</scale>\n      <coordinates>(E12°--E54°/N35°--N6°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"blmlsh\">\n    <geographic>Sudan -</geographic>\n    <genre>Views</genre>\n    <temporal>1884</temporal>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">UKMGB</recordContentSource>\n    <recordCreationDate encoding=\"marc\">030929</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8836595</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Birds eye view of the Soudan and surrounding countries","title_245a_display":"Birds eye view of the Soudan and surrounding countries","title_display":"Birds eye view of the Soudan and surrounding countries","title_full_display":"Birds eye view of the Soudan and surrounding countries.","author_person_facet":["Maclure.","Macdonald."],"author_sort":"MaclureBirds eye view of the Soudan and surrounding countries","author_person_display":["Maclure.","Macdonald."],"author_person_full_display":["Maclure.","Macdonald."],"geographic_facet":["Sudan -"],"era_facet":["1884"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : col."],"pub_display":["enk","[S.l.]"],"pub_date_sort":"1884","imprint_display":["1884"],"pub_date":"1884","pub_date_display":"1884","pub_year_tisim":[1884],"publication_year_isi":1884,"druid":"pb900ct4951","url_fulltext":["http://purl.stanford.edu/pb900ct4951"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["pb900ct4951_00_0001"],"content_metadata_first_image_width_ssm":["13897"],"content_metadata_first_image_height_ssm":["9834"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/pb900ct4951%2Fpb900ct4951_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_full"],"coordinates_tesim":["(E12°--E54°/N35°--N6°)."],"last_updated":"2015-02-09T03:10:56Z","created":"2015-02-09T03:10:56Z","timestamp":"2015-02-09T03:10:56.308Z","exhibit_1_tags_ssim":["nile","nilex"]},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"gm036df2527","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0146</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Map of Africa Showing its most Recent Discoveries.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Philadelphia</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Mitchell, S. Augustus (Samuel Augustus), 1792-1868</mods:publisher>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"\">1881</mods:dateCreated>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>27 x 34 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in miles</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n50036750\">\n    <mods:namePart>Mitchell, S. Augustus (Samuel Augustus), 1792-1868</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n88043012\">\n    <mods:namePart>Williams, W. (Wellington)</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note>\"First appeared in Mitchell's New General Atlas in 1867\". Map shows expedition routes of Stanley and Livingstone. Inset: Island of St. Helena (place where Napoleon was buried). Top right: 120; Prime meridian through Washington.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0146, p. 165</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_sort":"Map of Africa Showing its most Recent Discoveries","title_245a_display":"Map of Africa Showing its most Recent Discoveries.","title_display":"Map of Africa Showing its most Recent Discoveries","title_full_display":"Map of Africa Showing its most Recent Discoveries.","author_person_facet":["Mitchell, S. Augustus (Samuel Augustus), 1792-1868","Williams, W. (Wellington)"],"author_sort":"􏿿 Map of Africa Showing its most Recent Discoveries","author_person_display":["Mitchell, S. Augustus (Samuel Augustus), 1792-1868","Williams, W. (Wellington)"],"author_person_full_display":["Mitchell, S. Augustus (Samuel Augustus), 1792-1868","Williams, W. (Wellington)"],"topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["27 x 34 cm"],"pub_display":["Philadelphia"],"pub_date_sort":"1881","imprint_display":["1881"],"pub_date":"1881","pub_date_display":"1881","pub_year_tisim":[1881],"creation_year_isi":1881,"druid":"gm036df2527","url_fulltext":["http://purl.stanford.edu/gm036df2527"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_0100"],"content_metadata_first_image_width_ssm":["8686"],"content_metadata_first_image_height_ssm":["7557"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/gm036df2527%2FAM_0100/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/gm036df2527/AM_0100_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/gm036df2527/AM_0100_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/gm036df2527/AM_0100_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/gm036df2527/AM_0100_full"],"coordinates_tesim":["(W 18°--E 51°/N 37°--S 35°)"],"point_bbox":["-18.0 -35.0 51.0 37.0"],"last_updated":"2015-02-09T03:06:55Z","created":"2015-02-09T03:06:55Z","timestamp":"2015-02-09T03:06:55.684Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"wr055hy7401","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Nordwest-Afrika</title>\n  </titleInfo>\n  <name type=\"personal\">\n    <namePart>Petermann, August.</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Hanemann, Fritz.</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Habenicht, Hermann.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">gw</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Gotha</placeTerm>\n    </place>\n    <publisher>Perthes</publisher>\n    <dateIssued>[1881]</dateIssued>\n    <dateIssued encoding=\"marc\">1881</dateIssued>\n    <edition>Rev. 1882</edition>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">ger</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 Map. : col ; 43 x 36 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">von A. Petermann. Bearbeitet v. Hanemann &amp; Habenicht</note>\n  <note>Stieler's Hand-Atlas No. 69. - with 3 insets.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:12,500,000]</scale>\n      <coordinates>(W30°--E20°/N37°--S2°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa, North</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa, West</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Sierra Leone</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Gold Coast</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Senegambia</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110705</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8837560</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"NordwestAfrika","title_245a_display":"Nordwest-Afrika","title_display":"Nordwest-Afrika","title_full_display":"Nordwest-Afrika.","author_person_facet":["Petermann, August.","Hanemann, Fritz.","Habenicht, Hermann."],"author_sort":"Petermann AugustNordwestAfrika","author_person_display":["Petermann, August.","Hanemann, Fritz.","Habenicht, Hermann."],"author_person_full_display":["Petermann, August.","Hanemann, Fritz.","Habenicht, Hermann."],"geographic_facet":["Africa, North","Africa, West","Sierra Leone","Gold Coast","Senegambia"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["German"],"physical":["1 Map. : col ; 43 x 36 cm."],"pub_display":["gw","Gotha"],"pub_date_sort":"1881","imprint_display":["[1881]"],"pub_date":"1881","pub_date_display":"[1881]","pub_year_tisim":[1881],"publication_year_isi":1881,"druid":"wr055hy7401","url_fulltext":["http://purl.stanford.edu/wr055hy7401"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["wr055hy7401_00_0001"],"content_metadata_first_image_width_ssm":["11416"],"content_metadata_first_image_height_ssm":["9342"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/wr055hy7401%2Fwr055hy7401_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_full"],"coordinates_tesim":["(W30°--E20°/N37°--S2°)."],"last_updated":"2015-02-09T03:04:53Z","created":"2015-02-09T03:04:53Z","timestamp":"2015-02-09T03:04:53.463Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:7"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/qb438pg7646"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"qy240vt8937","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0144</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1880</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">London</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Tallis, John, 1817-1876</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>24 x 32 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>No scale given</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n88192201\">\n    <mods:namePart>Tallis, John, 1817-1876</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\" http://id.loc.gov/authorities/names/n83227676\">\n    <mods:namePart>Rapkin, J.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note>Steel</mods:note>\n  <mods:note>Five engraved vignettes are seen, an Arab family of Algeria, Bosjeman Hottentots, a view of St. Helena, a Bedouin Arabs' encampment and Korranna Hottentots. \"The illustrations were drawn by J. Marchant and engraved by J.H. Kernot. The map was drawn and engraved by J. Rapkin\"; Prime meridian through Greenwich.</mods:note>\n  <mods:note>Outline color</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0144, p. 163</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n","title_sort":"Africa","title_245a_display":"Africa.","title_display":"Africa","title_full_display":"Africa.","author_person_facet":["Tallis, John, 1817-1876","Rapkin, J."],"author_sort":"􏿿 Africa","author_person_display":["Tallis, John, 1817-1876","Rapkin, J."],"author_person_full_display":["Tallis, John, 1817-1876","Rapkin, J."],"topic_display":["map","Digital maps"],"geographic_facet":["Africa--Maps"],"format_main_ssim":["Map"],"format":["Map/Globe"],"physical":["24 x 32 cm"],"pub_display":["London"],"pub_date_sort":"1880","imprint_display":["1880"],"pub_date":"1880","pub_date_display":"1880","pub_year_tisim":[1880],"creation_year_isi":1880,"druid":"qy240vt8937","url_fulltext":["http://purl.stanford.edu/qy240vt8937"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["qb438pg7646"],"collection_with_title":["qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["AM_0250"],"content_metadata_first_image_width_ssm":["11036"],"content_metadata_first_image_height_ssm":["9084"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/qy240vt8937%2FAM_0250/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/qy240vt8937/AM_0250_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/qy240vt8937/AM_0250_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/qy240vt8937/AM_0250_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/qy240vt8937/AM_0250_full"],"coordinates_tesim":["(W 18°--E 51°/N 37°--S 35°)"],"point_bbox":["-18.0 -35.0 51.0 37.0"],"last_updated":"2015-02-09T03:06:48Z","created":"2015-02-09T03:06:48Z","timestamp":"2015-02-09T03:06:48.765Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"fx703zs6529","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Afrika im Massstab v. 1:25.000.000</title>\n  </titleInfo>\n  <titleInfo type=\"alternative\">\n    <title>Afrika im Massstab von 1:25.000.000</title>\n  </titleInfo>\n  <titleInfo type=\"alternative\">\n    <title>Adolf Stieler's Hand Atlas über alle Theile der Eund über das Weltgebäude</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Petermann, A. (August)</namePart>\n    <namePart type=\"date\">1822-1878</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Habenicht, H.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">gw</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Gotha</placeTerm>\n    </place>\n    <publisher>Justus Perthes</publisher>\n    <dateIssued>1880</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">ger</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 34 x 40 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">entworfen v. A. Petermann ; gezeichnet v. H. Habenicht.</note>\n  <note>Relief shown by hachures and spot heights.</note>\n  <note>Appears in Adolf Stieler's Hand Atlas über alle Theile der Erde und über das Weltgebäude. 1881.</note>\n  <note>\"Stieler's Hand Atlas, no. 68.\"</note>\n  <note>In bottom margin: X IX.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f------</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:25,000,000]</scale>\n      <coordinates>(W18°--E73°/N37°--S34°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CtY</recordContentSource>\n    <recordCreationDate encoding=\"marc\">020607</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8884267</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_variant_display":["Afrika im Massstab von 1:25.000.000","Adolf Stieler's Hand Atlas über alle Theile der Eund über das Weltgebäude"],"title_sort":"Afrika im Massstab v 125000000","title_245a_display":"Afrika im Massstab v. 1:25.000.000","title_display":"Afrika im Massstab v. 1:25.000.000","title_full_display":"Afrika im Massstab v. 1:25.000.000.","author_person_facet":["Petermann, A. (August), 1822-1878","Habenicht, H."],"author_sort":"Petermann A August 18221878Afrika im Massstab v 125000000","author_person_display":["Petermann, A. (August), 1822-1878","Habenicht, H."],"author_person_full_display":["Petermann, A. (August), 1822-1878","Habenicht, H."],"topic_display":["map"],"geographic_facet":["Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["German"],"physical":["1 map : col. ; 34 x 40 cm."],"pub_display":["gw","Gotha"],"pub_date_sort":"1880","imprint_display":["1880"],"pub_date":"1880","pub_date_display":"1880","pub_year_tisim":[1880],"publication_year_isi":1880,"druid":"fx703zs6529","url_fulltext":["http://purl.stanford.edu/fx703zs6529"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["fx703zs6529_00_0001"],"content_metadata_first_image_width_ssm":["11423"],"content_metadata_first_image_height_ssm":["9431"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/fx703zs6529%2Ffx703zs6529_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_full"],"coordinates_tesim":["(W18°--E73°/N37°--S34°)."],"last_updated":"2015-02-09T03:02:31Z","created":"2015-02-09T03:02:31Z","timestamp":"2015-02-09T03:02:31.943Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"qy458yc1855","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Afrique</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Andriveau-Goujon, E. (Eugène)</namePart>\n    <namePart type=\"date\">1832-1897</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">fr</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Paris</placeTerm>\n    </place>\n    <publisher>E. Andriveau-Goujon, éditeur ...</publisher>\n    <dateIssued>1880</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">fre</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : hand col. ; 61 x 45 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">E. Andriveau-Goujon ...</note>\n  <note>Relief shown by hachures.</note>\n  <note>In Upper right corner: \"Atlas Usuel, No. 26\" and \"Atlas Universel, No. 39\"</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">ff-----</geographicCode>\n    <geographicCode authority=\"marcgac\">ae-----</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>scale [ca. 1:15,000,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110216</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8939000</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Afrique","title_245a_display":"Afrique","title_display":"Afrique","title_full_display":"Afrique.","author_person_facet":["Andriveau-Goujon, E. (Eugène), 1832-1897"],"author_sort":"AndriveauGoujon E Eugène 18321897Afrique","author_person_display":["Andriveau-Goujon, E. (Eugène), 1832-1897"],"author_person_full_display":["Andriveau-Goujon, E. (Eugène), 1832-1897"],"topic_display":["map"],"geographic_facet":["Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["French"],"physical":["1 map : hand col. ; 61 x 45 cm."],"pub_display":["fr","Paris"],"pub_date_sort":"1880","imprint_display":["1880"],"pub_date":"1880","pub_date_display":"1880","pub_year_tisim":[1880],"publication_year_isi":1880,"druid":"qy458yc1855","url_fulltext":["http://purl.stanford.edu/qy458yc1855"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["qy458yc1855_00_0001"],"content_metadata_first_image_width_ssm":["16810"],"content_metadata_first_image_height_ssm":["12784"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/qy458yc1855%2Fqy458yc1855_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_full"],"coordinates_tesim":["(W18°--E51°/N37°--S35°)."],"last_updated":"2015-02-09T03:03:47Z","created":"2015-02-09T03:03:47Z","timestamp":"2015-02-09T03:03:47.053Z"},{"spotlight_exhibit_slug_default-exhibit_bsi":[true],"spotlight_resource_id_ssim":["spotlight/resources/purls:6"],"spotlight_resource_url_ssim":["http://purl.stanford.edu/ct961sj2730"],"spotlight_resource_type_ssim":["spotlight/resources/purls"],"id":"ct493wg6431","modsxml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Africa</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Bartholomew, John</namePart>\n    <namePart type=\"date\">1831-1893</namePart>\n  </name>\n  <name type=\"corporate\">\n    <namePart>Adam and Charles Black (Firm)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">stk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Edinburgh</placeTerm>\n    </place>\n    <publisher>A. &amp; C. Black</publisher>\n    <dateIssued>[1879?]</dateIssued>\n    <dateIssued encoding=\"marc\">1879</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : hand col. ; 53 x 42 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">by J. Bartholomew, F.R.G.S.</note>\n  <note>Relief shown by hachures.</note>\n  <note>Prime meridian: Greenwich.</note>\n  <note>\"Engraved by J. Bartholomew Edin.r.\"</note>\n  <note>In lower right corner: 36.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f------</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:18,500,000]</scale>\n      <coordinates>(W20°--E50°/N40°--S40°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">NDD</recordContentSource>\n    <recordCreationDate encoding=\"marc\">851004</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8923346</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n","title_sort":"Africa","title_245a_display":"Africa","title_display":"Africa","title_full_display":"Africa.","author_person_facet":["Bartholomew, John, 1831-1893"],"author_other_facet":["Adam and Charles Black (Firm)"],"author_sort":"Bartholomew John 18311893Africa","author_corp_display":["Adam and Charles Black (Firm)"],"author_person_display":["Bartholomew, John, 1831-1893"],"author_person_full_display":["Bartholomew, John, 1831-1893"],"topic_display":["map"],"geographic_facet":["Africa"],"format_main_ssim":["Map"],"format":["Map/Globe"],"language":["English"],"physical":["1 map : hand col. ; 53 x 42 cm."],"pub_display":["stk","Edinburgh"],"pub_date_sort":"1879","imprint_display":["[1879?]"],"pub_date":"1879","pub_date_display":"[1879?]","pub_year_tisim":[1879],"publication_year_isi":1879,"druid":"ct493wg6431","url_fulltext":["http://purl.stanford.edu/ct493wg6431"],"access_facet":["Online"],"display_type":["file"],"building_facet":["Stanford Digital Repository"],"collection":["ct961sj2730"],"collection_with_title":["ct961sj2730-|-The Caroline Batchelor Map Collection"],"content_metadata_type_ssim":["image"],"content_metadata_type_ssm":["image"],"content_metadata_first_image_file_name_ssm":["ct493wg6431_00_0001"],"content_metadata_first_image_width_ssm":["11069"],"content_metadata_first_image_height_ssm":["14750"],"content_metadata_image_iiif_info_ssm":["https://stacks.stanford.edu/image/iiif/ct493wg6431%2Fct493wg6431_00_0001/info.json"],"thumbnail_square_url_ssm":["https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_square"],"thumbnail_url_ssm":["https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_thumb"],"large_image_url_ssm":["https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_large"],"full_image_url_ssm":["https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_full"],"coordinates_tesim":["(W20°--E50°/N40°--S40°)."],"last_updated":"2015-02-09T03:02:25Z","created":"2015-02-09T03:02:25Z","timestamp":"2015-02-09T03:02:25.188Z"}]
+[
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Chias, Benito."
+        ],
+        "author_person_facet": [
+            "Chias, Benito."
+        ],
+        "author_person_full_display": [
+            "Chias, Benito."
+        ],
+        "author_sort": "Chias BenitoPosesiones españolas en Africa Costa Occidental  Golfo de Guinea",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "hj066rn6500_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "6523"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "9310"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/hj066rn6500%2Fhj066rn6500_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W18°--E51°/N37°--S35°)."
+        ],
+        "created": "2015-02-09T03:02:42Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "hj066rn6500",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa",
+            "Spain"
+        ],
+        "id": "hj066rn6500",
+        "imprint_display": [
+            "[194-?]"
+        ],
+        "language": [
+            "Spanish"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:02:42Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea</title>\n  </titleInfo>\n  <name type=\"personal\">\n    <namePart>Chias, Benito.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">sp</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Barcelona</placeTerm>\n    </place>\n    <publisher>Editorial Martin</publisher>\n    <dateIssued>[194-?]</dateIssued>\n    <dateIssued encoding=\"marc\">194u</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">spa</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>2 maps on 1 sheet : col. ; 23 x 15 cm. and 23 x 15 cm., sheet 38 x 27 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">Benito Chias.</note>\n  <note>Relief shown by hachures and spot heights.</note>\n  <note>Includes four insets, Islas Elobey, Guines Éspānola, Isla De Corsico and Isla de Annobon.</note>\n  <note>Scale [ca. 1:250,000], 1:7,000,000 and 1:140,000.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f------</geographicCode>\n    <geographicCode authority=\"marcgac\">e-sp---</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:250,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Spain</geographic>\n    <topic>Colonies</topic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110510</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8836435</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "2 maps on 1 sheet : col. ; 23 x 15 cm. and 23 x 15 cm., sheet 38 x 27 cm."
+        ],
+        "pub_date": "1940",
+        "pub_date_sort": "1940",
+        "pub_display": [
+            "sp",
+            "Barcelona"
+        ],
+        "pub_year_tisim": [
+            1940
+        ],
+        "publication_year_isi": 1940,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/hj066rn6500/hj066rn6500_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:02:42.205Z",
+        "title_245a_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea",
+        "title_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea",
+        "title_full_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea.",
+        "title_sort": "Posesiones españolas en Africa Costa Occidental Golfo de Guinea",
+        "topic_display": [
+            "map",
+            "Colonies"
+        ],
+        "topic_facet": [
+            "Colonies"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/hj066rn6500"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_corp_display": [
+            "Great Britain War Office. General Staff. Geographical Section."
+        ],
+        "author_other_facet": [
+            "Great Britain War Office. General Staff. Geographical Section."
+        ],
+        "author_sort": "Great Britain War Office General Staff Geographical SectionGambia",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "wd297xz1362_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "8400"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "18000"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/wd297xz1362%2Fwd297xz1362_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W16°--E28°/N13°--S15°)."
+        ],
+        "created": "2015-02-09T03:04:29Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "wd297xz1362",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa"
+        ],
+        "id": "wd297xz1362",
+        "imprint_display": [
+            "1928]"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:04:29Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Gambia</title>\n  </titleInfo>\n  <name type=\"corporate\">\n    <namePart>Great Britain</namePart>\n    <namePart>War Office.</namePart>\n    <namePart>General Staff.</namePart>\n    <namePart>Geographical Section.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London</placeTerm>\n    </place>\n    <publisher>War Office</publisher>\n    <dateIssued>1928]</dateIssued>\n    <dateIssued encoding=\"marc\">1928</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : col.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <subject>\n    <cartographics>\n      <scale>Scale 1:500,000</scale>\n      <coordinates>(W16°--E28°/N13°--S15°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <relatedItem type=\"series\">\n    <titleInfo>\n      <title>GSGS ; 2447</title>\n    </titleInfo>\n  </relatedItem>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">NLE</recordContentSource>\n    <recordCreationDate encoding=\"marc\">091221</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8881439</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col."
+        ],
+        "pub_date": "1928",
+        "pub_date_sort": "1928",
+        "pub_display": [
+            "enk",
+            "[London"
+        ],
+        "pub_year_tisim": [
+            1928
+        ],
+        "publication_year_isi": 1928,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/wd297xz1362/wd297xz1362_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:04:29.629Z",
+        "title_245a_display": "Gambia",
+        "title_display": "Gambia",
+        "title_full_display": "Gambia.",
+        "title_sort": "Gambia",
+        "topic_display": [
+            "map"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/wd297xz1362"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Vidal de La Blache, Paul, 1845-1918"
+        ],
+        "author_person_facet": [
+            "Vidal de La Blache, Paul, 1845-1918"
+        ],
+        "author_person_full_display": [
+            "Vidal de La Blache, Paul, 1845-1918"
+        ],
+        "author_sort": "Vidal de La Blache Paul 18451918Atlas Vidal Lablache",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "xy658qf4887_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9214"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "13088"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/xy658qf4887%2Fxy658qf4887_00_0001/info.json",
+            "https://stacks.stanford.edu/image/iiif/xy658qf4887%2Fxy658qf4887_00_0002/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W35°--E63°/N37°--S35°)."
+        ],
+        "created": "2015-02-09T03:04:56Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "xy658qf4887",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_full",
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_full"
+        ],
+        "geographic_facet": [
+            "World",
+            "Africa"
+        ],
+        "id": "xy658qf4887",
+        "imprint_display": [
+            "1921"
+        ],
+        "language": [
+            "French"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_large",
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_large"
+        ],
+        "last_updated": "2015-02-09T03:04:56Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Atlas Vidal. Lablache</title>\n  </titleInfo>\n  <name type=\"personal\">\n    <namePart>Vidal de La Blache, Paul</namePart>\n    <namePart type=\"date\">1845-1918</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">fr</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Paris</placeTerm>\n    </place>\n    <publisher>A. Colin</publisher>\n    <dateIssued>1921</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">fre</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>Flles : col. ; 44 x 29 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>123. Carte Physique de l'Afrique. 1:40,000,000 Cartouche : Régions naturelles 1:90,000.</note>\n  <note>124-125. Afrique. Carte politique 1:30,000,000 Cartouches : Explorations en Afrique. 1:60,000,000. - Essai de carte économique. 1:60,000,000. - Basse-Egypte et Fayoum. 1:4,000.000.</note>\n  <note>126. Amérique. Carte physique. 1/55.000.000e. Cartouche. Petites Autriches (îles en Vent) 1:6,000,000.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:30,000,000]</scale>\n      <coordinates>(W35°--E63°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"\">\n    <geographic>World</geographic>\n    <topic>Atlas</topic>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110630</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8925402</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "Flles : col. ; 44 x 29 cm."
+        ],
+        "pub_date": "1921",
+        "pub_date_sort": "1921",
+        "pub_display": [
+            "fr",
+            "Paris"
+        ],
+        "pub_year_tisim": [
+            1921
+        ],
+        "publication_year_isi": 1921,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_square",
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0001_thumb",
+            "https://stacks.stanford.edu/image/xy658qf4887/xy658qf4887_00_0002_thumb"
+        ],
+        "timestamp": "2015-02-09T03:04:56.547Z",
+        "title_245a_display": "Atlas Vidal. Lablache",
+        "title_display": "Atlas Vidal. Lablache",
+        "title_full_display": "Atlas Vidal. Lablache.",
+        "title_sort": "Atlas Vidal Lablache",
+        "topic_display": [
+            "map",
+            "Atlas"
+        ],
+        "topic_facet": [
+            "Atlas"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/xy658qf4887"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_sort": "􏿿 Africa Industries and Communications",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "wk210cf6868_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "12623"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "9613"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/wk210cf6868%2Fwk210cf6868_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W18°--E51°/N37°--S35°)."
+        ],
+        "created": "2015-02-09T03:04:35Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "wk210cf6868",
+        "era_facet": [
+            "1906-1908"
+        ],
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa",
+            "WORLD"
+        ],
+        "id": "wk210cf6868",
+        "imprint_display": [
+            "1906"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:04:35Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Africa: Industries and Communications</title>\n  </titleInfo>\n  <typeOfResource>cartographic</typeOfResource>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">xx</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">London : George Phillip and Son</placeTerm>\n    </place>\n    <dateIssued encoding=\"marc\">1906</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : col. ; 35 x 47 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>\"The Amalgamated Press Limited, London.\"</note>\n  <note>Lower right: \"136.\" Upper right: \"135.\"</note>\n  <note>\"The London Geographical Institute.\"</note>\n  <note>On verso: The Harmsworth Universal Atlas. Nos. 135-136. Africa: Industries and Communications. Index to the Commerical maps of the of the continents</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:20,000,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"blmlsh\">\n    <geographic>WORLD</geographic>\n    <topic>Industries and Communications-</topic>\n    <genre>Atlases</genre>\n    <temporal>1906-1908</temporal>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">Cst-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110222</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8940662</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col. ; 35 x 47 cm."
+        ],
+        "pub_date": "1906",
+        "pub_date_sort": "1906",
+        "pub_display": [
+            "xx",
+            "London : George Phillip and Son"
+        ],
+        "pub_year_tisim": [
+            1906
+        ],
+        "publication_year_isi": 1906,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/wk210cf6868/wk210cf6868_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:04:35.169Z",
+        "title_245a_display": "Africa: Industries and Communications",
+        "title_display": "Africa: Industries and Communications",
+        "title_full_display": "Africa: Industries and Communications.",
+        "title_sort": "Africa Industries and Communications",
+        "topic_display": [
+            "Industries and Communications-"
+        ],
+        "topic_facet": [
+            "Industries and Communications-"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/wk210cf6868"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_corp_display": [
+            "Royal Geographical Society (Great Britain)"
+        ],
+        "author_other_facet": [
+            "Royal Geographical Society (Great Britain)"
+        ],
+        "author_person_display": [
+            "Ravenstein, Ernst Georg, 1834-1913"
+        ],
+        "author_person_facet": [
+            "Ravenstein, Ernst Georg, 1834-1913"
+        ],
+        "author_person_full_display": [
+            "Ravenstein, Ernst Georg, 1834-1913"
+        ],
+        "author_sort": "Ravenstein Ernst Georg 18341913Ruwenzori to illustrate a paper by GF ScottElliot",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "hx676nr2846_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "5742"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "6998"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/hx676nr2846%2Fhx676nr2846_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(E29°--E31°/N1°--N0°)."
+        ],
+        "created": "2015-02-09T03:04:04Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "hx676nr2846",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Ruwenzori Mountains (Congo and Uganda)",
+            "Ruwenzori Mountains (Congo and Uganda)"
+        ],
+        "id": "hx676nr2846",
+        "imprint_display": [
+            "1895"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:04:04Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Ruwenzori</title>\n    <subTitle>to illustrate a paper by G.F. Scott-Elliot</subTitle>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Ravenstein, Ernst Georg</namePart>\n    <namePart type=\"date\">1834-1913</namePart>\n  </name>\n  <name type=\"corporate\">\n    <namePart>Royal Geographical Society (Great Britain)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London]</placeTerm>\n    </place>\n    <publisher>Royal Geographical Society</publisher>\n    <dateIssued>1895</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 27 x 25 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Relief shown by shading and spot heights.</note>\n  <note>Includes inset.</note>\n  <note>\"The geographical journal, 1895.\"</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f-ug---</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca: 1:500,000</scale>\n      <coordinates>(E29°--E31°/N1°--N0°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <name type=\"personal\">\n      <namePart>Elliot, G. F. Scott (George Francis Scott)</namePart>\n      <namePart type=\"date\">1862-1934</namePart>\n    </name>\n    <topic>Travel</topic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Ruwenzori Mountains (Congo and Uganda)</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Ruwenzori Mountains (Congo and Uganda)</geographic>\n    <topic>Discovery and exploration</topic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CGU</recordContentSource>\n    <recordCreationDate encoding=\"marc\">070501</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8837545</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n    <languageOfCataloging>\n      <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n    </languageOfCataloging>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col. ; 27 x 25 cm."
+        ],
+        "pub_date": "1895",
+        "pub_date_sort": "1895",
+        "pub_display": [
+            "enk",
+            "[London]"
+        ],
+        "pub_year_tisim": [
+            1895
+        ],
+        "publication_year_isi": 1895,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "subject_other_display": [
+            "Elliot, G. F. Scott (George Francis Scott), 1862-1934"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/hx676nr2846/hx676nr2846_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:04:04.543Z",
+        "title_245a_display": "Ruwenzori",
+        "title_display": "Ruwenzori : to illustrate a paper by G.F. Scott-Elliot",
+        "title_full_display": "Ruwenzori : to illustrate a paper by G.F. Scott-Elliot.",
+        "title_sort": "Ruwenzori to illustrate a paper by GF ScottElliot",
+        "topic_display": [
+            "map",
+            "Travel",
+            "Discovery and exploration"
+        ],
+        "topic_facet": [
+            "Travel",
+            "Discovery and exploration",
+            "Elliot, G. F. Scott (George Francis Scott), 1862-1934"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/hx676nr2846"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_sort": "􏿿 Map of South Africa",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_0256"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9706"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "12599"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/nz926xc1513%2FAM_0256/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "created": "2015-02-09T03:08:16Z",
+        "creation_year_isi": 1892,
+        "display_type": [
+            "file"
+        ],
+        "druid": "nz926xc1513",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/nz926xc1513/AM_0256_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps",
+            "Southern Africa"
+        ],
+        "id": "nz926xc1513",
+        "imprint_display": [
+            "1892"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/nz926xc1513/AM_0256_large"
+        ],
+        "last_updated": "2015-02-09T03:08:16Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0204</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Map of South Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1892</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Unknown</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Rand, McNally Co.</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>48.5 x 66.5 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in statute miles and kilometers</mods:scale>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001653\">Southern Africa</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:note>Historic sites are illustrated, such as the diamond fields of Griqualand West. Title across top: Rand, McNally &amp; Company's Indexed Atlas of the World. Top left: 138. Top right: 139; Prime meridian through Greenwich.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0204, p. 230</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "48.5 x 66.5 cm"
+        ],
+        "pub_date": "1892",
+        "pub_date_sort": "1892",
+        "pub_display": [
+            "Unknown"
+        ],
+        "pub_year_tisim": [
+            1892
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/nz926xc1513/AM_0256_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/nz926xc1513/AM_0256_thumb"
+        ],
+        "timestamp": "2015-02-09T03:08:16.477Z",
+        "title_245a_display": "Map of South Africa.",
+        "title_display": "Map of South Africa",
+        "title_full_display": "Map of South Africa.",
+        "title_sort": "Map of South Africa",
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/nz926xc1513"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Migeon, J.",
+            "Lorsignol, G."
+        ],
+        "author_person_facet": [
+            "Migeon, J.",
+            "Lorsignol, G."
+        ],
+        "author_person_full_display": [
+            "Migeon, J.",
+            "Lorsignol, G."
+        ],
+        "author_sort": "􏿿 Afrique Physique",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_0098"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9207"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "11592"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/gk885tn1705%2FAM_0098/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W 18°--E 51°/N 37°--S 35°)"
+        ],
+        "created": "2015-02-09T03:09:57Z",
+        "creation_year_isi": 1891,
+        "display_type": [
+            "file"
+        ],
+        "druid": "gk885tn1705",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/gk885tn1705/AM_0098_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps"
+        ],
+        "id": "gk885tn1705",
+        "imprint_display": [
+            "1891"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/gk885tn1705/AM_0098_large"
+        ],
+        "last_updated": "2015-02-09T03:09:57Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0148</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Afrique Physique.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1891</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Paris</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Migeon, J.</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>31 x 42 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in kilometers</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2010043385\">\n    <mods:namePart>Migeon, J.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2013137479\">\n    <mods:namePart>Lorsignol, G.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:titleInfo type=\"translated\">\n    <mods:title>Physical map of Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:note>Insets: Engraving of diamond fields by Fillatreau and Soudain. Heights of peaks and depths of lakes in Africa.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0148, p. 167</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "31 x 42 cm"
+        ],
+        "point_bbox": [
+            "-18.0 -35.0 51.0 37.0"
+        ],
+        "pub_date": "1891",
+        "pub_date_sort": "1891",
+        "pub_display": [
+            "Paris"
+        ],
+        "pub_year_tisim": [
+            1891
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/gk885tn1705/AM_0098_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/gk885tn1705/AM_0098_thumb"
+        ],
+        "timestamp": "2015-02-09T03:09:57.15Z",
+        "title_245a_display": "Afrique Physique.",
+        "title_display": "Afrique Physique",
+        "title_full_display": "Afrique Physique.",
+        "title_sort": "Afrique Physique",
+        "title_variant_display": [
+            "Physical map of Africa."
+        ],
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/gk885tn1705"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Bussy, J. H. de"
+        ],
+        "author_person_facet": [
+            "Bussy, J. H. de"
+        ],
+        "author_person_full_display": [
+            "Bussy, J. H. de"
+        ],
+        "author_sort": "􏿿 Kaart van ZuidAfrika",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_0500"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "8963"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "10513"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/zm589dr6916%2FAM_0500/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(E 14°--E 34°/S 21°--S 35°)"
+        ],
+        "created": "2015-02-09T03:08:36Z",
+        "creation_year_isi": 1890,
+        "display_type": [
+            "file"
+        ],
+        "druid": "zm589dr6916",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/zm589dr6916/AM_0500_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps",
+            "Africa, Southern"
+        ],
+        "id": "zm589dr6916",
+        "imprint_display": [
+            "1890"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/zm589dr6916/AM_0500_large"
+        ],
+        "last_updated": "2015-02-09T03:08:36Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:physicalDescription>\n    <mods:form authority=\"smd\"/>\n    <mods:internetMediaType/>\n    <mods:extent>34 x 41 cm</mods:extent>\n    <mods:digitalOrigin/>\n  </mods:physicalDescription>\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 1011</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Kaart van Zuid-Afrika.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"approximate\" point=\"start\">1890</mods:dateCreated>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"no\" qualifier=\"approximate\" point=\"end\">1899</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Amsterdam</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>J. H. de Bussy</mods:publisher>\n  </mods:originInfo>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale/>\n      <mods:coordinates>(E 14°--E 34°/S 21°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001653\">Africa, Southern</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2013125962\">\n    <mods:namePart>Bussy, J. H. de</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "34 x 41 cm"
+        ],
+        "point_bbox": [
+            "14.0 -35.0 34.0 -21.0"
+        ],
+        "pub_date": "1890",
+        "pub_date_sort": "1890",
+        "pub_display": [
+            "Amsterdam"
+        ],
+        "pub_year_tisim": [
+            1890
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/zm589dr6916/AM_0500_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/zm589dr6916/AM_0500_thumb"
+        ],
+        "timestamp": "2015-02-09T03:08:36.73Z",
+        "title_245a_display": "Kaart van Zuid-Afrika.",
+        "title_display": "Kaart van Zuid-Afrika",
+        "title_full_display": "Kaart van Zuid-Afrika.",
+        "title_sort": "Kaart van ZuidAfrika",
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/zm589dr6916"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_corp_display": [
+            "Royal Geographical Society (Great Britain)"
+        ],
+        "author_other_facet": [
+            "Royal Geographical Society (Great Britain)"
+        ],
+        "author_person_display": [
+            "Shawe, W."
+        ],
+        "author_person_facet": [
+            "Shawe, W."
+        ],
+        "author_person_full_display": [
+            "Shawe, W."
+        ],
+        "author_sort": "Shawe WMap illustrating Mr A Sharpes journey from Lake Nyassa to the Loangwa  Upper Zambezi Rivers",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "by513wd0839_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "4155"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "6212"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/by513wd0839%2Fby513wd0839_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(E29°--E35/°S12°--S16°)."
+        ],
+        "created": "2015-02-09T03:02:10Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "by513wd0839",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Zambia",
+            "Malawi"
+        ],
+        "id": "by513wd0839",
+        "imprint_display": [
+            "1890"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:02:10Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa &amp; Upper Zambezi Rivers</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Shawe, W.</namePart>\n  </name>\n  <name type=\"corporate\">\n    <namePart>Royal Geographical Society (Great Britain)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London]</placeTerm>\n    </place>\n    <publisher>Royal Geographical Society</publisher>\n    <dateIssued>1890</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 21 x 21 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">W. Shawe.</note>\n  <note>Relief shown by hachures and spot heights.</note>\n  <note>Includes: \"Section from the Loangwa River in 13⁰45' S. Lat. to Lake Nyassa (Leopard Bay).\"</note>\n  <note>\"Published for the Proceedings of the Royal Geographical Society, 1890\"--In lower margin.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f-za---</geographicCode>\n    <geographicCode authority=\"marcgac\">f-mw---</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca: 1:2,700,000]</scale>\n      <coordinates>(E29°--E35/°S12°--S16°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <name type=\"personal\">\n      <namePart>Sharpe, Alfred</namePart>\n      <namePart type=\"date\">1853-1935</namePart>\n    </name>\n    <topic>Travel</topic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Zambia</geographic>\n    <topic>Discovery and exploration</topic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Malawi</geographic>\n    <topic>Discovery and exploration</topic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CGU</recordContentSource>\n    <recordCreationDate encoding=\"marc\">060425</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8832727</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n    <languageOfCataloging>\n      <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n    </languageOfCataloging>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col. ; 21 x 21 cm."
+        ],
+        "pub_date": "1890",
+        "pub_date_sort": "1890",
+        "pub_display": [
+            "enk",
+            "[London]"
+        ],
+        "pub_year_tisim": [
+            1890
+        ],
+        "publication_year_isi": 1890,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "subject_other_display": [
+            "Sharpe, Alfred, 1853-1935"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/by513wd0839/by513wd0839_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:02:10.548Z",
+        "title_245a_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers",
+        "title_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers",
+        "title_full_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers.",
+        "title_sort": "Map illustrating Mr A Sharpes journey from Lake Nyassa to the Loangwa Upper Zambezi Rivers",
+        "topic_display": [
+            "map",
+            "Travel",
+            "Discovery and exploration",
+            "Discovery and exploration"
+        ],
+        "topic_facet": [
+            "Travel",
+            "Discovery and exploration",
+            "Discovery and exploration",
+            "Sharpe, Alfred, 1853-1935"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/by513wd0839"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_corp_display": [
+            "Royal Geographical Society (Great Britain)"
+        ],
+        "author_other_facet": [
+            "Royal Geographical Society (Great Britain)"
+        ],
+        "author_sort": "Royal Geographical Society Great BritainEast Africa showing the recentlyarranged political boundaries",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "ht152fg3281_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "4119"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "6528"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/ht152fg3281%2Fht152fg3281_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(E20°--E51°/N37°--S5°)."
+        ],
+        "created": "2015-02-09T03:02:49Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "ht152fg3281",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa, Eastern"
+        ],
+        "id": "ht152fg3281",
+        "imprint_display": [
+            "1887"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:02:49Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>East Africa</title>\n    <subTitle>showing the recently-arranged political boundaries</subTitle>\n  </titleInfo>\n  <name type=\"corporate\">\n    <namePart>Royal Geographical Society (Great Britain)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[London]</placeTerm>\n    </place>\n    <publisher>Royal Geographical Society</publisher>\n    <dateIssued>1887</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 21 x 25 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Relief shown by spot heights.</note>\n  <note>Shows demarcation between English and German sphere of influence in the Kenya/Tanzania area.</note>\n  <note>Includes insets: Eastern Somal[i]land -- [Zanzibar area].</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">fe-----</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale 1:8,000,000</scale>\n      <coordinates>(E20°--E51°/N37°--S5°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa, Eastern</geographic>\n    <topic>Boundaries</topic>\n    <genre>Maps</genre>\n  </subject>\n  <identifier type=\"oclc\">65468210</identifier>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CGU</recordContentSource>\n    <recordCreationDate encoding=\"marc\">060404</recordCreationDate>\n    <recordChangeDate encoding=\"iso8601\">20110105141829.0</recordChangeDate>\n    <recordIdentifier source=\"OCoLC\">a8832730</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n    <languageOfCataloging>\n      <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n    </languageOfCataloging>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col. ; 21 x 25 cm."
+        ],
+        "pub_date": "1887",
+        "pub_date_sort": "1887",
+        "pub_display": [
+            "enk",
+            "[London]"
+        ],
+        "pub_year_tisim": [
+            1887
+        ],
+        "publication_year_isi": 1887,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/ht152fg3281/ht152fg3281_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:02:49.354Z",
+        "title_245a_display": "East Africa",
+        "title_display": "East Africa : showing the recently-arranged political boundaries",
+        "title_full_display": "East Africa : showing the recently-arranged political boundaries.",
+        "title_sort": "East Africa showing the recentlyarranged political boundaries",
+        "topic_display": [
+            "map",
+            "Boundaries"
+        ],
+        "topic_facet": [
+            "Boundaries"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/ht152fg3281"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Rissik, Johann, 1857-1925"
+        ],
+        "author_person_facet": [
+            "Rissik, Johann, 1857-1925"
+        ],
+        "author_person_full_display": [
+            "Rissik, Johann, 1857-1925"
+        ],
+        "author_sort": "􏿿 Plan van de geproclameerde Goud Velden te Witwatersrand ZAR",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_0261"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "8263"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "10870"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/cx876zn3079%2FAM_0261/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "created": "2015-02-09T03:09:10Z",
+        "creation_year_isi": 1886,
+        "display_type": [
+            "file"
+        ],
+        "druid": "cx876zn3079",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/cx876zn3079/AM_0261_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps"
+        ],
+        "id": "cx876zn3079",
+        "imprint_display": [
+            "1886"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/cx876zn3079/AM_0261_large"
+        ],
+        "last_updated": "2015-02-09T03:09:10Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0345</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Pretoria</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Landmeter Generaal's Kantoor</mods:publisher>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"\">1886</mods:dateCreated>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>12 x 23.5 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>No scale given</mods:scale>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2014012373\">\n    <mods:namePart>Rissik, Johann, 1857-1925</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:titleInfo type=\"translated\">\n    <mods:title>Plan of the proclaimed gold-fields at the Witwatersrand.</mods:title>\n  </mods:titleInfo>\n  <mods:note>Photocopy. \"This diagram is of great historical importance, as it is believed to be the first diagram depicting the location of the village of Johannesburg on government ground, and the first diagram showing the location of Mynpachts, mining right leases on Witwatersrand gold fields ... \". Inset: Lyst van Mynpachten Toegestaan.</mods:note>\n  <mods:note>Uncolored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0345, p. 394</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "12 x 23.5 cm"
+        ],
+        "pub_date": "1886",
+        "pub_date_sort": "1886",
+        "pub_display": [
+            "Pretoria"
+        ],
+        "pub_year_tisim": [
+            1886
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/cx876zn3079/AM_0261_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/cx876zn3079/AM_0261_thumb"
+        ],
+        "timestamp": "2015-02-09T03:09:10.09Z",
+        "title_245a_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.",
+        "title_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R",
+        "title_full_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.",
+        "title_sort": "Plan van de geproclameerde Goud Velden te Witwatersrand ZAR",
+        "title_variant_display": [
+            "Plan of the proclaimed gold-fields at the Witwatersrand."
+        ],
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/cx876zn3079"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Wyld, James, 1812-1887"
+        ],
+        "author_person_facet": [
+            "Wyld, James, 1812-1887"
+        ],
+        "author_person_full_display": [
+            "Wyld, James, 1812-1887"
+        ],
+        "author_sort": "􏿿 South Africa by Jas Wyld Geographer to the Queen",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_604"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "10412"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "14944"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/rn350bb9484%2FAM_604/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(E 6°59′--E 41°44′/S 5°8′--S 37°32′)"
+        ],
+        "created": "2015-02-09T03:09:04Z",
+        "creation_year_isi": 1886,
+        "display_type": [
+            "file"
+        ],
+        "druid": "rn350bb9484",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/rn350bb9484/AM_604_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps",
+            "Southern Africa"
+        ],
+        "id": "rn350bb9484",
+        "imprint_display": [
+            "1886"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/rn350bb9484/AM_604_large"
+        ],
+        "last_updated": "2015-02-09T03:09:04Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0201</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>South Africa by Jas Wyld, Geographer to the Queen.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:place>\n      <mods:placeTerm type=\"text\">London</mods:placeTerm>\n    </mods:place>\n    <mods:publisher/>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"\">1886</mods:dateCreated>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>52 x 82 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in miles</mods:scale>\n      <mods:coordinates>(E 6°59′--E 41°44′/S 5°8′--S 37°32′)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001653\">Southern Africa</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n83049169\">\n    <mods:namePart>Wyld, James, 1812-1887</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note>Part of a series of South African maps, (see NOR 0198, NOR 0199, NOR 0200). Verso: 33.</mods:note>\n  <mods:note>Outline color</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0210, p. 227</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "52 x 82 cm"
+        ],
+        "point_bbox": [
+            "6.0 -37.0 41.0 -5.0"
+        ],
+        "pub_date": "1886",
+        "pub_date_sort": "1886",
+        "pub_display": [
+            "London"
+        ],
+        "pub_year_tisim": [
+            1886
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/rn350bb9484/AM_604_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/rn350bb9484/AM_604_thumb"
+        ],
+        "timestamp": "2015-02-09T03:09:04.719Z",
+        "title_245a_display": "South Africa by Jas Wyld, Geographer to the Queen.",
+        "title_display": "South Africa by Jas Wyld, Geographer to the Queen",
+        "title_full_display": "South Africa by Jas Wyld, Geographer to the Queen.",
+        "title_sort": "South Africa by Jas Wyld Geographer to the Queen",
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/rn350bb9484"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Bevan, G. Phillips, 1829?-1889"
+        ],
+        "author_person_facet": [
+            "Bevan, G. Phillips, 1829?-1889"
+        ],
+        "author_person_full_display": [
+            "Bevan, G. Phillips, 1829?-1889"
+        ],
+        "author_sort": "Bevan G Phillips 18291889Africa",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "rg759wj0953_00_0003"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "11236"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "6254"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_0003/info.json",
+            "https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0001/info.json",
+            "https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0002/info.json",
+            "https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0003/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W18°--E51°/N37°--S35°)."
+        ],
+        "created": "2015-02-09T03:03:51Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "rg759wj0953",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_full",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_full",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_full",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_full"
+        ],
+        "geographic_facet": [
+            "Africa"
+        ],
+        "id": "rg759wj0953",
+        "imprint_display": [
+            "1885"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_large",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_large",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_large",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_large"
+        ],
+        "last_updated": "2015-02-09T03:03:51Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Africa</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Bevan, G. Phillips</namePart>\n    <namePart type=\"date\">1829?-1889</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">London</placeTerm>\n    </place>\n    <publisher>G. Philip and Son</publisher>\n    <dateIssued>1885</dateIssued>\n    <edition>3rd ed.</edition>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 col. map. 22 x 26 cm. on sheet 25 x 30 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Found in: Royal relief atlas of all parts of the world :</note>\n  <note>Map is accompanied by a leaf of description on verso.</note>\n  <note>\"No. 26.\" in uppper right corner.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:60,000,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <topic>Relief models</topic>\n  </subject>\n  <subject authority=\"lcsh\">\n    <topic>World maps</topic>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CST-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110412</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a9131116</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 col. map. 22 x 26 cm. on sheet 25 x 30 cm."
+        ],
+        "pub_date": "1885",
+        "pub_date_sort": "1885",
+        "pub_display": [
+            "enk",
+            "London"
+        ],
+        "pub_year_tisim": [
+            1885
+        ],
+        "publication_year_isi": 1885,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_square",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_square",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_square",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_0003_thumb",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0001_thumb",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0002_thumb",
+            "https://stacks.stanford.edu/image/rg759wj0953/rg759wj0953_00_00_0003_thumb"
+        ],
+        "timestamp": "2015-02-09T03:03:51.387Z",
+        "title_245a_display": "Africa",
+        "title_display": "Africa",
+        "title_full_display": "Africa.",
+        "title_sort": "Africa",
+        "topic_display": [
+            "map",
+            "Relief models",
+            "World maps"
+        ],
+        "topic_facet": [
+            "Relief models",
+            "World maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/rg759wj0953"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Maclure.",
+            "Macdonald."
+        ],
+        "author_person_facet": [
+            "Maclure.",
+            "Macdonald."
+        ],
+        "author_person_full_display": [
+            "Maclure.",
+            "Macdonald."
+        ],
+        "author_sort": "MaclureBirds eye view of the Soudan and surrounding countries",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "pb900ct4951_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9834"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "13897"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/pb900ct4951%2Fpb900ct4951_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(E12°--E54°/N35°--N6°)."
+        ],
+        "created": "2015-02-09T03:10:56Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "pb900ct4951",
+        "era_facet": [
+            "1884"
+        ],
+        "exhibit_1_tags_ssim": [
+            "nile",
+            "nilex"
+        ],
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Sudan -"
+        ],
+        "id": "pb900ct4951",
+        "imprint_display": [
+            "1884"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:10:56Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Birds eye view of the Soudan and surrounding countries</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Maclure.</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Macdonald.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">enk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">[S.l.]</placeTerm>\n    </place>\n    <publisher>[s.n.]</publisher>\n    <dateIssued>1884</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : col.</extent>\n  </physicalDescription>\n  <tableOfContents>With portraits of General Gordon and Colonel Stewart, and four inset views of Khartoum and other notable sites.</tableOfContents>\n  <tableOfContents>With tables giving distances between most important towns.</tableOfContents>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\"/>\n  <note>Scale not give. Scale and coordinates determined from other sources.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:8,000,000]</scale>\n      <coordinates>(E12°--E54°/N35°--N6°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"blmlsh\">\n    <geographic>Sudan -</geographic>\n    <genre>Views</genre>\n    <temporal>1884</temporal>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">UKMGB</recordContentSource>\n    <recordCreationDate encoding=\"marc\">030929</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8836595</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col."
+        ],
+        "pub_date": "1884",
+        "pub_date_sort": "1884",
+        "pub_display": [
+            "enk",
+            "[S.l.]"
+        ],
+        "pub_year_tisim": [
+            1884
+        ],
+        "publication_year_isi": 1884,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:10"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/pb900ct4951"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/pb900ct4951/pb900ct4951_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:10:56.308Z",
+        "title_245a_display": "Birds eye view of the Soudan and surrounding countries",
+        "title_display": "Birds eye view of the Soudan and surrounding countries",
+        "title_full_display": "Birds eye view of the Soudan and surrounding countries.",
+        "title_sort": "Birds eye view of the Soudan and surrounding countries",
+        "url_fulltext": [
+            "http://purl.stanford.edu/pb900ct4951"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
+            "Williams, W. (Wellington)"
+        ],
+        "author_person_facet": [
+            "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
+            "Williams, W. (Wellington)"
+        ],
+        "author_person_full_display": [
+            "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
+            "Williams, W. (Wellington)"
+        ],
+        "author_sort": "􏿿 Map of Africa Showing its most Recent Discoveries",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_0100"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "7557"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "8686"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/gm036df2527%2FAM_0100/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W 18°--E 51°/N 37°--S 35°)"
+        ],
+        "created": "2015-02-09T03:06:55Z",
+        "creation_year_isi": 1881,
+        "display_type": [
+            "file"
+        ],
+        "druid": "gm036df2527",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/gm036df2527/AM_0100_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps"
+        ],
+        "id": "gm036df2527",
+        "imprint_display": [
+            "1881"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/gm036df2527/AM_0100_large"
+        ],
+        "last_updated": "2015-02-09T03:06:55Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0146</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Map of Africa Showing its most Recent Discoveries.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Philadelphia</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Mitchell, S. Augustus (Samuel Augustus), 1792-1868</mods:publisher>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"\">1881</mods:dateCreated>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>27 x 34 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in miles</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n50036750\">\n    <mods:namePart>Mitchell, S. Augustus (Samuel Augustus), 1792-1868</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n88043012\">\n    <mods:namePart>Williams, W. (Wellington)</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note>\"First appeared in Mitchell's New General Atlas in 1867\". Map shows expedition routes of Stanley and Livingstone. Inset: Island of St. Helena (place where Napoleon was buried). Top right: 120; Prime meridian through Washington.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0146, p. 165</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "27 x 34 cm"
+        ],
+        "point_bbox": [
+            "-18.0 -35.0 51.0 37.0"
+        ],
+        "pub_date": "1881",
+        "pub_date_sort": "1881",
+        "pub_display": [
+            "Philadelphia"
+        ],
+        "pub_year_tisim": [
+            1881
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/gm036df2527/AM_0100_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/gm036df2527/AM_0100_thumb"
+        ],
+        "timestamp": "2015-02-09T03:06:55.684Z",
+        "title_245a_display": "Map of Africa Showing its most Recent Discoveries.",
+        "title_display": "Map of Africa Showing its most Recent Discoveries",
+        "title_full_display": "Map of Africa Showing its most Recent Discoveries.",
+        "title_sort": "Map of Africa Showing its most Recent Discoveries",
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/gm036df2527"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Petermann, August.",
+            "Hanemann, Fritz.",
+            "Habenicht, Hermann."
+        ],
+        "author_person_facet": [
+            "Petermann, August.",
+            "Hanemann, Fritz.",
+            "Habenicht, Hermann."
+        ],
+        "author_person_full_display": [
+            "Petermann, August.",
+            "Hanemann, Fritz.",
+            "Habenicht, Hermann."
+        ],
+        "author_sort": "Petermann AugustNordwestAfrika",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "wr055hy7401_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9342"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "11416"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/wr055hy7401%2Fwr055hy7401_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W30°--E20°/N37°--S2°)."
+        ],
+        "created": "2015-02-09T03:04:53Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "wr055hy7401",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa, North",
+            "Africa, West",
+            "Sierra Leone",
+            "Gold Coast",
+            "Senegambia"
+        ],
+        "id": "wr055hy7401",
+        "imprint_display": [
+            "[1881]"
+        ],
+        "language": [
+            "German"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:04:53Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Nordwest-Afrika</title>\n  </titleInfo>\n  <name type=\"personal\">\n    <namePart>Petermann, August.</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Hanemann, Fritz.</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Habenicht, Hermann.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">gw</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Gotha</placeTerm>\n    </place>\n    <publisher>Perthes</publisher>\n    <dateIssued>[1881]</dateIssued>\n    <dateIssued encoding=\"marc\">1881</dateIssued>\n    <edition>Rev. 1882</edition>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">ger</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 Map. : col ; 43 x 36 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">von A. Petermann. Bearbeitet v. Hanemann &amp; Habenicht</note>\n  <note>Stieler's Hand-Atlas No. 69. - with 3 insets.</note>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:12,500,000]</scale>\n      <coordinates>(W30°--E20°/N37°--S2°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa, North</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa, West</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Sierra Leone</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Gold Coast</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Senegambia</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110705</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8837560</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 Map. : col ; 43 x 36 cm."
+        ],
+        "pub_date": "1881",
+        "pub_date_sort": "1881",
+        "pub_display": [
+            "gw",
+            "Gotha"
+        ],
+        "pub_year_tisim": [
+            1881
+        ],
+        "publication_year_isi": 1881,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/wr055hy7401/wr055hy7401_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:04:53.463Z",
+        "title_245a_display": "Nordwest-Afrika",
+        "title_display": "Nordwest-Afrika",
+        "title_full_display": "Nordwest-Afrika.",
+        "title_sort": "NordwestAfrika",
+        "url_fulltext": [
+            "http://purl.stanford.edu/wr055hy7401"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Tallis, John, 1817-1876",
+            "Rapkin, J."
+        ],
+        "author_person_facet": [
+            "Tallis, John, 1817-1876",
+            "Rapkin, J."
+        ],
+        "author_person_full_display": [
+            "Tallis, John, 1817-1876",
+            "Rapkin, J."
+        ],
+        "author_sort": "􏿿 Africa",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "qb438pg7646"
+        ],
+        "collection_with_title": [
+            "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "AM_0250"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9084"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "11036"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/qy240vt8937%2FAM_0250/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W 18°--E 51°/N 37°--S 35°)"
+        ],
+        "created": "2015-02-09T03:06:48Z",
+        "creation_year_isi": 1880,
+        "display_type": [
+            "file"
+        ],
+        "druid": "qy240vt8937",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/qy240vt8937/AM_0250_full"
+        ],
+        "geographic_facet": [
+            "Africa--Maps"
+        ],
+        "id": "qy240vt8937",
+        "imprint_display": [
+            "1880"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/qy240vt8937/AM_0250_large"
+        ],
+        "last_updated": "2015-02-09T03:06:48Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0144</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1880</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">London</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Tallis, John, 1817-1876</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>24 x 32 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>No scale given</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/n88192201\">\n    <mods:namePart>Tallis, John, 1817-1876</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\" http://id.loc.gov/authorities/names/n83227676\">\n    <mods:namePart>Rapkin, J.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:note>Steel</mods:note>\n  <mods:note>Five engraved vignettes are seen, an Arab family of Algeria, Bosjeman Hottentots, a view of St. Helena, a Bedouin Arabs' encampment and Korranna Hottentots. \"The illustrations were drawn by J. Marchant and engraved by J.H. Kernot. The map was drawn and engraved by J. Rapkin\"; Prime meridian through Greenwich.</mods:note>\n  <mods:note>Outline color</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0144, p. 163</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:identifier type=\"uri\">http://purl.stanford.edu/qb438pg7646</mods:identifier>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
+        "physical": [
+            "24 x 32 cm"
+        ],
+        "point_bbox": [
+            "-18.0 -35.0 51.0 37.0"
+        ],
+        "pub_date": "1880",
+        "pub_date_sort": "1880",
+        "pub_display": [
+            "London"
+        ],
+        "pub_year_tisim": [
+            1880
+        ],
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:7"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/qb438pg7646"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/qy240vt8937/AM_0250_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/qy240vt8937/AM_0250_thumb"
+        ],
+        "timestamp": "2015-02-09T03:06:48.765Z",
+        "title_245a_display": "Africa.",
+        "title_display": "Africa",
+        "title_full_display": "Africa.",
+        "title_sort": "Africa",
+        "topic_display": [
+            "map",
+            "Digital maps"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/qy240vt8937"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Petermann, A. (August), 1822-1878",
+            "Habenicht, H."
+        ],
+        "author_person_facet": [
+            "Petermann, A. (August), 1822-1878",
+            "Habenicht, H."
+        ],
+        "author_person_full_display": [
+            "Petermann, A. (August), 1822-1878",
+            "Habenicht, H."
+        ],
+        "author_sort": "Petermann A August 18221878Afrika im Massstab v 125000000",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "fx703zs6529_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "9431"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "11423"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/fx703zs6529%2Ffx703zs6529_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W18°--E73°/N37°--S34°)."
+        ],
+        "created": "2015-02-09T03:02:31Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "fx703zs6529",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa"
+        ],
+        "id": "fx703zs6529",
+        "imprint_display": [
+            "1880"
+        ],
+        "language": [
+            "German"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:02:31Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Afrika im Massstab v. 1:25.000.000</title>\n  </titleInfo>\n  <titleInfo type=\"alternative\">\n    <title>Afrika im Massstab von 1:25.000.000</title>\n  </titleInfo>\n  <titleInfo type=\"alternative\">\n    <title>Adolf Stieler's Hand Atlas über alle Theile der Eund über das Weltgebäude</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Petermann, A. (August)</namePart>\n    <namePart type=\"date\">1822-1878</namePart>\n  </name>\n  <name type=\"personal\">\n    <namePart>Habenicht, H.</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">gw</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Gotha</placeTerm>\n    </place>\n    <publisher>Justus Perthes</publisher>\n    <dateIssued>1880</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">ger</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : col. ; 34 x 40 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">entworfen v. A. Petermann ; gezeichnet v. H. Habenicht.</note>\n  <note>Relief shown by hachures and spot heights.</note>\n  <note>Appears in Adolf Stieler's Hand Atlas über alle Theile der Erde und über das Weltgebäude. 1881.</note>\n  <note>\"Stieler's Hand Atlas, no. 68.\"</note>\n  <note>In bottom margin: X IX.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f------</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:25,000,000]</scale>\n      <coordinates>(W18°--E73°/N37°--S34°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CtY</recordContentSource>\n    <recordCreationDate encoding=\"marc\">020607</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8884267</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : col. ; 34 x 40 cm."
+        ],
+        "pub_date": "1880",
+        "pub_date_sort": "1880",
+        "pub_display": [
+            "gw",
+            "Gotha"
+        ],
+        "pub_year_tisim": [
+            1880
+        ],
+        "publication_year_isi": 1880,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/fx703zs6529/fx703zs6529_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:02:31.943Z",
+        "title_245a_display": "Afrika im Massstab v. 1:25.000.000",
+        "title_display": "Afrika im Massstab v. 1:25.000.000",
+        "title_full_display": "Afrika im Massstab v. 1:25.000.000.",
+        "title_sort": "Afrika im Massstab v 125000000",
+        "title_variant_display": [
+            "Afrika im Massstab von 1:25.000.000",
+            "Adolf Stieler's Hand Atlas über alle Theile der Eund über das Weltgebäude"
+        ],
+        "topic_display": [
+            "map"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/fx703zs6529"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_person_display": [
+            "Andriveau-Goujon, E. (Eugène), 1832-1897"
+        ],
+        "author_person_facet": [
+            "Andriveau-Goujon, E. (Eugène), 1832-1897"
+        ],
+        "author_person_full_display": [
+            "Andriveau-Goujon, E. (Eugène), 1832-1897"
+        ],
+        "author_sort": "AndriveauGoujon E Eugène 18321897Afrique",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "qy458yc1855_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "12784"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "16810"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/qy458yc1855%2Fqy458yc1855_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W18°--E51°/N37°--S35°)."
+        ],
+        "created": "2015-02-09T03:03:47Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "qy458yc1855",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa"
+        ],
+        "id": "qy458yc1855",
+        "imprint_display": [
+            "1880"
+        ],
+        "language": [
+            "French"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:03:47Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Afrique</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Andriveau-Goujon, E. (Eugène)</namePart>\n    <namePart type=\"date\">1832-1897</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">fr</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Paris</placeTerm>\n    </place>\n    <publisher>E. Andriveau-Goujon, éditeur ...</publisher>\n    <dateIssued>1880</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">fre</languageTerm>\n  </language>\n  <physicalDescription>\n    <extent>1 map : hand col. ; 61 x 45 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">E. Andriveau-Goujon ...</note>\n  <note>Relief shown by hachures.</note>\n  <note>In Upper right corner: \"Atlas Usuel, No. 26\" and \"Atlas Universel, No. 39\"</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">ff-----</geographicCode>\n    <geographicCode authority=\"marcgac\">ae-----</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>scale [ca. 1:15,000,000]</scale>\n      <coordinates>(W18°--E51°/N37°--S35°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">CSt-ES</recordContentSource>\n    <recordCreationDate encoding=\"marc\">110216</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8939000</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : hand col. ; 61 x 45 cm."
+        ],
+        "pub_date": "1880",
+        "pub_date_sort": "1880",
+        "pub_display": [
+            "fr",
+            "Paris"
+        ],
+        "pub_year_tisim": [
+            1880
+        ],
+        "publication_year_isi": 1880,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/qy458yc1855/qy458yc1855_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:03:47.053Z",
+        "title_245a_display": "Afrique",
+        "title_display": "Afrique",
+        "title_full_display": "Afrique.",
+        "title_sort": "Afrique",
+        "topic_display": [
+            "map"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/qy458yc1855"
+        ]
+    },
+    {
+        "access_facet": [
+            "Online"
+        ],
+        "author_corp_display": [
+            "Adam and Charles Black (Firm)"
+        ],
+        "author_other_facet": [
+            "Adam and Charles Black (Firm)"
+        ],
+        "author_person_display": [
+            "Bartholomew, John, 1831-1893"
+        ],
+        "author_person_facet": [
+            "Bartholomew, John, 1831-1893"
+        ],
+        "author_person_full_display": [
+            "Bartholomew, John, 1831-1893"
+        ],
+        "author_sort": "Bartholomew John 18311893Africa",
+        "building_facet": [
+            "Stanford Digital Repository"
+        ],
+        "collection": [
+            "ct961sj2730"
+        ],
+        "collection_with_title": [
+            "ct961sj2730-|-The Caroline Batchelor Map Collection"
+        ],
+        "content_metadata_first_image_file_name_ssm": [
+            "ct493wg6431_00_0001"
+        ],
+        "content_metadata_first_image_height_ssm": [
+            "14750"
+        ],
+        "content_metadata_first_image_width_ssm": [
+            "11069"
+        ],
+        "content_metadata_image_iiif_info_ssm": [
+            "https://stacks.stanford.edu/image/iiif/ct493wg6431%2Fct493wg6431_00_0001/info.json"
+        ],
+        "content_metadata_type_ssim": [
+            "image"
+        ],
+        "content_metadata_type_ssm": [
+            "image"
+        ],
+        "coordinates_tesim": [
+            "(W20°--E50°/N40°--S40°)."
+        ],
+        "created": "2015-02-09T03:02:25Z",
+        "display_type": [
+            "file"
+        ],
+        "druid": "ct493wg6431",
+        "format": [
+            "Map/Globe"
+        ],
+        "format_main_ssim": [
+            "Map"
+        ],
+        "full_image_url_ssm": [
+            "https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_full"
+        ],
+        "geographic_facet": [
+            "Africa"
+        ],
+        "id": "ct493wg6431",
+        "imprint_display": [
+            "[1879?]"
+        ],
+        "language": [
+            "English"
+        ],
+        "large_image_url_ssm": [
+            "https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_large"
+        ],
+        "last_updated": "2015-02-09T03:02:25Z",
+        "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" version=\"3.4\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd\">\n  <titleInfo>\n    <title>Africa</title>\n  </titleInfo>\n  <name type=\"personal\" usage=\"primary\">\n    <namePart>Bartholomew, John</namePart>\n    <namePart type=\"date\">1831-1893</namePart>\n  </name>\n  <name type=\"corporate\">\n    <namePart>Adam and Charles Black (Firm)</namePart>\n  </name>\n  <typeOfResource>cartographic</typeOfResource>\n  <genre authority=\"marcgt\">map</genre>\n  <originInfo>\n    <place>\n      <placeTerm type=\"code\" authority=\"marccountry\">stk</placeTerm>\n    </place>\n    <place>\n      <placeTerm type=\"text\">Edinburgh</placeTerm>\n    </place>\n    <publisher>A. &amp; C. Black</publisher>\n    <dateIssued>[1879?]</dateIssued>\n    <dateIssued encoding=\"marc\">1879</dateIssued>\n    <issuance>monographic</issuance>\n  </originInfo>\n  <language>\n    <languageTerm authority=\"iso639-2b\" type=\"code\">eng</languageTerm>\n  </language>\n  <physicalDescription>\n    <form authority=\"marccategory\">map</form>\n    <form authority=\"marcsmd\">map</form>\n    <extent>1 map : hand col. ; 53 x 42 cm.</extent>\n  </physicalDescription>\n  <note type=\"statement of responsibility\" altRepGroup=\"00\">by J. Bartholomew, F.R.G.S.</note>\n  <note>Relief shown by hachures.</note>\n  <note>Prime meridian: Greenwich.</note>\n  <note>\"Engraved by J. Bartholomew Edin.r.\"</note>\n  <note>In lower right corner: 36.</note>\n  <subject>\n    <geographicCode authority=\"marcgac\">f------</geographicCode>\n  </subject>\n  <subject>\n    <cartographics>\n      <scale>Scale [ca. 1:18,500,000]</scale>\n      <coordinates>(W20°--E50°/N40°--S40°).</coordinates>\n    </cartographics>\n  </subject>\n  <subject authority=\"lcsh\">\n    <geographic>Africa</geographic>\n    <genre>Maps</genre>\n  </subject>\n  <recordInfo>\n    <descriptionStandard>aacr</descriptionStandard>\n    <recordContentSource authority=\"marcorg\">NDD</recordContentSource>\n    <recordCreationDate encoding=\"marc\">851004</recordCreationDate>\n    <recordIdentifier source=\"SIRSI\">a8923346</recordIdentifier>\n    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>\n  </recordInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Caroline Batchelor Map Collection</title>\n    </titleInfo>\n    <identifier type=\"uri\">http://purl.stanford.edu/ct961sj2730</identifier>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">This item is in the public domain. There are no restrictions on use.</accessCondition>\n  <accessCondition type=\"copyright\">Content in the public domain with no use restriction.</accessCondition>\n  <accessCondition type=\"license\">CC by-nc: Attribution Non-Commercial 3.0 Unported</accessCondition>\n</mods>\n",
+        "physical": [
+            "1 map : hand col. ; 53 x 42 cm."
+        ],
+        "pub_date": "1879",
+        "pub_date_sort": "1879",
+        "pub_display": [
+            "stk",
+            "Edinburgh"
+        ],
+        "pub_year_tisim": [
+            1879
+        ],
+        "publication_year_isi": 1879,
+        "spotlight_exhibit_slug_default-exhibit_bsi": [
+            true
+        ],
+        "spotlight_resource_id_ssim": [
+            "spotlight/resources/purls:6"
+        ],
+        "spotlight_resource_type_ssim": [
+            "spotlight/resources/purls"
+        ],
+        "spotlight_resource_url_ssim": [
+            "http://purl.stanford.edu/ct961sj2730"
+        ],
+        "thumbnail_square_url_ssm": [
+            "https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_square"
+        ],
+        "thumbnail_url_ssm": [
+            "https://stacks.stanford.edu/image/ct493wg6431/ct493wg6431_00_0001_thumb"
+        ],
+        "timestamp": "2015-02-09T03:02:25.188Z",
+        "title_245a_display": "Africa",
+        "title_display": "Africa",
+        "title_full_display": "Africa.",
+        "title_sort": "Africa",
+        "topic_display": [
+            "map"
+        ],
+        "url_fulltext": [
+            "http://purl.stanford.edu/ct493wg6431"
+        ]
+    }
+]

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -48,9 +48,6 @@
             "file"
         ],
         "druid": "hj066rn6500",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -166,9 +163,6 @@
             "file"
         ],
         "druid": "wd297xz1362",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -283,9 +277,6 @@
             "file"
         ],
         "druid": "xy658qf4887",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -401,9 +392,6 @@
         "druid": "wk210cf6868",
         "era_facet": [
             "1906-1908"
-        ],
-        "format": [
-            "Map/Globe"
         ],
         "format_main_ssim": [
             "Map"
@@ -528,9 +516,6 @@
             "file"
         ],
         "druid": "hx676nr2846",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -644,9 +629,6 @@
             "file"
         ],
         "druid": "nz926xc1513",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -761,9 +743,6 @@
             "file"
         ],
         "druid": "gk885tn1705",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -880,9 +859,6 @@
             "file"
         ],
         "druid": "zm589dr6916",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1002,9 +978,6 @@
             "file"
         ],
         "druid": "by513wd0839",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1128,9 +1101,6 @@
             "file"
         ],
         "druid": "ht152fg3281",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1246,9 +1216,6 @@
             "file"
         ],
         "druid": "cx876zn3079",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1362,9 +1329,6 @@
             "file"
         ],
         "druid": "rn350bb9484",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1481,9 +1445,6 @@
             "file"
         ],
         "druid": "rg759wj0953",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1625,9 +1586,6 @@
             "nile",
             "nilex"
         ],
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1742,9 +1700,6 @@
             "file"
         ],
         "druid": "gm036df2527",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1863,9 +1818,6 @@
             "file"
         ],
         "druid": "wr055hy7401",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -1984,9 +1936,6 @@
             "file"
         ],
         "druid": "qy240vt8937",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -2102,9 +2051,6 @@
             "file"
         ],
         "druid": "fx703zs6529",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -2222,9 +2168,6 @@
             "file"
         ],
         "druid": "qy458yc1855",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],
@@ -2344,9 +2287,6 @@
             "file"
         ],
         "druid": "ct493wg6431",
-        "format": [
-            "Map/Globe"
-        ],
         "format_main_ssim": [
             "Map"
         ],

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -73,7 +73,8 @@
         "physical": [
             "2 maps on 1 sheet : col. ; 23 x 15 cm. and 23 x 15 cm., sheet 38 x 27 cm."
         ],
-        "pub_date": "1940",
+        "pub_year_no_approx_isi": 1940,
+        "pub_year_w_approx_isi": 1940,
         "pub_date_sort": "1940",
         "pub_display": [
             "sp",
@@ -187,7 +188,8 @@
         "physical": [
             "1 map : col."
         ],
-        "pub_date": "1928",
+        "pub_year_no_approx_isi": 1928,
+        "pub_year_w_approx_isi": 1928,
         "pub_date_sort": "1928",
         "pub_display": [
             "enk",
@@ -304,7 +306,8 @@
         "physical": [
             "Flles : col. ; 44 x 29 cm."
         ],
-        "pub_date": "1921",
+        "pub_year_no_approx_isi": 1921,
+        "pub_year_w_approx_isi": 1921,
         "pub_date_sort": "1921",
         "pub_display": [
             "fr",
@@ -418,7 +421,8 @@
         "physical": [
             "1 map : col. ; 35 x 47 cm."
         ],
-        "pub_date": "1906",
+        "pub_year_no_approx_isi": 1906,
+        "pub_year_w_approx_isi": 1906,
         "pub_date_sort": "1906",
         "pub_display": [
             "xx",
@@ -541,7 +545,8 @@
         "physical": [
             "1 map : col. ; 27 x 25 cm."
         ],
-        "pub_date": "1895",
+        "pub_year_no_approx_isi": 1895,
+        "pub_year_w_approx_isi": 1895,
         "pub_date_sort": "1895",
         "pub_display": [
             "enk",
@@ -651,7 +656,8 @@
         "physical": [
             "48.5 x 66.5 cm"
         ],
-        "pub_date": "1892",
+        "pub_year_no_approx_isi": 1892,
+        "pub_year_w_approx_isi": 1892,
         "pub_date_sort": "1892",
         "pub_display": [
             "Unknown"
@@ -767,7 +773,8 @@
         "point_bbox": [
             "-18.0 -35.0 51.0 37.0"
         ],
-        "pub_date": "1891",
+        "pub_year_no_approx_isi": 1891,
+        "pub_year_w_approx_isi": 1891,
         "pub_date_sort": "1891",
         "pub_display": [
             "Paris"
@@ -884,7 +891,8 @@
         "point_bbox": [
             "14.0 -35.0 34.0 -21.0"
         ],
-        "pub_date": "1890",
+        "pub_year_no_approx_isi": 1890,
+        "pub_year_w_approx_isi": 1890,
         "pub_date_sort": "1890",
         "pub_display": [
             "Amsterdam"
@@ -1003,7 +1011,8 @@
         "physical": [
             "1 map : col. ; 21 x 21 cm."
         ],
-        "pub_date": "1890",
+        "pub_year_no_approx_isi": 1890,
+        "pub_year_w_approx_isi": 1890,
         "pub_date_sort": "1890",
         "pub_display": [
             "enk",
@@ -1125,7 +1134,8 @@
         "physical": [
             "1 map : col. ; 21 x 25 cm."
         ],
-        "pub_date": "1887",
+        "pub_year_no_approx_isi": 1887,
+        "pub_year_w_approx_isi": 1887,
         "pub_date_sort": "1887",
         "pub_display": [
             "enk",
@@ -1237,7 +1247,8 @@
         "physical": [
             "12 x 23.5 cm"
         ],
-        "pub_date": "1886",
+        "pub_year_no_approx_isi": 1886,
+        "pub_year_w_approx_isi": 1886,
         "pub_date_sort": "1886",
         "pub_display": [
             "Pretoria"
@@ -1354,7 +1365,8 @@
         "point_bbox": [
             "6.0 -37.0 41.0 -5.0"
         ],
-        "pub_date": "1886",
+        "pub_year_no_approx_isi": 1886,
+        "pub_year_w_approx_isi": 1886,
         "pub_date_sort": "1886",
         "pub_display": [
             "London"
@@ -1475,7 +1487,8 @@
         "physical": [
             "1 col. map. 22 x 26 cm. on sheet 25 x 30 cm."
         ],
-        "pub_date": "1885",
+        "pub_year_no_approx_isi": 1885,
+        "pub_year_w_approx_isi": 1885,
         "pub_date_sort": "1885",
         "pub_display": [
             "enk",
@@ -1610,7 +1623,8 @@
         "physical": [
             "1 map : col."
         ],
-        "pub_date": "1884",
+        "pub_year_no_approx_isi": 1884,
+        "pub_year_w_approx_isi": 1884,
         "pub_date_sort": "1884",
         "pub_display": [
             "enk",
@@ -1724,7 +1738,8 @@
         "point_bbox": [
             "-18.0 -35.0 51.0 37.0"
         ],
-        "pub_date": "1881",
+        "pub_year_no_approx_isi": 1881,
+        "pub_year_w_approx_isi": 1881,
         "pub_date_sort": "1881",
         "pub_display": [
             "Philadelphia"
@@ -1846,7 +1861,8 @@
         "physical": [
             "1 Map. : col ; 43 x 36 cm."
         ],
-        "pub_date": "1881",
+        "pub_year_no_approx_isi": 1881,
+        "pub_year_w_approx_isi": 1881,
         "pub_date_sort": "1881",
         "pub_display": [
             "gw",
@@ -1960,7 +1976,8 @@
         "point_bbox": [
             "-18.0 -35.0 51.0 37.0"
         ],
-        "pub_date": "1880",
+        "pub_year_no_approx_isi": 1880,
+        "pub_year_w_approx_isi": 1880,
         "pub_date_sort": "1880",
         "pub_display": [
             "London"
@@ -2075,7 +2092,8 @@
         "physical": [
             "1 map : col. ; 34 x 40 cm."
         ],
-        "pub_date": "1880",
+        "pub_year_no_approx_isi": 1880,
+        "pub_year_w_approx_isi": 1880,
         "pub_date_sort": "1880",
         "pub_display": [
             "gw",
@@ -2192,7 +2210,8 @@
         "physical": [
             "1 map : hand col. ; 61 x 45 cm."
         ],
-        "pub_date": "1880",
+        "pub_year_no_approx_isi": 1880,
+        "pub_year_w_approx_isi": 1880,
         "pub_date_sort": "1880",
         "pub_display": [
             "fr",
@@ -2311,7 +2330,8 @@
         "physical": [
             "1 map : hand col. ; 53 x 42 cm."
         ],
-        "pub_date": "1879",
+        "pub_year_no_approx_isi": 1879,
+        "pub_year_w_approx_isi": 1879,
         "pub_date_sort": "1879",
         "pub_display": [
             "stk",


### PR DESCRIPTION
also removed some cruft fields.

My intent is that Solr field pub_year_w_approx_isi   replaces  Solr field pub_date   and that we also have  pub_year_no_approx_isi.    

Does this seem to encompass that change?