### PR TITLE
[WIP] initial version of Zotero bibliography service

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 11
+  Max: 16
 
 # Offense count: 2
 RSpec/AnyInstance:

--- a/app/services/bibliography_service.rb
+++ b/app/services/bibliography_service.rb
@@ -1,0 +1,4 @@
+# A Bibliography service that right now is only a Zotero implementation
+class BibliographyService
+  include ZoteroApi
+end

--- a/app/services/concerns/zotero_api.rb
+++ b/app/services/concerns/zotero_api.rb
@@ -1,0 +1,128 @@
+#
+# @see https://www.zotero.org/support/dev/web_api/v3/start
+#
+module ZoteroApi
+  # A single Zotero Bibliography item
+  class BibliographyItem < Hash
+    # @return [String] an Author-Date sort key
+    def to_author_date
+      [author, date].join(' ')
+    end
+
+    # @return [String] returns the first author's full name (last, first)
+    def author
+      creator = data['creators'].first
+      [creator['lastName'], creator['firstName']].join(', ')
+    end
+
+    # @return [String] the (unparsed) date for the item
+    def date
+      data['date']
+    end
+
+    # @return [Array<String>] all of the tags associated with the item
+    def tags
+      data['tags'].collect { |i| i['tag'] }
+    end
+
+    # @return [String] the HTML that represents the bibliography entry for the item
+    # @example
+    #     <div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+    #       <div class="csl-entry">Allen, John. <i>Another Book</i>, 2017.</div>
+    #     </div>
+    #
+    def to_html
+      fetch('bib')
+    end
+
+    # @return [Array<String>] the list of druids associated with this bibliography item
+    def druids
+      druids = []
+      tags.each do |t|
+        druid = t.match(/([a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4})/) # parse out druid from tag
+        druids << druid[1] unless druid.nil?
+      end
+      druids.uniq
+    end
+
+    private
+
+    def data
+      fetch('data')
+    end
+  end
+
+  # A complete Zotero bibliography
+  class Bibliography < Array
+    # @return [Bibliography] all items sorted by Author-Date
+    def sort_by_author_date
+      self.class.new(sort_by(&:to_author_date))
+    end
+
+    # @param [String] `key` the bibliography item's `key` value
+    # @return [BibliographyItem] the matching item, or `nil`
+    def find(key)
+      each { |item| return item if item['key'] == key }
+      nil
+    end
+
+    # @return [String] HTML for the entire bibliography, sorted by Author-Date
+    def render
+      sort_by_author_date.collect(&:to_html).join("\n")
+    end
+  end
+
+  attr_reader :zotero_id, :zotero_id_type
+
+  def initialize(zotero_id, zotero_id_type = :user)
+    @zotero_id = zotero_id.to_i
+    @zotero_id_type = zotero_id_type == :user ? :user : :group
+  end
+
+  # @return [String] the URL for the Zotero endpoint
+  def endpoint
+    "https://api.zotero.org/#{zotero_id_type == :user ? 'users' : 'groups'}/#{zotero_id}"
+  end
+
+  # @return [Bibliography] the set of all bibliography items for the zotero account
+  def bibliography
+    return @items unless @items.nil? # cache them
+
+    @items = Bibliography.new
+    loop do
+      response = conn.get 'items', include: 'data,bib',
+                                   start: @items.length,
+                                   limit: 100
+      next_items = JSON.parse(response.body)
+      break if next_items.empty?
+      next_items.each do |i|
+        @items << BibliographyItem.new.merge(i)
+      end
+    end
+    @items
+  end
+
+  # @return [Hash<String,Bibliography>] an inverted index mapping druids into a bibliography
+  def inverted_index
+    return @index unless @index.nil?
+
+    @index = {}
+    bibliography.collect(&:druids).flatten.uniq.compact.each do |druid|
+      @index[druid] = Bibliography.new
+      bibliography.each do |item|
+        @index[druid] << item if item.druids.include?(druid)
+      end
+    end
+    @index
+  end
+
+  private
+
+  # @return [Faraday::Connection] connection to the Zotero API v3 service
+  def conn
+    @conn ||= Faraday.new(url: endpoint, params: { v: 3, format: :json }) do |faraday|
+      faraday.response :logger, ::Logger.new('log/zotero.log') # TODO: move to settings
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/spec/fixtures/zotero_user_3802090_rendered.html
+++ b/spec/fixtures/zotero_user_3802090_rendered.html
@@ -1,0 +1,21 @@
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Center for History and New Media. &#x201C;Zotero Quick Start Guide,&#x201D; n.d. http://zotero.org/support/quick_start_guide.</div>
+</div>
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Abby, Jane. &#x201C;My Thesis,&#x201D; 2010.</div>
+</div>
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Allen, John. <i>Another Book</i>, 2017.</div>
+</div>
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Doe, Jane, ed. <i>Yet Another Book</i>, 2001.</div>
+</div>
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Doe, John. <i>Fix</i>, 2016.</div>
+</div>
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Doe, John. <i>My Book</i>, 2017.</div>
+</div>
+<div class="csl-bib-body" style="line-height: 1.35; padding-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Doe, John, and Jane Doe. <i>My Test Book</i>, 2016.</div>
+</div>

--- a/spec/services/bibliography_service_spec.rb
+++ b/spec/services/bibliography_service_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe BibliographyService do
+  subject { described_class.new 3_802_090 } # TODO: replace with fixtures, currently drh's public library
+  context 'user' do
+    context 'properties' do
+      it '#endpoint' do
+        expect(subject.endpoint).to eq "https://api.zotero.org/users/#{subject.zotero_id}"
+      end
+    end
+    context 'many bibliography items' do
+      it 'retrieves bibliography' do
+        expect(subject.bibliography).to be_a(ZoteroApi::Bibliography)
+        expect(subject.bibliography.first['key']).to eq 'J8ZWJ73E'
+        expect(subject.bibliography.length).to eq 7
+      end
+      it 'sorts bibliography' do
+        sorted = subject.bibliography.sort_by_author_date
+        expect(sorted).to be_a(ZoteroApi::Bibliography)
+        expect(sorted.first['key']).to eq 'ABCD2345'
+        expect(sorted.length).to eq 7
+      end
+      it 'renders as HTML' do
+        expect(subject.bibliography.render).to eq(
+          File.read(Rails.root.join('spec', 'fixtures', 'zotero_user_3802090_rendered.html'))
+        )
+      end
+      it 'builds inverted index' do
+        expect(subject.inverted_index.keys.sort).to eq(%w(aa111bb2222 cc333dd4444 ee555ff6666))
+        expect(subject.inverted_index['ee555ff6666']).to be_a(ZoteroApi::Bibliography)
+        expect(subject.inverted_index['ee555ff6666'].collect { |i| i['key'] }).to include(
+          'J8ZWJ73E', 'VG8GVGNQ', '8HQ6SRVX', 'ZNWKPQHK', 'DHNES6FB'
+        )
+      end
+    end
+    context 'one item' do
+      let(:item) { subject.bibliography.find('J8ZWJ73E') }
+      it '#tags' do
+        expect(item.tags).to include('My Favorite Book (ee555ff6666)')
+      end
+      it '#druids' do
+        expect(item.druids).to include('ee555ff6666')
+      end
+      it '#to_html' do
+        expect(item.to_html).to eq(
+          "<div class=\"csl-bib-body\" style=\"line-height: 1.35; padding-left: 2em; text-indent:-2em;\">\n" \
+          "  <div class=\"csl-entry\">Doe, Jane, ed. <i>Yet Another Book</i>, 2001.</div>\n" \
+          '</div>'
+        )
+      end
+    end
+  end
+  context 'group' do # other than an endpoint, `group` is identical to `user` behavior
+    subject { described_class.new 1_051_392, :group } # parker-library's group ID
+    context 'properties' do
+      it '#endpoint' do
+        expect(subject.endpoint).to eq "https://api.zotero.org/groups/#{subject.zotero_id}"
+      end
+    end
+    # context 'many bibliography' do
+    #   it 'retrieves bibliography' do # TODO: this takes a looooong time (>10 mins)
+    #     expect(subject.bibliography.length).to eq 7360
+    #   end
+    # end
+  end
+end


### PR DESCRIPTION
This PR is connected to #448. It implements a `BibliographyService` API that only has a Zotero backend. Take a look at the specs for usage -- the main entry point is `bibliography` and `inverted_index` (to iterate through the druids that have bibliographies).

NOTE: Marked WIP as:
1. I dumped all of the code into the `zotero_api.rb` file and we may want to reorganize this into `Bibliography` and `BibliographyItem`, etc.
1. It's not using fixture data yet -- it's pulling data from the Zotero API live from my little test library online