### PR TITLE
Changed Giving to SUL link per JVine

### DIFF
--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -14,8 +14,8 @@
       "http://library.stanford.edu/spc" %>
     </li>
     <li>
-      <%= link_to "Giving to SUL",
-      "http://library.stanford.edu/#middle-tab-24" %>
+      <%= link_to "Giving to Stanford Libraries",
+      "http://library.stanford.edu/department/library-communications-and-development" %>
     </li>
     <li>
       <%= link_to "https://consul.stanford.edu/x/2ok1CQ" do %>


### PR DESCRIPTION
> The "Giving to SUL" link on the Exhibits home page is broken now that the new website is up, and we can't create a redirect on the website itself. 
> 
> Currently links to http://library.stanford.edu/#middle-tab-24
> 
> Should link to http://library.stanford.edu/department/library-communications-and-development
> 
> (Also, we're no longer SUL - maybe "Giving to Stanford Libraries"?)
> 
> JV