### PR TITLE
Add minimum set of Zotero API BibTeX fields to show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -142,6 +142,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'title_variant_display', label: 'Alternate Title'
     config.add_index_field 'author_person_full_display', label: 'Author' # includes Collectors
     config.add_index_field 'author_no_collector_ssim', label: 'Author (no Collectors)'
+    config.add_index_field 'editor_ssim', label: 'Editor'
     config.add_index_field 'collector_ssim', label: 'Collector'
     config.add_index_field 'author_corp_display', label: 'Corporate Author'
     config.add_index_field 'author_meeting_display', label: 'Meeting Author'
@@ -163,8 +164,15 @@ class CatalogController < ApplicationController
     config.add_index_field 'location_ssi', label: 'Location'
     config.add_index_field 'donor_tags_ssim', label: 'Donor tags'
     config.add_index_field 'doc_subtype_ssi', label: 'Document Subtype'
+    # Fields added by Zotero API BibTeX import
     config.add_index_field 'volume_ssm', label: 'Volume'
     config.add_index_field 'pages_ssm', label: 'Pages'
+    config.add_index_field 'doi_ssim', label: 'DOI'
+    config.add_index_field 'issue_ssm', label: 'Issue'
+    config.add_index_field 'edition_ssm', label: 'Edition'
+    config.add_index_field 'university_ssim', label: 'University'
+    config.add_index_field 'thesis_type_ssm', label: 'Degree Type'
+    config.add_index_field 'book_title_ssim', label: 'Book Title'
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
     config.add_index_field 'general_notes_ssim', label: 'Notes'

--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -47,16 +47,57 @@ to_field 'pub_year_isi', lambda { |record, accumulator, _context|
   accumulator << record.year.to_i.presence if record.respond_to?(:year)
 }
 
+to_field 'editor_ssim', lambda { |record, accumulator, _context|
+  accumulator << record.editor.to_s.presence if record.respond_to?(:editor)
+}
+
+to_field 'book_title_ssim', lambda { |record, accumulator, _context|
+  accumulator << record.booktitle.to_s.presence if record.respond_to?(:booktitle)
+}
+
 to_field 'pub_display', lambda { |record, accumulator, _context|
   accumulator << record.journal.to_s.presence if record.respond_to?(:journal)
+  accumulator << record.publisher.to_s.presence if record.respond_to?(:publisher)
+}
+
+to_field 'pub_year_w_approx_isi', lambda { |record, accumulator, _context|
+  accumulator << record.year.to_s.presence if record.respond_to?(:year)
+}
+
+to_field 'location_ssi', lambda { |record, accumulator, _context|
+  accumulator << record.address.to_s.presence if record.respond_to?(:address)
+}
+
+to_field 'university_ssim', lambda { |record, accumulator, _context|
+  accumulator << record.school.to_s.presence if record.respond_to?(:school)
+}
+
+to_field 'edition_ssm', lambda { |record, accumulator, _context|
+  accumulator << record.edition.to_s.presence if record.respond_to?(:edition)
+}
+
+to_field 'series_ssi', lambda { |record, accumulator, _context|
+  accumulator << record.series.to_s.presence if record.respond_to?(:series)
+}
+
+to_field 'thesis_type_ssm', lambda { |record, accumulator, _context|
+  accumulator << record.fields[:type].to_s.presence if record.fields.include?(:type)
 }
 
 to_field 'volume_ssm', lambda { |record, accumulator, _context|
   accumulator << record.volume.to_s.presence if record.respond_to?(:volume)
 }
 
+to_field 'issue_ssm', lambda { |record, accumulator, _context|
+  accumulator << record.issue.to_s.presence if record.respond_to?(:issue)
+}
+
 to_field 'pages_ssm', lambda { |record, accumulator, _context|
   accumulator << record.pages.to_s.presence if record.respond_to?(:pages)
+}
+
+to_field 'doi_ssim', lambda { |record, accumulator, _context|
+  accumulator << record.doi.to_s.presence if record.respond_to?(:doi)
 }
 
 to_field 'format_main_ssim', literal('Reference')

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -47,18 +47,6 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       end
     end
 
-    it 'has publication title' do
-      expect(document['pub_display']).to eq ['Reinardus. Yearbook of the International Reynard Society']
-    end
-
-    it 'has a volume' do
-      expect(document['volume_ssm']).to eq ['17']
-    end
-
-    it 'has pages' do
-      expect(document['pages_ssm']).to eq ['181–201']
-    end
-
     it 'has BibTeX' do
       expect(document.bibtex.to_s).to include '@article{http://zotero.org/groups/1051392/items/QTWBAWKX'
     end
@@ -75,10 +63,73 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       expect(document['place']).to be_nil
     end
 
-    it 'has a year' do
-      expect(document['pub_year_isi']).to eq [2004]
+    context 'article' do
+      it 'has publication title' do
+        expect(document['pub_display']).to eq ['Reinardus. Yearbook of the International Reynard Society']
+      end
+
+      it 'has a volume' do
+        expect(document['volume_ssm']).to eq ['17']
+      end
+
+      it 'has pages' do
+        expect(document['pages_ssm']).to eq ['181–201']
+      end
+
+      it 'has a year' do
+        expect(document['pub_year_isi']).to eq [2004]
+      end
+
+      it 'has a DOI' do
+        expect(document['doi_ssim']).to eq ['10.1075/rein.17.14wil']
+      end
+    end
+
+    context 'book' do
+      let(:file) { 'spec/fixtures/bibliography/book.bib' }
+
+      it 'has a publisher' do
+        expect(document['pub_display']).to eq ['Faculdade de Letras da Universidade de Coimbra']
+      end
+
+      it 'has an edition' do
+        expect(document['edition_ssm']).to eq ['1st']
+      end
+
+      it 'has an address' do
+        expect(document['location_ssi']).to eq ['Coimbra']
+      end
+    end
+
+    context 'book section' do
+      let(:file) { 'spec/fixtures/bibliography/incollection.bib' }
+
+      it 'has a book title' do
+        expect(document['book_title_ssim'].first).to match(/^Legenda aurea/)
+      end
+
+      it 'has a series' do
+        expect(document['series_ssi']).to eq ['Textes et Études du Moyen Âge']
+      end
+
+      it 'has an editor ' do
+        expect(document['editor_ssim']).to eq ['Dunn-Lardeau, B.']
+      end
+    end
+
+    context 'thesis' do
+      let(:file) { 'spec/fixtures/bibliography/phdthesis.bib' }
+
+      it 'has a degree type' do
+        expect(document['thesis_type_ssm']).to eq ['B.Litt.']
+      end
+
+      it 'has a university' do
+        expect(document['university_ssim']).to eq ['University of Oxford']
+      end
     end
   end
+
   context 'with related documents' do
     let(:file) { 'spec/fixtures/bibliography/noauthor.bib' }
 


### PR DESCRIPTION
Closes #659 

This PR: 
- adds the minimum set of metadata fields for the bibliography resource show page, as relevant to the Parker Library (list below)

## Notes
- you may need to go to `Curation > Metadata` for fields to be visible

Enhancements for future tickets:
- reorder fields? I guess this is configured in `Curation > Metadata`. 
- add a `Reference type` field that reads `record.type` and maps it to the appropriate Zotero name

### Reference types (BibTeX name | Zotero name)
- phdthesis / Thesis
- book
- incollection / Book Section
- misc / Document

### Added fields (BibTeX name | exhibit label)
- editor / Editor
- doi / DOI
- issue / Issue
- edition / Edition
- school / University
- type / Degree Type
- booktitle / Book Title
- publisher / Publication Info
- year / Date
- address / Location
- series / Series
- issue / Issue

## After
### Document
![document_after](https://user-images.githubusercontent.com/5402927/31152357-8c503a70-a850-11e7-83b5-501e25012f09.png)

### Book selection
![book selection_after](https://user-images.githubusercontent.com/5402927/31152359-8c580b6a-a850-11e7-9943-d987745afd66.png)

### Book
![book_after](https://user-images.githubusercontent.com/5402927/31152360-8d1222b6-a850-11e7-9211-eadfeb469c46.png)

### Article
![article_after](https://user-images.githubusercontent.com/5402927/31152356-8c4d0558-a850-11e7-9926-c715f3ebe5a1.png)

### Thesis
![thesis_after](https://user-images.githubusercontent.com/5402927/31152358-8c53404e-a850-11e7-9a30-b38a61f2d4bc.png)





