### PR TITLE
Only show mirador viewer when there is a manifest to show

### DIFF
--- a/app/models/concerns/manifest_concern.rb
+++ b/app/models/concerns/manifest_concern.rb
@@ -1,0 +1,8 @@
+##
+# A concern to be mixed into the SolrDocument class in order to provide
+# convenient accessors for IIIF manifests embeded in a SolrDocument
+module ManifestConcern
+  def manifest
+    fetch('iiif_manifest_url_ssi', nil)
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -11,6 +11,8 @@ class SolrDocument
 
   include BibliographyConcern
 
+  include ManifestConcern
+
   # self.unique_key = 'id'
 
   # Email uses the semantic field mappings below to generate the body of an email.

--- a/app/views/viewers/_mirador.html.erb
+++ b/app/views/viewers/_mirador.html.erb
@@ -1,12 +1,14 @@
-<iframe
-  src="<%= mirador_index_path(
-    manifest_url: document['iiif_manifest_url_ssi']
-  ) %>"
-  allowfullscreen="true"
-  class="mirador-embed-wrapper"
-  frameborder="0"
-  marginwidth="0"
-  marginheight="0"
-  scrolling="no"
-  width="100%"
-></iframe>
+<% if document.manifest %>
+  <iframe
+    src="<%= mirador_index_path(
+      manifest_url: document.manifest
+    ) %>"
+    allowfullscreen="true"
+    class="mirador-embed-wrapper"
+    frameborder="0"
+    marginwidth="0"
+    marginheight="0"
+    scrolling="no"
+    width="100%"
+  ></iframe>
+<% end %>

--- a/spec/views/viewers/_mirador.html.erb_spec.rb
+++ b/spec/views/viewers/_mirador.html.erb_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 describe 'viewers/_mirador.html.erb', type: :view do
-  let(:document) { { 'iiif_manifest_url_ssi' => 'https://purl.stanford.edu/bc853rd3116?manifest' } }
+  let(:document) do
+    SolrDocument.new('iiif_manifest_url_ssi' => 'https://purl.stanford.edu/bc853rd3116?manifest')
+  end
 
   before do
     render partial: 'viewers/mirador', locals: { document: document }
@@ -15,5 +17,12 @@ describe 'viewers/_mirador.html.erb', type: :view do
     iframe = Capybara.string(rendered).find('iframe')
 
     expect(iframe['allowfullscreen']).to eq 'true'
+  end
+  context 'when manifest is missing' do
+    let(:document) { SolrDocument.new }
+
+    it 'is not viewable' do
+      expect(rendered).not_to have_css 'iframe'
+    end
   end
 end


### PR DESCRIPTION
Closes #654 

Might be useful when working on #612 