### PR TITLE
use simplecov string not glob to shut up warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require 'fixtures/response_fixtures'
 SimpleCov.start('rails') do
   # Ignore these because simplecov doesn't detect when traject
   # loads and evals them. See https://github.com/traject/traject/blob/6df447621826b92e26a4675a2f7610f8c78056ff/lib/traject/indexer.rb#L193
-  add_filter 'lib/traject/**/*.rb'
+  add_filter 'lib/traject/'
 
   # the upstream default is app + lib, but track_files doesn't respect any
   # applied filters. https://github.com/colszowka/simplecov/issues/610


### PR DESCRIPTION
This PR removes the warnings we get running the specs, like so:

```
/Users/drh/.rvm/gems/ruby-2.4.1/gems/simplecov-0.12.0/lib/simplecov/filter.rb:33: warning: regular expression has redundant nested repeat operator '*': /lib\/traject\/**\/*.rb/
```