### PR TITLE
use BibTeX prefix for Traject pipeline throughout

### DIFF
--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'bib_reader'
+require_relative 'bibtex_reader'
 require_relative 'macros/bibtex'
 require_relative 'macros/general'
 
@@ -10,7 +10,7 @@ extend Macros::BibTeX
 extend Macros::General
 
 settings do
-  provide 'reader_class_name', 'BibReader'
+  provide 'reader_class_name', 'BibTeXReader'
   provide 'processing_thread_pool', ::Settings.traject.processing_thread_pool || 1
 end
 

--- a/lib/traject/bibtex_reader.rb
+++ b/lib/traject/bibtex_reader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Reads in BibTex records for traject
-class BibReader
+class BibTeXReader
   # @param input_stream [File]
   # @param settings [Traject::Indexer::Settings]
   def initialize(input_stream, settings)


### PR DESCRIPTION
This PR just keeps our file/class naming consistent for the BibTeX Traject pipeline code.