### PR TITLE
add SolrDocument.related_document_ids and use SolrDocument.first where possible

### DIFF
--- a/app/models/concerns/bibliography_concern.rb
+++ b/app/models/concerns/bibliography_concern.rb
@@ -3,14 +3,18 @@
 # bibliography
 module BibliographyConcern
   def reference?
-    fetch('format_main_ssim', []).first == 'Reference'
+    first('format_main_ssim') == 'Reference'
   end
 
   def bibtex
-    BibTeX.parse(fetch('bibtex_ts', []).first) if reference?
+    BibTeX.parse(first('bibtex_ts')) if reference?
   end
 
   def formatted_bibliography
-    fetch('formatted_bibliography_ts', []).first if reference?
+    first('formatted_bibliography_ts') if reference?
+  end
+
+  def related_document_ids
+    fetch('related_document_id_ssim', []) if reference?
   end
 end

--- a/spec/fixtures/bibliography/noauthor.bib
+++ b/spec/fixtures/bibliography/noauthor.bib
@@ -3,6 +3,6 @@
 	title = {A declaration of certayne principall articles of religion: set out by the order of both archebyshoppes metropolitans, and the rest of the byshoppes, for the vnitie of doctrine to be taught and holden of all parsons, vicars, and curates, aswell in the testification of theyr common consent in the sayde doctrine, to the stoppyng of the mouthes of them that goo about to slaunder the ministers of the church for diuersitie of iudgement: as necessary for the instruction of their people, to read by the sayde parsons, vicars, and curates, at theyr possession takyng or first entrye into theyr cures: and also after that yerely at two seuerall tymes. {That} is to say, the {Sundayes} next folowyng {Easter} day and {Saint} {Michaell} tharchaungell, or on some other {Sunday} within one moneth after those feastes, immediately after the {Gospell}},
 	shorttitle = {A {Declaration} 1561},
 	year = {1561},
-	keywords = {dg156sv6886, test},
+	keywords = {dg156sv6886, test, aa111bb2222},
 	annote = { NJC}
 }


### PR DESCRIPTION
This PR closes #640 by adding tests of the Traject code that indexes related documents using the BibTeX.keywords field. Also, uses `first` method in the bibliography concern where possible. Finally, I cleaned up the indexing specs a bit.
