### PR TITLE
Hide exhibit creation from non-admin users. Fixes #212

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  # Exhibits will populate its own roles from workgroups, and doesn't need
+  # this upstream feature.
+  def add_default_roles
+    # no-op
+  end
+
   private
 
   # rubocop:disable Metrics/MethodLength

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -19,9 +19,11 @@
     </li>
   </ul>
 
-  <%= link_to spotlight.new_exhibit_path, class: "btn btn-default", role: "button" do %>
-    Request a new exhibit
-    <small class="sunet-notice">Requires SUNet login</small>
+  <% if can?(:create, Spotlight::Exhibit) %>
+      <%= link_to spotlight.new_exhibit_path, class: "btn btn-default", role: "button" do %>
+          Request a new exhibit
+          <small class="sunet-notice">Requires SUNet login</small>
+      <% end %>
   <% end %>
 
   <% if can?(:manage, Spotlight::Site.instance) || can?(:create, Spotlight::Exhibit) %>
@@ -33,7 +35,7 @@
         <li><%= link_to t(:'spotlight.sites.edit.page_title'), spotlight.edit_site_path %></li>
       <% end %>
 
-      <% if can? :manange, Spotlight::Exhibit %>
+      <% if can? :manage, Spotlight::Exhibit %>
         <li><%= link_to t(:'spotlight.sites.edit_exhibits.page_title'), spotlight.edit_site_exhibits_path %></li>
         <li><%= link_to t(:'spotlight.admin_users.index.page_title'), spotlight.admin_users_path %></li>
       <% end %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,4 +14,9 @@ describe User do
       expect(subject).to be_a_superadmin
     end
   end
+  describe '#add_default_roles' do
+    it 'does not inject the administrative role' do
+      expect(subject).not_to be_a_superadmin
+    end
+  end
 end

--- a/spec/views/shared/_site_sidebar.html.erb_spec.rb
+++ b/spec/views/shared/_site_sidebar.html.erb_spec.rb
@@ -1,0 +1,22 @@
+describe 'shared/_site_sidebar', type: :view do
+  subject { rendered }
+
+  context 'with a non-admin user' do
+    before do
+      allow(view).to receive(:can?).with(:create, Spotlight::Exhibit) { false }
+      allow(view).to receive(:can?).with(:manage, Spotlight::Site.instance) { false }
+      render
+    end
+    it { is_expected.not_to have_link('Request a new exhibit') }
+  end
+
+  context 'with an admin user' do
+    before do
+      allow(view).to receive(:can?).with(:create, Spotlight::Exhibit) { true }
+      allow(view).to receive(:can?).with(:manage, Spotlight::Exhibit) { true }
+      allow(view).to receive(:can?).with(:manage, Spotlight::Site.instance) { true }
+      render
+    end
+    it { is_expected.to have_link('Request a new exhibit') }
+  end
+end


### PR DESCRIPTION
Use the existing `:create, Spotlight::Exhibit` ability to determine who sees exhibit creation links.

Fix a typo in the `shared/_site_sidebar.html.erb` partial.

Override the Spotlight `add_default_roles` method from our `User` model; otherwise all user instances wind up being administrators in the test env. We do not use this built-in functionality, instead relying on Stanford WebAuth group membership to determine who gets administrative access. **N.B.**: this was required for the prior feature spec-based tests to pass, and is not required for this PR. I left it in so it doesn't trip us up in the future and added a model spec to cover the change. If you'd rather see this dropped from this PR, or broken into separate commits, let me know. Otherwise, :shipit:.