### PR TITLE
Ignore Rails framework exceptions

### DIFF
--- a/config/initializers/squash_defaults.rb
+++ b/config/initializers/squash_defaults.rb
@@ -1,0 +1,15 @@
+Squash::Ruby.configure ignored_exception_classes: [
+                                                    'ActionController::RoutingError',
+                                                    'AbstractController::ActionNotFound',
+                                                    'ActionController::MethodNotAllowed',
+                                                    'ActionController::UnknownHttpMethod',
+                                                    'ActionController::NotImplemented',
+                                                    'ActionController::UnknownFormat',
+                                                    'ActionController::InvalidAuthenticityToken',
+                                                    'ActionController::InvalidCrossOriginRequest',
+                                                    'ActionDispatch::ParamsParser::ParseError',
+                                                    'ActionController::BadRequest',
+                                                    'ActionController::ParameterMissing',
+                                                    'ActiveRecord::RecordNotFound',
+                                                    'ActionController::UnknownAction'
+                                                  ]


### PR DESCRIPTION
Silencing some of the Squash noise by ignoring framework exceptions. The specific list is taken from honeybadger's blacklist and seems pretty reasonable at weeding out client errors.