### PR TITLE
Add SUL-specific reference links to exhibit curator invitation email

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -12,3 +12,5 @@
 <p><%= link_to t("spotlight.#{key}.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token, referrer: spotlight.exhibit_path(@resource.roles.first.resource)) %></p>
 
 <p><%= t("spotlight.#{key}.invitation_instructions.ignore_html", exhibit_name: @resource.roles.first.resource.title) %></p>
+
+<p><%= t("spotlight.#{key}.invitation_instructions.reference_links_text_html", :href => link_to(t("spotlight.#{key}.invitation_instructions.reference_links_href"), "http://exhibits.stanford.edu"), :mailto => mail_to(t("spotlight.#{key}.invitation_instructions.mail_to_href"))) %></p>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -4,6 +4,9 @@ en:
       invitation_instructions:
         someone_invited_you: 'The SUL Exhibits Administrator has invited you to help work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking the link below.'
         ignore_html: "If you don't want to accept the invitation, please ignore this email. You won't be added to the \"%{exhibit_name}\" exhibit team until you access the link above."
+        reference_links_text_html: "If you have questions about this invitation or SUL Exhibits, send an email to %{mailto}. To see examples of exhibits created by other SUL exhibit curators, visit the %{href} page."
+        mail_to_href: "exhibits-feedback@lists.stanford.edu"
+        reference_links_href: "SUL Online Exhibits"
     exhibits_admin_invitation_mailer:
       invitation_instructions:
         someone_invited_you: "The SUL Exhibits Administrator has invited you to join the administrative group that manages the SUL online exhibits. You can accept this invitation by clicking the link below."


### PR DESCRIPTION
Closes #145 

Adds the text in the last paragraph:

![tmp_html_preview_ __users_geisler_desktop](https://cloud.githubusercontent.com/assets/101482/16856772/e5e2d2b2-49d0-11e6-8006-099d5ad63ad0.png)
