### PR TITLE
Add sort fields for uploaded resources

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -1,4 +1,4 @@
-Spotlight::Engine.config.upload_title_field = OpenStruct.new(field_name: 'title', solr_field: %w(title_full_display title_display title_245_search))
+Spotlight::Engine.config.upload_title_field = OpenStruct.new(field_name: 'title', solr_field: %w(title_full_display title_display title_245_search title_sort))
 Spotlight::Engine.config.default_contact_email = Settings.default_contact_email
 Spotlight::Engine.config.external_resources_partials += ['dor_harvester/form']
 

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -1,4 +1,9 @@
 Spotlight::Engine.config.upload_title_field = OpenStruct.new(field_name: 'title', solr_field: %w(title_full_display title_display title_245_search title_sort))
+Spotlight::Engine.config.upload_fields = [
+  OpenStruct.new(field_name: Spotlight::Engine.config.upload_description_field, label: 'Description', form_field_type: :text_area),
+  OpenStruct.new(field_name: :spotlight_upload_attribution_tesim, label: 'Attribution'),
+  OpenStruct.new(field_name: 'date', solr_field: %w(spotlight_upload_date_tesim date_sort), label: 'Date')
+]
 Spotlight::Engine.config.default_contact_email = Settings.default_contact_email
 Spotlight::Engine.config.external_resources_partials += ['dor_harvester/form']
 


### PR DESCRIPTION
Closes #457 

I kept this in two commits in case we didn't want to override the entire `upload_fields` config just to add `date_sort`.

I can either yank that commit or squash these if we're 🆗 with it.