### PR TITLE
refactor BibTeX extraction macros

### DIFF
--- a/lib/traject/bib_reader.rb
+++ b/lib/traject/bib_reader.rb
@@ -4,18 +4,20 @@
 class BibReader
   # @param input_stream [File]
   # @param settings [Traject::Indexer::Settings]
-
-  delegate :size, to: :bibtex
-
   def initialize(input_stream, settings)
     @settings = Traject::Indexer::Settings.new settings
     @input_stream = input_stream
-    @bibtex = BibTeX.parse(input_stream.read, filter: :latex)
+    @bibliography = Bibliography.new(input_stream.read)
   end
 
+  # @return [BibTeX::Entry]
   def each(&block)
-    bibtex.each(&block)
+    bibliography.bibliography.each(&block)
   end
 
-  attr_reader :bibtex
+  def size
+    bibliography.bibliography.size
+  end
+
+  attr_reader :bibliography
 end

--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -2,9 +2,12 @@
 
 require_relative 'bib_reader'
 require_relative 'macros/bibtex'
+require_relative 'macros/general'
+
 require 'bibliography'
 require 'active_support/core_ext/object/blank'
 extend Macros::BibTeX
+extend Macros::General
 
 settings do
   provide 'reader_class_name', 'BibReader'
@@ -17,71 +20,26 @@ each_record do |record, context|
   context.skip!("Skipping #{record.key} no keywords") unless record.respond_to?(:keywords)
 end
 
-to_field 'id', from_bibtex(:id)
-
-to_field 'bibtex_key_ss', from_bibtex(:key)
-
-to_field 'ref_type_ssm', from_bibtex(:ref_type)
-
-to_field 'title_display', from_bibtex(:title)
-to_field 'title_full_display', from_bibtex(:title)
-to_field 'title_uniform_search', from_bibtex(:title)
-to_field 'title_sort', from_bibtex(:title)
-
-to_field 'author_person_full_display', from_bibtex(:author)
-to_field 'author_sort', from_bibtex(:author)
-
-to_field 'pub_year_isi', from_bibtex(:year)
-to_field 'pub_year_w_approx_isi', from_bibtex(:year)
-
-to_field 'editor_ssim', from_bibtex(:editor)
-
-to_field 'book_title_ssim', from_bibtex(:booktitle)
-
-to_field 'pub_display', lambda { |record, accumulator, _context|
-  accumulator << record.journal.to_s.presence if record.respond_to?(:journal)
-  accumulator << record.publisher.to_s.presence if record.respond_to?(:publisher)
-}
-
-to_field 'location_ssi', from_bibtex(:address)
-
-to_field 'university_ssim', from_bibtex(:school)
-
-to_field 'edition_ssm', from_bibtex(:edition)
-
-to_field 'series_ssi', from_bibtex(:series)
-
-to_field 'thesis_type_ssm', from_bibtex(:type)
-
-to_field 'volume_ssm', from_bibtex(:volume)
-
-to_field 'issue_ssm', from_bibtex(:issue)
-
-to_field 'pages_ssm', from_bibtex(:pages)
-
-to_field 'doi_ssim', from_bibtex(:doi)
-
-to_field 'general_notes_ssim', lambda { |record, accumulator, _context|
-  accumulator << record.annote.to_s.presence if record.respond_to?(:annote)
-}
-
+to_field 'id', extract_bibtex_id
+to_field 'bibtex_key_ss', extract_bibtex_key
+to_field 'ref_type_ssm', extract_bibtex_field(:ref_type)
+to_fields %w(title_display title_full_display title_uniform_search title_sort), extract_bibtex_field(:title)
+to_fields %w(author_person_full_display author_sort), extract_bibtex_field(:author)
+to_fields %w(pub_year_isi pub_year_w_approx_isi), extract_bibtex_field(:year)
+to_field 'editor_ssim', extract_bibtex_field(:editor)
+to_field 'book_title_ssim', extract_bibtex_field(:booktitle)
+to_field 'pub_display', extract_bibtex_publication
+to_field 'location_ssi', extract_bibtex_field(:address)
+to_field 'university_ssim', extract_bibtex_field(:school)
+to_field 'edition_ssm', extract_bibtex_field(:edition)
+to_field 'series_ssi', extract_bibtex_field(:series)
+to_field 'thesis_type_ssm', extract_bibtex_field(:type)
+to_field 'volume_ssm', extract_bibtex_field(:volume)
+to_field 'issue_ssm', extract_bibtex_field(:issue)
+to_field 'pages_ssm', extract_bibtex_field(:pages)
+to_field 'doi_ssim', extract_bibtex_field(:doi)
+to_field 'general_notes_ssim', extract_bibtex_field(:annote, split: '|', trim: true)
 to_field 'format_main_ssim', literal('Reference')
-
-# raw serialization of BibTeX::Entry
-to_field 'bibtex_ts', from_bibtex(:raw)
-
-# formatted BibTeX::Entry in Chicago style as HTML
-to_field 'formatted_bibliography_ts', lambda { |record, accumulator, _context|
-  html = Bibliography.new(record.to_s).to_html
-  doc = Nokogiri::HTML(html)
-  li = doc.at_css('ol li')
-  reference = li.children.to_html if li.present? # extract just the reference from <li>
-  accumulator << reference.to_s
-}
-
-# Druids are kept as tags (keywords) in the BibTeX::Entry
-to_field 'related_document_id_ssim', lambda { |record, accumulator, _context|
-  record.keywords.to_s.split(',').map(&:strip).each do |druid|
-    accumulator << druid if druid =~ Exhibits::Application.config.druid_regex
-  end
-}
+to_field 'bibtex_ts', extract_bibtex_raw
+to_field 'formatted_bibliography_ts', extract_bibtex_formatted_bibliography
+to_field 'related_document_id_ssim', extract_bibtex_related_document_ids

--- a/lib/traject/macros/bibtex.rb
+++ b/lib/traject/macros/bibtex.rb
@@ -1,3 +1,5 @@
+require_relative 'extraction'
+
 module Macros
   # BibTeX extraction macros
   module BibTeX
@@ -9,28 +11,77 @@ module Macros
       misc: 'Document'
     }.freeze
 
+    # we need to transform the key for a good id
+    def extract_bibtex_id
+      lambda do |record, accumulator, _context|
+        bibtex_id = record.key.to_s
+        accumulator << bibtex_id.gsub(%r{http:\/\/zotero.org\/groups\/\d*\/items\/}, '')
+      end
+    end
+
+    # `key` is always available (yet `provides?(:key)` is false)
+    def extract_bibtex_key
+      lambda do |record, accumulator, _context|
+        accumulator << record.key.to_s
+      end
+    end
+
+    # raw serialization of BibTeX::Entry
+    def extract_bibtex_raw
+      lambda do |record, accumulator, _context|
+        accumulator << record.to_s
+      end
+    end
+
+    def extract_bibtex_publication
+      lambda do |record, accumulator, _context|
+        %i(journal publisher).each do |key|
+          accumulator << record.send(key).to_s.presence if record.respond_to?(key)
+        end
+      end
+    end
+
+    # formatted BibTeX::Entry in Chicago style as HTML
+    def extract_bibtex_formatted_bibliography
+      lambda do |record, accumulator, _context|
+        html = Bibliography.new(record.to_s).to_html
+        doc = Nokogiri::HTML(html)
+        li = doc.at_css('ol li')
+        reference = li.children.to_html if li.present? # extract just the reference from <li>
+        accumulator << reference.to_s
+      end
+    end
+
+    # Druids are kept as tags (keywords) in the BibTeX::Entry
+    def extract_bibtex_related_document_ids
+      extract_bibtex_field(:keywords,
+                           split: ',',
+                           trim: true,
+                           match: Exhibits::Application.config.druid_regex)
+    end
+
     ##
     # Traject macro for converting BibTeX fields into Solr fields
     #
     # @param [Symbol] `key` the BibTeX field name
-    def from_bibtex(key) # rubocop: disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def extract_bibtex_field(key, options = {}) # rubocop: disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       # Note that `record` is a BibTeX::Entry object
       lambda do |record, accumulator, _context|
-        case key # BibTeX fields don't all follow the same rules, so handle them here
-        when :id # we need to transform the key for a good id
-          accumulator << record.key.to_s.gsub(%r{http:\/\/zotero.org\/groups\/\d*\/items\/}, '')
-        when :key # `key` is always available (yet `provides?(:key)` is false)
-          accumulator << record.key.to_s
+        case key.to_sym # BibTeX fields don't all follow the same rules, so handle them here
         when :type # conflates with BibTeX notion of type (`record.type`) rather than field "type"
           accumulator << record.fields[:type].to_s.presence if record.fields.include?(:type)
         when :ref_type # use record.type to get BibTeX type
           accumulator << BIBTEX_ZOTERO_MAPPING[record.type] if BIBTEX_ZOTERO_MAPPING.include?(record.type)
         when :year # built-in method in BibTeX::Entry
           accumulator << record.year
-        when :raw # serialization into BibTeX format
-          accumulator << record.to_s
         else # use the dynamically constructed BibTeX method to fetch the field rather than fetch/get
-          accumulator << record.send(key).to_s.presence if record.respond_to?(key)
+          if record.respond_to?(key.to_sym)
+            result = record.send(key.to_sym).to_s.presence
+            result = Macros::Extraction.apply_extraction_options(result, options)
+            Array.wrap(result).compact.each do |value|
+              accumulator << value
+            end
+          end
         end
       end
     end

--- a/lib/traject/macros/extraction.rb
+++ b/lib/traject/macros/extraction.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Macros
+  # Helpers for traject mappings & normalization for Parker, stolen from DLME
+  module Extraction
+    def self.apply_extraction_options(result, options = {})
+      TransformPipeline.new(options).transform(result)
+    end
+
+    # Pipeline for transforming extracted values into normalized values
+    class TransformPipeline
+      attr_reader :options
+
+      def append(values, append_string)
+        values.flat_map do |v|
+          "#{v}#{append_string}"
+        end
+      end
+
+      def default(values, default_value)
+        if values.present?
+          values
+        else
+          default_value
+        end
+      end
+
+      def initialize(options)
+        @options = options
+      end
+
+      def insert(values, insert_string)
+        values.flat_map do |v|
+          insert_string.gsub('%s', v)
+        end
+      end
+
+      def match(values, regex)
+        values.map.grep(regex)
+      end
+
+      def replace(values, options)
+        values.flat_map do |v|
+          v.gsub(options[0], options[1])
+        end
+      end
+
+      def split(*values, splitter)
+        values.flat_map do |v|
+          v.split(splitter)
+        end
+      end
+
+      def transform(values)
+        options.inject(values) { |memo, (step, params)| public_send(step, memo, params) }
+      end
+
+      def translation_map(values, maps)
+        translation_map = Traject::TranslationMap.new(*Array(maps))
+        # without overwriting (further) translation map, could add
+        # fuzzy match method here after pulling array out of TM
+        values = Array(values).map(&:downcase)
+        translation_map.translate_array values
+      end
+
+      def trim(values, _)
+        values.map(&:strip)
+      end
+    end
+  end
+end

--- a/lib/traject/macros/general.rb
+++ b/lib/traject/macros/general.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Macros
+  # General helpers for any traject mappings, stolen originally from DLME
+  module General
+    # only accumulate values if a condition is met
+    def conditional(condition, lambda)
+      lambda do |record, accumulator, context|
+        if condition.call(record, context)
+          lambda.call(record, accumulator, context)
+        end
+      end
+    end
+
+    # try a bunch of macros and short-circuit after one returns values
+    def first(*macros)
+      lambda do |record, accumulator, context|
+        macros.lazy.map do |lambda|
+          lambda.call(record, accumulator, context)
+        end.reject(&:blank?).first
+      end
+    end
+
+    def from_settings(field)
+      lambda do |_record, accumulator, context|
+        accumulator << context.settings.fetch(field)
+      end
+    end
+
+    # apply the same mapping to multiple fields
+    def to_fields(fields, mapping_method)
+      fields.each { |field| to_field field, mapping_method }
+    end
+
+    # construct a structured hash using values extracted using traject
+    def transform_values(context, hash)
+      hash.transform_values do |lambdas|
+        accumulator = []
+        Array(lambdas).each do |lambda|
+          lambda.call(context.source_record, accumulator, context)
+        end
+        accumulator
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #671 and it does a few things:

1. Migrates all extraction-related code from bib_config into BibTeX macros
2. Reuses some common macros used by DLME (`Macros::General` and `Extraction`)
3. Fixes bug where `\textbackslash` wasn't being properly removed during parsing
4. Consolidates application logic into `Bibliography` model and uses it for `BibReader`

Some benchmarks from my laptop instance:
```
2017-10-09T15:45:36-07:00  INFO Reading from /Users/drh/Local/ParkerProductionBibliography.bib
2017-10-09T15:45:40-07:00  INFO    Indexer with 5 processing threads, reader: BibReader and writer: Traject::DebugWriter
2017-10-09T15:51:10-07:00  INFO finished Indexer#process: 6165 records in 333.451 seconds; 18.5 records/second overall.
```

cc: @cmh2166