### PR TITLE
add controller for formating sorted bibliographies

### DIFF
--- a/app/controllers/bibliography_formatting_controller.rb
+++ b/app/controllers/bibliography_formatting_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+##
+# Class for handling BibliographyResourcesController
+class BibliographyFormattingController < ApplicationController
+  def show
+    bibliography_ids = Array.wrap(params.require(:id))
+    bibtex = bibliography_ids.collect do |document_id|
+      SolrDocument.find(document_id).bibtex.to_s
+    end.join("\n")
+    render html: Bibliography.new(bibtex).to_html.html_safe # rubocop: disable Rails/OutputSafety
+  end
+end

--- a/app/models/concerns/bibliography_concern.rb
+++ b/app/models/concerns/bibliography_concern.rb
@@ -11,10 +11,10 @@ module BibliographyConcern
   end
 
   def bibtex
-    BibTeX.parse(fetch('bibtex_ts', []).first) if reference?
+    BibTeX.parse(first('bibtex_ts')) if reference?
   end
 
   def formatted_bibliography
-    fetch('formatted_bibliography_ts', []).first if reference?
+    first('formatted_bibliography_ts') if reference?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Exhibits::Application.routes.draw do
 
   resources :exhibits, path: '/', only: [] do
     resource :dor_harvester, controller: :"dor_harvester", only: [:create, :update]
+    resource :bibliography_formatting, controller: :"bibliography_formatting", only: [:show]
     resource :bibliography_resources, only: [:create, :update]
     resource :services, only: [:create, :edit, :update] do
       member do

--- a/spec/controllers/bibliography_formatting_controller_spec.rb
+++ b/spec/controllers/bibliography_formatting_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BibliographyFormattingController, type: :controller do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:bibtex) { Pathname('spec/fixtures/bibliography/article.bib') }
+  let(:document) { instance_double(SolrDocument, bibtex: bibtex) }
+
+  describe '#show' do
+    context 'when input is valid' do
+      let(:id) { 'QTWBAWKX' }
+
+      before do
+        allow(SolrDocument).to receive(:find).with(id).and_return(document)
+      end
+
+      it 'formats the bibliography correctly' do
+        get :show, params: { exhibit_id: exhibit.id, id: [id] }
+        expect(response.content_type).to eq 'text/html'
+        expect(response.body).to include 'Wille, Clara'
+      end
+    end
+
+    context 'when input is invalid' do
+      it 'raises an exception' do
+        expect { get :show, params: { exhibit_id: exhibit.id } }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #632. It establishes a new route that takes in one or more bibliography document identifiers and returns a sorted bibliography in HTML.

For example, from http://localhost:3000/default/bibliography_formatting?id[]=QTWBAWKX&id[]=GWT7TMKR&id[]=KJ5WQIFZ&id[]=WJ72DTUD (note these IDs are from the full Parker bibliography)

![screen shot 2017-10-02 at 11 14 06 am](https://user-images.githubusercontent.com/1861171/31092541-9b4da5be-a763-11e7-8120-621699e70d98.png)

whose HTML looks like: 

![screen shot 2017-10-02 at 11 21 52 am](https://user-images.githubusercontent.com/1861171/31092639-ec5c67ec-a763-11e7-9901-49c808f5ba8f.png)
