### PR TITLE
load bibliography section asynchonously on manuscript show page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require blacklight/blacklight
 
 //= require analytics
+//= require bibliography
 //= require blacklight_gallery
 //= require blacklight_heatmaps
 //= require blacklight_oembed

--- a/app/assets/javascripts/bibliography.js
+++ b/app/assets/javascripts/bibliography.js
@@ -1,0 +1,41 @@
+/* eslint-disable camelcase */
+/* global Bibliography */
+
+(function (global) {
+  var Bibliography;
+
+  Bibliography = {
+    init: function (el) {
+      var $el = $(el);
+      var data = $el.data();
+      $.getJSON(data.path, {
+          'f[related_document_id_ssim][]': data.parentid,
+          'f[format_main_ssim][]': 'Reference',
+          sort: data.sort,
+          format: 'json',
+          rows: '1000'
+        }, function (response) {
+        for (var i = 0; i < response.response.docs.length; i++) {
+          var bibEntry = response.response.docs[i];
+          var html = '<p class="bibliography-body">' +
+                      bibEntry.formatted_bibliography_ts +
+                      ' <a href="' +
+                      data.baseurl + bibEntry.id +
+                      '">[View full reference]</a>' +
+                      '</p>';
+          $el.find('.bibliography-list').append(html);
+        }
+      });
+    }
+  };
+
+  global.Bibliography = Bibliography;
+}(this));
+
+Blacklight.onLoad(function () {
+  'use strict';
+
+  $('.bibliography-contents').each(function (i, element) {
+    Bibliography.init(element); // eslint-disable-line no-undef
+  });
+});

--- a/app/assets/stylesheets/modules/bibliography.scss
+++ b/app/assets/stylesheets/modules/bibliography.scss
@@ -1,5 +1,25 @@
-.show-document {
+.bibliography-contents {
+  margin-left: 0;
+  padding-left: 0;
+
   h3 {
     color: $brand-primary;
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  .bibliography-list {
+    margin-left: 0;
+    padding-left: 0;
+
+    a {
+      white-space: nowrap;
+    }
+
+    .bibliography-body {
+      margin-left: 2em;
+      max-width: 80ch;
+      text-indent: -2em;
+    }
   }
 }

--- a/app/views/catalog/_bibliography_default.html.erb
+++ b/app/views/catalog/_bibliography_default.html.erb
@@ -1,0 +1,9 @@
+<div class='col-md-12 bibliography-contents'
+     data-path="<%= search_exhibit_catalog_path(exhibit_id: @exhibit) %>"
+     data-parentid="<%= @document.id %>"
+     data-baseurl="http://zotero.org/groups/1051392/items/"
+     data-sort="author_sort asc, pub_year_isi asc, title_sort asc">
+     <%# TODO: retrieve this sort configuration from the blacklight config %>
+     <h3 class="col-md-9">Bibliography</h3>
+     <div class="col-md-9 bibliography-list"></div>
+</div>

--- a/spec/features/bibliography_display_manuscript_spec.rb
+++ b/spec/features/bibliography_display_manuscript_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Bibliography display on the manuscript show page', type: :feature do
+  let(:exhibit) { FactoryGirl.create(:exhibit, slug: 'default-exhibit') }
+  let(:resource_id) { 'gk885tn1705' }
+  let(:bibtex_data) do
+    Dir.glob('spec/fixtures/bibliography/{article,incollection}.bib').collect do |fn|
+      File.read(fn)
+    end.join("\n")
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :inline # block until indexing has committed
+
+    # we index some bibliography records that have links to our resource
+    bib = BibliographyResource.new(bibtex_file: bibtex_data, exhibit: exhibit)
+    bib.save_and_index
+
+    # render the resource show page
+    visit spotlight.exhibit_solr_document_path(exhibit_id: exhibit.slug, id: resource_id)
+  end
+
+  after :all do
+    ActiveJob::Base.queue_adapter = :test # restore
+  end
+
+  scenario 'bibliography element data required by async loader' do
+    expect(page).to have_css('div.bibliography-contents[data-path="/default-exhibit/catalog"]')
+    expect(page).to have_css("div.bibliography-contents[data-parentid=\"#{resource_id}\"]")
+    expect(page).to have_css('div.bibliography-contents[data-sort="author_sort asc, pub_year_isi asc, title_sort asc"]')
+  end
+
+  scenario 'async loading of the sorted, formatted bibliography', js: true do # rubocop: disable RSpec/ExampleLength
+    within '.bibliography-contents' do
+      within '.bibliography-list' do
+        # must be sorted correctly
+        within 'p:nth-child(1)' do
+          expect(page).to have_content('Whatley, E. G. 1986.')
+          expect(page).to have_css('a[href="http://zotero.org/groups/1051392/items/EI8BRRXB"]')
+        end
+        within 'p:nth-child(2)' do
+          expect(page).to have_content('Wille, Clara. 2004.')
+          expect(page).to have_css('a[href="http://zotero.org/groups/1051392/items/QTWBAWKX"]')
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/bibliography/article.bib
+++ b/spec/fixtures/bibliography/article.bib
@@ -6,7 +6,7 @@
 	journal = {Reinardus. Yearbook of the International Reynard Society},
 	author = {Clara Wille},
 	year = {2004},
-	keywords = {gs233db8425},
+	keywords = {gs233db8425, gk885tn1705},
 	pages = {181--201},
 	annote = { ELB},
 	annote = {The following values have no corresponding Zotero field:custom1: 63}

--- a/spec/fixtures/bibliography/incollection.bib
+++ b/spec/fixtures/bibliography/incollection.bib
@@ -10,7 +10,7 @@
 	volume = {1},
 	edition = {1st},
 	publisher = {My Publisher},
-	keywords = {qt747ct6627},
+	keywords = {qt747ct6627, gk885tn1705},
 	pages = {333--43},
 	annote = { NJM}
 }


### PR DESCRIPTION
This PR closes #632 and closes #539.

- [x] Async loading on manuscript (resource) show page
- [x] Proper sorting by Chicago-Author-Date
- [x] Automated testing
  - [x] View tests
  - [x] JavaScript tests

Note that to try this out, you need to (in this order):

  1. Load some Parker resources into your exhibit (e.g., cg531kv2466) 
  2. Load some BibTeX items into your exhibit that refer to the druids of your Parker objects (ones that reference cg531kv2466 in the keywords field)

### After

![screen shot 2017-10-04 at 2 49 37 pm](https://user-images.githubusercontent.com/1861171/31201364-4840914a-a913-11e7-974f-9b667491a4a2.png)
