### PR TITLE
Ensure thumbnails don't overflow list view boundaries; fixes #303

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -58,6 +58,13 @@
   }
 
   &.documents-list {
+    .document {
+      box-sizing: content-box;
+      min-height: 100px;
+      padding-bottom: $padding-large-vertical;
+      padding-top: $padding-large-vertical;
+    }
+
     .index_title {
       margin-left: 120px;
     }


### PR DESCRIPTION
After:
![screen shot 2016-08-04 at 11 56 56 am](https://cloud.githubusercontent.com/assets/111218/17414505/8e347c26-5a3a-11e6-8438-271041666c0c.png)
