### PR TITLE
Update styling of admins email addresses box

### DIFF
--- a/app/assets/stylesheets/modules/home.scss
+++ b/app/assets/stylesheets/modules/home.scss
@@ -35,3 +35,11 @@
   border-bottom: 1px solid $color-beige-40;
   box-shadow: 0 4px 6px -6px $color-gray-60;
 }
+
+.new_user .form-actions {
+  margin-bottom: $padding-large-vertical * 4;
+}
+
+#all_users.well {
+  background-color: $white;
+}


### PR DESCRIPTION
Minor update to avoid beige background overload on the page.

<img width="874" alt="manage_exhibits_-_manage_administrators___online_exhibits" src="https://cloud.githubusercontent.com/assets/101482/17452690/a796ae72-5b26-11e6-8cd1-8c25e6e017e3.png">
