### PR TITLE
Add author and publication to show page

### DIFF
--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -22,6 +22,14 @@ to_field 'title_uniform_search', lambda { |record, accumulator, _context|
   accumulator << record.title.to_s(filter: :latex)
 }
 
+to_field 'author_person_full_display', lambda { |record, accumulator, _context|
+  accumulator << record.author.to_s(filter: :latex)
+}
+
+to_field 'pub_display', lambda { |record, accumulator, _context|
+  accumulator << record.journal.to_s(filter: :latex)
+}
+
 to_field 'format_main_ssim', literal('Reference')
 
 # raw serialization of BibTeX::Entry

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       end
     end
 
+    it 'has an author' do
+      expect(document['author_person_full_display']).to eq ['Wille, Clara']
+    end
+
+    it 'has publication title' do
+      expect(document['pub_display']).to eq ['Reinardus. Yearbook of the International Reynard Society']
+    end
+
     it 'has BibTeX' do
       expect(document.bibtex.to_s).to include '@article{http://zotero.org/groups/1051392/items/QTWBAWKX'
     end


### PR DESCRIPTION
Fixes part of #605 

This PR adds `author_person_full_display` and `pub_display` to the show page. I followed the pattern from #622. I wanted to ask some questions at stand-up before adding fields to `catalog_controller.rb`.

## Before
<img width="791" alt="before_show" src="https://user-images.githubusercontent.com/5402927/30996558-96a7158a-a476-11e7-8520-fe6eb05e038c.png">

## After
<img width="1000" alt="after_show" src="https://user-images.githubusercontent.com/5402927/30996559-96a92b7c-a476-11e7-8845-673f23554e42.png">
