### PR TITLE
Update i18n keys for exhibit admin user management.

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -4,3 +4,7 @@ en:
       invitation_instructions:
         someone_invited_you: 'The SUL Exhibits Administrator has invited you to help work on the "%{exhibit_name}" exhibit at %{url}. You can accept this invitation by clicking the link below.'
         ignore_html: "If you don't want to accept the invitation, please ignore this email. You won't be added to the \"%{exhibit_name}\" exhibit team until you access the link above."
+    exhibits_admin_invitation_mailer:
+      invitation_instructions:
+        someone_invited_you: "The SUL Exhibits Administrator has invited you to join the administrative group that manages the SUL online exhibits. You can accept this invitation by clicking the link below."
+        ignore_html: "If you don't want to accept the invitation, please ignore this email. You won't be made a SUL online exhibits administrator until you access the link above."


### PR DESCRIPTION
(Note: this feature is not available until Spotlight 0.16.0)

Closes #165 