### PR TITLE
Add flash messages for bibliography resource creation

### DIFF
--- a/app/controllers/bibliography_resources_controller.rb
+++ b/app/controllers/bibliography_resources_controller.rb
@@ -12,9 +12,11 @@ class BibliographyResourcesController < Spotlight::ResourcesController
     @resource.update(resource_params)
 
     if @resource.save_and_index
-      redirect_to spotlight.admin_exhibit_catalog_path(current_exhibit)
+      redirect_to spotlight.admin_exhibit_catalog_path(current_exhibit),
+                  notice: I18n.t('bibliography_resources.create.notice')
     else
-      redirect_to spotlight.new_exhibit_resource_path(current_exhibit)
+      redirect_to spotlight.new_exhibit_resource_path(current_exhibit),
+                  alert: I18n.t('bibliography_resources.create.error')
     end
   end
   alias update create

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,9 @@ en:
     form:
       add_item: Add items
       title: Bibliography via BibTeX
+    create:
+      notice: Your bibliography resource has been successfully created.
+      error:  There was a problem with adding the BibTeX resource.
 
   admin:
     items:

--- a/spec/features/bibliography_indexing_spec.rb
+++ b/spec/features/bibliography_indexing_spec.rb
@@ -23,5 +23,6 @@ RSpec.feature 'Bibliography indexing', type: :feature do
       click_button 'Add items'
     end
     expect(page).to have_css 'h5', text: /Quelques/
+    expect(page).to have_css '.alert-info', text: 'Your bibliography resource has been successfully created.'
   end
 end


### PR DESCRIPTION
Closes #614 

- This PR adds a flash message for successful creation of bibliography resources via the `Bibliography via BibTeX`. 
- Adds an error message for unsuccessful creation (`There was a problem with adding the BibTeX resource.`)
But...we don't have any validations on the form yet. @mejackreed should this be added as a separate ticket or will this be part of #611?

## Screenshot
<img width="457" alt="successful_flash_message" src="https://user-images.githubusercontent.com/5402927/30991889-e26d7f6a-a45b-11e7-8e34-fa2f5fb9d91a.png">
