### PR TITLE
add format type to bib records "Reference"

### DIFF
--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -17,3 +17,5 @@ to_field 'title_display', lambda { |record, accumulator, _context|
 to_field 'title_uniform_search', lambda { |record, accumulator, _context|
   accumulator << record.title.to_s(filter: :latex)
 }
+
+to_field 'format_main_ssim', literal('Reference')

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       end
     end
 
+    it 'has a format type' do
+      expect(document).to include 'format_main_ssim' => ['Reference']
+    end
+
     it 'has spotlight data' do
       expect(document).to include :spotlight_resource_id_ssim, :spotlight_resource_type_ssim
     end


### PR DESCRIPTION
Allows our "Resource type" facet to be populated.

<img width="1246" alt="screen shot 2017-09-28 at 4 24 22 pm" src="https://user-images.githubusercontent.com/1656824/30988814-8d99f88e-a469-11e7-9522-acff064e4dc7.png">
