### PR TITLE
Move fetching collection information into a background job

### DIFF
--- a/app/jobs/record_resource_metadata_job.rb
+++ b/app/jobs/record_resource_metadata_job.rb
@@ -1,0 +1,6 @@
+# Record the metadata for an index job
+class RecordResourceMetadataJob < ActiveJob::Base
+  def perform(resource)
+    resource.update_collection_metadata!
+  end
+end

--- a/app/models/dor_harvester.rb
+++ b/app/models/dor_harvester.rb
@@ -22,7 +22,8 @@ class DorHarvester < Spotlight::Resource
 
   def waiting!
     super
-    update(collections: fetch_collection_metadata)
+    update(collections: {})
+    RecordResourceMetadataJob.perform_later(self)
   end
 
   def collections
@@ -64,6 +65,10 @@ class DorHarvester < Spotlight::Resource
               end
 
     RecordIndexStatusJob.perform_later(self, resource.bare_druid, ok: false, message: message)
+  end
+
+  def update_collection_metadata!
+    update(collections: fetch_collection_metadata)
   end
 
   private

--- a/spec/models/dor_harvester_spec.rb
+++ b/spec/models/dor_harvester_spec.rb
@@ -74,6 +74,15 @@ describe DorHarvester do
   end
 
   describe '#waiting!' do
+    it 'retrieves collection metadata' do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        subject.waiting!
+      end.to enqueue_job(RecordResourceMetadataJob)
+    end
+  end
+
+  describe '#update_collection_metadata!' do
     let(:resource) do
       instance_double(Harvestdor::Indexer::Resource, bare_druid: druid,
                                                      exists?: true,
@@ -86,7 +95,7 @@ describe DorHarvester do
     end
 
     it 'retrieves collection metadata' do
-      subject.waiting!
+      subject.update_collection_metadata!
       expect(subject.collections[druid]).to eq 'size' => 3
     end
   end


### PR DESCRIPTION
This might fix #391, where exhibits with excessively long lists of druids where we hit an HTTP timeout collecting this information.