### PR TITLE
Set thumbnails to width: 100%; to avoid inferred sizing

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -188,5 +188,6 @@
 .items-block {
   .thumbnail img {
     max-width: 400px;
+    width: 100%;
   }
 }


### PR DESCRIPTION
Before:

![screen shot 2016-07-27 at 11 41 18 am](https://cloud.githubusercontent.com/assets/111218/17187657/0d02dfb8-53ef-11e6-9f2c-a92421432201.png)

After:

![screen shot 2016-07-27 at 11 41 14 am](https://cloud.githubusercontent.com/assets/111218/17187660/0fbdea5e-53ef-11e6-8c2b-9b67f0c36f16.png)
