### PR TITLE
Map reference types to Zotero labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). One notable difference is that for this project, semantic versioning is used in reference to user facing experience.
 
+## [1.1.1] - 2017-10-?
+### Changed
+- Adds additional Zotero fields to BibTeX index  #664, #675
+
 ## [1.1.0] - 2017-10-04
 
 ### Added

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -173,6 +173,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'university_ssim', label: 'University'
     config.add_index_field 'thesis_type_ssm', label: 'Degree Type'
     config.add_index_field 'book_title_ssim', label: 'Book Title'
+    config.add_index_field 'ref_type_ssm', label: 'Reference Type'
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
     config.add_index_field 'general_notes_ssim', label: 'Notes'

--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -8,6 +8,14 @@ settings do
   provide 'reader_class_name', 'BibReader'
 end
 
+BIBTEX_ZOTERO_MAPPING = {
+  phdthesis: 'Thesis',
+  incollection: 'Book section',
+  article: 'Journal article',
+  book: 'Book',
+  misc: 'Document'
+}.freeze
+
 each_record do |record, context|
   context.skip!("Skipping #{record.key} no title") if record.title.blank?
   context.skip!("Skipping #{record.key} no keywords") unless record.respond_to?(:keywords)
@@ -21,6 +29,10 @@ to_field 'id', lambda { |record, accumulator, _context|
 
 to_field 'bibtex_key_ss', lambda { |record, accumulator, _context|
   accumulator << record.key
+}
+
+to_field 'ref_type_ssm', lambda { |record, accumulator, _context|
+  accumulator << BIBTEX_ZOTERO_MAPPING[record.type] if BIBTEX_ZOTERO_MAPPING.include?(record.type)
 }
 
 to_field 'title_display', lambda { |_record, accumulator, context|

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       it 'has a DOI' do
         expect(document['doi_ssim']).to eq ['10.1075/rein.17.14wil']
       end
+
+      it 'has a reference type' do
+        expect(document['ref_type_ssm']).to eq ['Journal article']
+      end
     end
 
     context 'book' do
@@ -119,6 +123,10 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       it 'has an editor ' do
         expect(document['editor_ssim']).to eq ['Dunn-Lardeau, B.']
       end
+
+      it 'has a reference type' do
+        expect(document['ref_type_ssm']).to eq ['Book section']
+      end
     end
 
     context 'thesis' do
@@ -130,6 +138,18 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
 
       it 'has a university' do
         expect(document['university_ssim']).to eq ['University of Oxford']
+      end
+
+      it 'has a reference type' do
+        expect(document['ref_type_ssm']).to eq ['Thesis']
+      end
+    end
+
+    context 'miscellaneous' do
+      let(:file) { 'spec/fixtures/bibliography/misc.bib' }
+
+      it 'has a reference type' do
+        expect(document['ref_type_ssm']).to eq ['Document']
       end
     end
   end


### PR DESCRIPTION
Closes #672 
Design #605 

This PR:
- adds a `Reference type` field to the bibliography resource show page
- maps BibTeX `resource.type` to Zotero Item Types

## Before
<img width="683" alt="reftype_before" src="https://user-images.githubusercontent.com/5402927/31206389-61693b54-a92c-11e7-825e-61afd92e0ab8.png">

## After
<img width="694" alt="reftype_after" src="https://user-images.githubusercontent.com/5402927/31206311-e57a2260-a92b-11e7-93ee-2e8954ea5999.png">
