### PR TITLE
Restrict thumbnail images to no more than 400px wide

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -183,4 +183,5 @@
 
 .thumbnail > img {
   @include thumbnail-image-border;
+  max-width: 400px;
 }


### PR DESCRIPTION
To fix #207, we could limit all thumbnails to no more 400px wide.

![screen shot 2016-07-08 at 4 38 40 pm](https://cloud.githubusercontent.com/assets/111218/16704316/71bb9400-452a-11e6-96e7-4b0fea57857c.png)

cc @ggeisler 