### PR TITLE
Remove medium index field from configuration…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -143,7 +143,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'collector_ssim', label: 'Collector'
     config.add_index_field 'author_corp_display', label: 'Corporate Author'
     config.add_index_field 'author_meeting_display', label: 'Meeting Author'
-    config.add_index_field 'medium', label: 'Medium'
     config.add_index_field 'summary_display', label: 'Description'
     config.add_index_field 'topic_display', label: 'Topic'
     config.add_index_field 'subject_other_display', label: 'Subject'


### PR DESCRIPTION
…(we do have that field in our index).
Closes #455 

Looking over https://github.com/sul-dlss/sul-solr-configs/tree/master/exhibits it doesn't appear that we populate a `medium_display` (and we don't have `*_display` dynamic fields) and there is no other `medium_*` dynamic field referenced anywhere that I could find.

If we populate it in the indexing code, please feel free to chime in and I'm happy to update this PR to use that field instead.