### PR TITLE
Exhibits styling updates

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -53,7 +53,7 @@
 
   .thumbnail {
     img {
-      border: 1px solid $gray;
+      @include thumbnail-image-border;
     }
   }
 

--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -19,6 +19,18 @@
   font-weight: 600;
 }
 
+.nav-pills > li > a {
+  background-color: $color-beige-10;
+  border: 1px solid $color-gray-80;
+  margin-left: 3px;
+  margin-right: 3px;
+}
+
+.nav-pills > li > a:hover,
+.nav-pills > li > a:focus {
+  background-color: $color-beige-30;
+}
+
 a:hover {
   border-radius: $border-radius-base;
 }

--- a/app/assets/stylesheets/modules/mixins.scss
+++ b/app/assets/stylesheets/modules/mixins.scss
@@ -16,3 +16,7 @@
   color: $sidebar-link-color;
   font-weight: 600;
 }
+
+@mixin thumbnail-image-border() {
+  border: 1px solid $color-gray-80;
+}

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -172,3 +172,15 @@
 .callout-danger .btn-default {
   @extend .btn-danger;
 }
+
+.st__content-block--image {
+  text-align: center;
+
+  img {
+    @include thumbnail-image-border;
+  }
+}
+
+.thumbnail > img {
+  @include thumbnail-image-border;
+}

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -168,3 +168,7 @@
     color: $color-blackish;
   }
 }
+
+.callout-danger .btn-default {
+  @extend .btn-danger;
+}


### PR DESCRIPTION
Some minor style updates, mostly to make the exhibit tags look better on the exhibits home page:

![online_exhibits](https://cloud.githubusercontent.com/assets/101482/16212702/6c87731c-36fe-11e6-96ef-2f4d7a921a45.png)
