### PR TITLE
Update BibTeX upload UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 ### Changed
+- Updates BibTeX file upload UI #699
 ### Deprecated
 ### Removed
 ### Fixed

--- a/app/views/bibliography_resources/_form.html.erb
+++ b/app/views/bibliography_resources/_form.html.erb
@@ -1,5 +1,5 @@
-<%= bootstrap_form_for([current_exhibit, @resource.becomes(BibliographyResource)], as: :resource) do |f| %>
-  <%= f.file_field :bibtex_file, label: 'BibTeX File', required: true, accept: 'application/x-bibtex'  %>
+<%= bootstrap_form_for([current_exhibit, @resource.becomes(BibliographyResource)], layout: :horizontal, label_col: `col-md-2`, control_col: `col-md-6`, as: :resource) do |f| %>
+  <%= f.file_field :bibtex_file, label: 'BibTeX File', class: 'form-control', control_col: 'col-sm-6', required: true, accept: 'application/x-bibtex', help: 'Each BibTeX file entry will be added as an exhibit item with a “Reference” resource type.'  %>
   <div class="form-actions">
     <div class="primary-actions">
       <%= cancel_link @resource, :back, class: 'btn btn-default' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
   bibliography_resources:
     form:
       add_item: Add items
-      title: Bibliography via BibTeX
+      title: BibTeX
     create:
       notice: Your bibliography resource has been successfully created.
       error:  There was a problem with adding the BibTeX resource.

--- a/spec/features/bibliography_indexing_spec.rb
+++ b/spec/features/bibliography_indexing_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Bibliography indexing', type: :feature do
 
   scenario 'indexes an item and makes it available to search' do
     visit spotlight.new_exhibit_resource_path(exhibit)
-    click_link 'Bibliography via BibTeX'
+    click_link 'BibTeX'
     within '#external_resource_tab_1' do
       attach_file 'resource_bibtex_file', 'spec/fixtures/bibliography/article.bib'
       click_button 'Add items'


### PR DESCRIPTION
Closes #695 

This PR updates our BibTeX file upload UI:
- shortens button text
- uses a horizontal label + form to match other upload options
- adds helper text

## Before
<img width="885" alt="bibtex_upload_form_before" src="https://user-images.githubusercontent.com/5402927/31302943-fba902d2-aaba-11e7-9e4f-94be8f829f8d.png">

## After
<img width="759" alt="bibtex_upload_form_after" src="https://user-images.githubusercontent.com/5402927/31350204-26121c76-acdb-11e7-8317-da37491f11d5.png">
