### PR TITLE
Tweak rubocop behavior

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,10 @@ require: rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.2
+  DisplayCopNames: true
   Exclude:
-    - 'Gemfile'
-    - 'bin/**/*'
     - 'db/**/*'
     - 'config/**/*'
-    - 'spec/spec_helper.rb'
-    - 'spec/teaspoon_env.rb'
     - 'vendor/**/*'
 
 Rails:
@@ -23,14 +20,6 @@ Style/StringLiterals:
   Enabled: true
   EnforcedStyle: single_quotes
 
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/features/*'
-
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
-
-# pending updated rubocop-rspec gem
-RSpec/FilePath:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,2 +1,4 @@
+require: rubocop-rspec
+
 RSpec/AnyInstance:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,15 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 require File.expand_path('../config/application', __FILE__)
 
-task default: [:ci, :rubocop]
+task default: :ci
 
 Exhibits::Application.load_tasks
 
 begin
   require 'rubocop/rake_task'
-  RuboCop::RakeTask.new(:rubocop)
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.fail_on_error = true
+  end
 
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
@@ -19,7 +21,7 @@ rescue LoadError
 end
 
 desc 'Run tests in generated test Rails app with generated Solr instance running'
-task ci: [:environment] do
+task ci: [:rubocop, :environment] do
   require 'solr_wrapper'
   require 'exhibits_solr_conf'
   ENV['environment'] = 'test'

--- a/spec/features/exhibit_index_spec.rb
+++ b/spec/features/exhibit_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'the exhibit home page' do
+describe 'the exhibit home page', type: :feature do
   it 'loads the home page' do
     visit '/'
   end

--- a/spec/features/exhibit_spec.rb
+++ b/spec/features/exhibit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'an exhibit' do
+describe 'an exhibit', type: :feature do
   before do
     allow_any_instance_of(Spotlight::Search).to receive(:set_default_thumbnail)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,7 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  if config.files_to_run.one?
-    config.default_formatter = 'doc'
-  end
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
   config.order = :random
 


### PR DESCRIPTION
* Display cop names to more easily troubleshoot Rubocop offenses
* Remove exclusions that do not cause Rubocop offenses
* Remove `RSpec/DescribeClass` exclusion in favor of marking feature specs with `type: :feature`
* Remove `RSpec/FilePath` exclusion (has no effect on # of offenses)
* Require rubocop-rspec in TODO file to silence warning
* Push `rubocop` task down as dependency of `ci` task, and fail early if offenses are found
* Fix offense in `spec_helper.rb`