### PR TITLE
add BibTeX and formatted bibliography to ingest pipeline

### DIFF
--- a/app/models/concerns/bibliography_concern.rb
+++ b/app/models/concerns/bibliography_concern.rb
@@ -5,4 +5,17 @@ module BibliographyConcern
   def bibliography
     fetch(Settings.zotero_api.solr_document_field, nil)
   end
+
+  def reference?
+    fetch('format_main_ssim', []).first == 'Reference'
+  end
+
+  def bibtex
+    BibTeX.parse(fetch('bibtex_ts', []).first) if reference?
+  end
+
+  def formatted_bibliography
+    fetch('formatted_bibliography_ts', []).first if reference?
+    # TODO: for non-reference resources we'll generate a bibliography for them
+  end
 end

--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -19,3 +19,16 @@ to_field 'title_uniform_search', lambda { |record, accumulator, _context|
 }
 
 to_field 'format_main_ssim', literal('Reference')
+
+# raw serialization of BibTeX::Entry
+to_field 'bibtex_ts', lambda { |record, accumulator, _context|
+  accumulator << record.to_s
+}
+
+# formatted BibTeX::Entry in Chicago style as HTML
+to_field 'formatted_bibliography_ts', lambda { |record, accumulator, _context|
+  html = Exhibits::Bibliography.new(record.to_s).to_html
+  doc = Nokogiri::HTML(html)
+  reference = doc.at_css('ol li').children.to_html # extract just the reference from <li>
+  accumulator << reference.to_s
+}

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -259,6 +259,7 @@
     <dynamicField name="*_bbox" type="bbox" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_srpt" type="location_rpt" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_geohash" type="geohash" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ts" type="text" indexed="false" stored="true" multiValued="false" />
   </fields>
 
   <!-- copy fields -->

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -16,11 +16,15 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
 
   context 'to_solr' do
     subject(:document) do
-      bibliograpy_resource.document_builder.to_solr.first
+      SolrDocument.new(bibliograpy_resource.document_builder.to_solr.first)
     end
 
     it 'has a doc id' do
       expect(document[:id]).to eq 'QTWBAWKX'
+    end
+
+    it 'is a reference document' do
+      expect(document.reference?).to be_truthy
     end
 
     it 'has some titles' do
@@ -30,8 +34,12 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       end
     end
 
-    it 'has a format type' do
-      expect(document).to include 'format_main_ssim' => ['Reference']
+    it 'has BibTeX' do
+      expect(document.bibtex.to_s).to include '@article{http://zotero.org/groups/1051392/items/QTWBAWKX'
+    end
+
+    it 'has formatted bibliography in HTML' do
+      expect(document.formatted_bibliography).to match(/^Wille, Clara/)
     end
 
     it 'has spotlight data' do


### PR DESCRIPTION
This PR fixes #600. Use `document.bibtex` to get a `BibTeX::Bibliography`. Also adds `document.reference?` and `document.formatted_bibliography`.

Note that you will need to do a `solr_wrapper clean` for this PR to work as the `schema.xml` file has a change. The PR uses a Solr `text` field without indexing to store the BibTeX and HTML data.