### PR TITLE
Start adding varied metadata to show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -163,6 +163,8 @@ class CatalogController < ApplicationController
     config.add_index_field 'location_ssi', label: 'Location'
     config.add_index_field 'donor_tags_ssim', label: 'Donor tags'
     config.add_index_field 'doc_subtype_ssi', label: 'Document Subtype'
+    config.add_index_field 'volume_ssm', label: 'Volume'
+    config.add_index_field 'pages_ssm', label: 'Pages'
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
     config.add_index_field 'general_notes_ssim', label: 'Notes'

--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -35,7 +35,15 @@ to_field 'author_person_full_display', lambda { |record, accumulator, _context|
 }
 
 to_field 'pub_display', lambda { |record, accumulator, _context|
-  accumulator << record.journal.to_s.presence
+  accumulator << record.journal.to_s.presence if record.respond_to?(:journal)
+}
+
+to_field 'volume_ssm', lambda { |record, accumulator, _context|
+  accumulator << record.volume.to_s.presence if record.respond_to?(:volume)
+}
+
+to_field 'pages_ssm', lambda { |record, accumulator, _context|
+  accumulator << record.pages.to_s.presence if record.respond_to?(:pages)
 }
 
 to_field 'format_main_ssim', literal('Reference')

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       expect(document['pub_display']).to eq ['Reinardus. Yearbook of the International Reynard Society']
     end
 
+    it 'has a volume' do
+      expect(document['volume_ssm']).to eq ['17']
+    end
+
+    it 'has pages' do
+      expect(document['pages_ssm']).to eq ['181–201']
+    end
+
     it 'has BibTeX' do
       expect(document.bibtex.to_s).to include '@article{http://zotero.org/groups/1051392/items/QTWBAWKX'
     end
@@ -57,6 +65,10 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
 
     it 'has spotlight data' do
       expect(document).to include :spotlight_resource_id_ssim, :spotlight_resource_type_ssim
+    end
+
+    it 'skips undefined fields' do
+      expect(document['place']).to be_nil
     end
   end
   context 'with no title' do


### PR DESCRIPTION
Addresses part of #605 
Requires #637 to be merged
Additional fields will be added after #649 / #650 

This PR:
- adds a pattern for handling a larger variety of metadata fields on the show page
e.g. a Zotero Thesis item may have a blank `pages` field, but it cannot have a `volume` field. The first returns `nil`, the latter returns a `NoMethodError` and interrupts the indexing process. Once more fields were added, I was able to index `article.bib`, but `book.bib` and `phdthesis.bib` would silently fail.
- adds Volume, Pages, and Short Title to the show page

## Before
<img width="1000" alt="before_show" src="https://user-images.githubusercontent.com/5402927/31133773-45901ab4-a815-11e7-9eab-d4facb6532bb.png">

## After
![after_show](https://user-images.githubusercontent.com/5402927/31133812-53c19158-a815-11e7-8b4e-5c12291f784f.png)
