### PR TITLE
Updates Spotlight to enable delete email fixes #704

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight
-  revision: 6a6f7ecf3a5e0fc8eca2980e77beef7db4cd9f07
+  revision: f5c3e65b204fd0f30fab4539d99273507ded3ab3
   branch: master
   specs:
     blacklight-spotlight (1.0.0)
@@ -90,7 +90,7 @@ GEM
       io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.3.0)
-    autoprefixer-rails (7.1.4.1)
+    autoprefixer-rails (7.1.5)
       execjs
     babel-source (5.8.35)
     babel-transpiler (0.7.0)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,8 @@ feature_flags:
 traject:
   processing_thread_pool: 1
 iiif_dnd_base_url: https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?%{query}
+action_mailer:
+  default_options:
+    from: "example-team@example.com"
+  default_url_options:
+    host: "example.com"


### PR DESCRIPTION
0cc9e4405f6d6097fc4fcc01a497aabb4964be70 was needed since the new `ContactEmail` factory can't validate itself.