### PR TITLE
add View on Zotero site to bibliography show page

### DIFF
--- a/app/assets/stylesheets/modules/bibliography.scss
+++ b/app/assets/stylesheets/modules/bibliography.scss
@@ -23,3 +23,7 @@
     }
   }
 }
+
+.btn-view-on-zotero {
+  margin-right: 10px;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,9 +58,10 @@ class CatalogController < ApplicationController
 
     config.show.title_field = 'title_full_display'
     config.show.oembed_field = :url_fulltext
-    config.show.partials.insert(1, :viewer)
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
 
+    config.show.partials.insert(1, :viewer)
+    config.show.partials.unshift :bibliography_buttons
     config.show.partials << :bibliography
 
     config.view.list.thumbnail_field = :thumbnail_square_url_ssm

--- a/app/models/concerns/bibliography_concern.rb
+++ b/app/models/concerns/bibliography_concern.rb
@@ -17,4 +17,18 @@ module BibliographyConcern
   def related_document_ids
     fetch('related_document_id_ssim', []) if reference?
   end
+
+  def bibliography_url
+    first('bibtex_key_ss') if reference?
+  end
+
+  def zotero_url
+    return unless reference?
+    begin
+      url = URI.parse(bibliography_url)
+      url.to_s if url.host =~ /zotero/i
+    rescue URI::InvalidURIError
+      nil # just a regular BibTeX key
+    end
+  end
 end

--- a/app/views/catalog/_bibliography_buttons_default.html.erb
+++ b/app/views/catalog/_bibliography_buttons_default.html.erb
@@ -1,0 +1,5 @@
+<% if @document.zotero_url.present? %>
+  <a href="<%= @document.zotero_url %>" class="btn btn-info btn-view-on-zotero pull-right">
+    View on Zotero site
+  </a>
+<% end %>

--- a/app/views/catalog/_bibliography_default.html.erb
+++ b/app/views/catalog/_bibliography_default.html.erb
@@ -1,9 +1,11 @@
-<div class='col-md-12 bibliography-contents'
-     data-path="<%= search_exhibit_catalog_path(exhibit_id: @exhibit) %>"
-     data-parentid="<%= @document.id %>"
-     data-baseurl="http://zotero.org/groups/1051392/items/"
-     data-sort="author_sort asc, pub_year_isi asc, title_sort asc">
-     <%# TODO: retrieve this sort configuration from the blacklight config %>
-     <h3 class="col-md-9">Bibliography</h3>
-     <div class="col-md-9 bibliography-list"></div>
-</div>
+<% unless @document.reference? %>
+  <div class='col-md-12 bibliography-contents'
+       data-path="<%= search_exhibit_catalog_path(exhibit_id: @exhibit) %>"
+       data-parentid="<%= @document.id %>"
+       data-baseurl="http://zotero.org/groups/1051392/items/"
+       data-sort="author_sort asc, pub_year_isi asc, title_sort asc">
+       <%# TODO: retrieve this sort configuration from the blacklight config %>
+       <h3 class="col-md-9">Bibliography</h3>
+       <div class="col-md-9 bibliography-list"></div>
+  </div>
+<% end %>

--- a/spec/views/catalog/_bibliography_buttons_default.html.erb_spec.rb
+++ b/spec/views/catalog/_bibliography_buttons_default.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'catalog/_bibliography_buttons_default', type: :view do
+  let(:document) { SolrDocument.new(format_main_ssim: 'Reference', bibtex_key_ss: url) }
+
+  before do
+    assign(:document, document)
+    render
+  end
+
+  context 'with a valid Zotero URL' do
+    let(:url) { 'http://Zotero.ORG/groups/1051392/items/QTWBAWKX' }
+
+    it 'renders a View on Zotero site button' do
+      expect(rendered).to have_css("a.btn-view-on-zotero[href=\"#{url}\"]", text: 'View on Zotero site')
+    end
+  end
+
+  context 'with a regular BibTeX key' do
+    let(:url) { 'smith_2010' }
+
+    it 'skips button' do
+      expect(rendered).not_to have_css('a.btn-view-on-zotero')
+    end
+  end
+
+  context 'without a URL' do
+    let(:url) { nil }
+
+    it 'skips button' do
+      expect(rendered).not_to have_css('a.btn-view-on-zotero')
+    end
+  end
+end


### PR DESCRIPTION
This PR closes #539. It adds a new partial that'll allow us to add blue buttons before the Edit button on bibliography show pages.

### After

![screen shot 2017-10-05 at 12 11 34 pm](https://user-images.githubusercontent.com/1861171/31248067-6e903bc0-a9c7-11e7-91eb-fa9efd197891.png)

Also the change to `_bibliography_default.html.erb` removes the (not-needed) Bibliography section from the bibliography show page.