### PR TITLE
configure sidekiq processes on stage to better match prod

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -6,4 +6,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 
 set :sidekiq_role, :background
-set :sidekiq_processes, 2
+set :sidekiq_processes, 6 # prod has 10 but stage box has more limited memory


### PR DESCRIPTION
This PR bumps up the sidekiq processes on stage to 6 to better match what's in production. The stage vs prod boxes have different memory footprints (16MB vs 24MB)