### PR TITLE
refactor BibTeX field extraction into Traject Macro

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,5 @@ sidekiq:
 feature_flags:
   themes: false
   bibliography_resource: false
+traject:
+  processing_thread_pool: 1

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -1,0 +1,5 @@
+# Stolen from https://github.com/sul-dlss/dlme/blob/master/config/traject.rb
+unless defined? Rails
+  puts 'Loading environment...'
+  require File.expand_path('../../config/environment', __FILE__)
+end

--- a/lib/traject/README.md
+++ b/lib/traject/README.md
@@ -1,0 +1,21 @@
+# Traject+ Usage Notes
+
+Traject is a Ruby library to create lambdas for indexing mappings and transform pipelines. It was originally written for MARC (binary MARC21 or MARCXML) to Solr Documents mappings.
+
+Traject+ are extensions to Traject+, particularly within Spotlight projects, to be able to transform multiple input formats (BibTex, JSON, XML that isn't MARC, etc.) to multiple output formats (Spotlight Ruby resources, Solr, JSON intermediary representations, other).
+
+Notes here will be documenting the current usage of Traject+ within Parker specifically, including examples, explanations, etc.
+
+## Running Traject+ in CLI for Conversion Testing
+
+You can also run traject directly:
+
+```
+$ bundle exec traject -c config/traject.rb -c lib/traject/TYPE_config.rb -w SELECTED_WRITER [path to some file]
+```
+
+Example:
+
+```bash
+$ bundle exec traject -c config/traject.rb -c lib/traject/bibtex_config.rb -w DebugWriter spec/fixtures/bibliography/article.bib
+```

--- a/lib/traject/macros/bibtex.rb
+++ b/lib/traject/macros/bibtex.rb
@@ -1,0 +1,38 @@
+module Macros
+  # BibTeX extraction macros
+  module BibTeX
+    BIBTEX_ZOTERO_MAPPING = {
+      phdthesis: 'Thesis',
+      incollection: 'Book section',
+      article: 'Journal article',
+      book: 'Book',
+      misc: 'Document'
+    }.freeze
+
+    ##
+    # Traject macro for converting BibTeX fields into Solr fields
+    #
+    # @param [Symbol] `key` the BibTeX field name
+    def from_bibtex(key) # rubocop: disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # Note that `record` is a BibTeX::Entry object
+      lambda do |record, accumulator, _context|
+        case key # BibTeX fields don't all follow the same rules, so handle them here
+        when :id # we need to transform the key for a good id
+          accumulator << record.key.to_s.gsub(%r{http:\/\/zotero.org\/groups\/\d*\/items\/}, '')
+        when :key # `key` is always available (yet `provides?(:key)` is false)
+          accumulator << record.key.to_s
+        when :type # conflates with BibTeX notion of type (`record.type`) rather than field "type"
+          accumulator << record.fields[:type].to_s.presence if record.fields.include?(:type)
+        when :ref_type # use record.type to get BibTeX type
+          accumulator << BIBTEX_ZOTERO_MAPPING[record.type] if BIBTEX_ZOTERO_MAPPING.include?(record.type)
+        when :year # built-in method in BibTeX::Entry
+          accumulator << record.year
+        when :raw # serialization into BibTeX format
+          accumulator << record.to_s
+        else # use the dynamically constructed BibTeX method to fetch the field rather than fetch/get
+          accumulator << record.send(key).to_s.presence if record.respond_to?(key)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #671 and #669. It's a straight refactor (no feature changes) to use a Traject macro for each field extraction. Some were a bit complicated and I didn't put those into a macro.

cc: @cmh2166