### PR TITLE
Add a single annotation to bibliography show page

### DIFF
--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -116,6 +116,10 @@ to_field 'doi_ssim', lambda { |record, accumulator, _context|
   accumulator << record.doi.to_s.presence if record.respond_to?(:doi)
 }
 
+to_field 'general_notes_ssim', lambda { |record, accumulator, _context|
+  accumulator << record.annote.to_s.presence if record.respond_to?(:annote)
+}
+
 to_field 'format_main_ssim', literal('Reference')
 
 # raw serialization of BibTeX::Entry

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       it 'has a reference type' do
         expect(document['ref_type_ssm']).to eq ['Journal article']
       end
+
+      it 'has annotations' do
+        expect(document['general_notes_ssim'].last).to match(/^The following values/)
+      end
     end
 
     context 'book' do


### PR DESCRIPTION
Closes #676 
Design #605
Spawned #685 (see notes below)

# Screenshot (book.bib)
![book_record_with_notes_section_added](https://user-images.githubusercontent.com/5402927/31255447-b4d6efc4-a9e1-11e7-892f-044880a98473.png)



## Notes
Our BibTeX reader only captures a single annotation! e.g. [book.bib](https://github.com/sul-dlss/exhibits/blob/676-bib-show-page-annotations/spec/fixtures/bibliography/book.bib) has 3 `annote` values. When I checked our our BibTeX `record`, only the last annotation is captured.

### Current input --> output
#### BibTeX:
```
@book{http://zotero.org/groups/1051392/items/TXXUJDG2,
	address = {Coimbra},
	title = {A {Carta} ou {Memória} do {Cruzado} {Inglês} {R}. para {Osberto} de {Bawdsey} sobre a conquista de {Lisboa} em 1147},
        …
	annote = { KAW},
	annote = {CCC MS 470 [p. 9, and referred to (without MS number) throughout]reproductions from CCC MS 470, ff. 125-146, in the appendix},
	annote = {The following values have no corresponding Zotero field:custom1: 23}
}
```
#### BibTeX::Entry
```
#<BibTeX::Entry 
  address = Coimbra, 
  title = A Carta ou Memória do Cruzado Inglês R. para Osberto de Bawdsey sobre a conquista de Lisboa em 1147, 
  …
  annote = The following values have no corresponding Zotero field:custom1: 23
>
```

### Possible routes forward:

1. mess with our BibTex translator so that we get something more like:
`annote = {KAW, The following values have no corresponding Zotero field:custom1: 23}}`
2. adjust our Traject settings to deal with multiple `annote` values.
