### PR TITLE
Support multiple notes per bibliography resource

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -180,7 +180,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'ref_type_ssm', label: 'Reference Type'
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
-    config.add_index_field 'general_notes_ssim', label: 'Notes'
+    config.add_index_field 'general_notes_ssim', label: 'Notes', helper_method: :paragraph_wrap
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,4 +22,9 @@ module ApplicationHelper
       image_tag 'iiif-drag-n-drop.svg', width: '40px', alt: 'IIIF Drag-n-drop'
     end
   end
+
+  def paragraph_wrap(options = {})
+    return if options[:value].blank?
+    safe_join(options[:value].map { |value| content_tag('p', value) })
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,12 @@ module ApplicationHelper
 
   def paragraph_wrap(options = {})
     return if options[:value].blank?
-    safe_join(options[:value].map { |value| content_tag('p', value) })
+    safe_join(options[:value].map do |value|
+      if value.start_with?('<p>')
+        value.html_safe
+      else
+        content_tag('p', value.html_safe)
+      end
+    end)
   end
 end

--- a/app/models/bibliography.rb
+++ b/app/models/bibliography.rb
@@ -42,6 +42,7 @@ class Bibliography
     # BibTeX.parse `filter: latex` doesn't handle these cases correctly
     bibtex_data.gsub!(/\\textbackslash/i, '')
     bibtex_data.gsub!(/\\textit/i, '')
+    bibtex_data.gsub!(/\\textbar/i, '|')
 
     bibtex_data
   end

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       end
 
       it 'has annotations' do
+        expect(document['general_notes_ssim'].first).to eq 'ELB'
         expect(document['general_notes_ssim'].last).to match(/^The following values/)
       end
     end
@@ -122,6 +123,11 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
 
       it 'has formatted bibliography in HTML' do
         expect(document.formatted_bibliography).to match(/^de Azevedo, R\./)
+      end
+
+      it 'has annotations with commas' do
+        expect(document['general_notes_ssim'][1]).to match(/^CCC MS 470/)
+        expect(document['general_notes_ssim'].last).to match(/^The following values/)
       end
     end
 

--- a/spec/fixtures/bibliography/article.bib
+++ b/spec/fixtures/bibliography/article.bib
@@ -8,6 +8,5 @@
 	year = {2004},
 	keywords = {gs233db8425, gk885tn1705},
 	pages = {181--201},
-	annote = { ELB},
-	annote = {The following values have no corresponding Zotero field:custom1: 63}
+	annote = { ELB{\textbar} The following values have no corresponding Zotero field:custom1: 63}
 }

--- a/spec/fixtures/bibliography/book.bib
+++ b/spec/fixtures/bibliography/book.bib
@@ -8,7 +8,5 @@
 	edition = {1st},
 	year = {1962},
 	keywords = {sg012cr8689},
-	annote = { KAW},
-	annote = {CCC MS 470 [p. 9, and referred to (without MS number) throughout]reproductions from CCC MS 470, ff. 125-146, in the appendix},
-	annote = {The following values have no corresponding Zotero field:custom1: 23}
+	annote = { KAW{\textbar} CCC MS 470 [p. 9, and referred to (without MS number) throughout]reproductions from CCC MS 470, ff. 125-146, in the appendix{\textbar} The following values have no corresponding Zotero field:custom1: 23}
 }

--- a/spec/fixtures/bibliography/misc.bib
+++ b/spec/fixtures/bibliography/misc.bib
@@ -6,7 +6,5 @@
 	year = {2000},
   publisher = {My Publisher},
 	keywords = {wz353pg0755},
-	annote = { ELB},
-	annote = {Pamphlet Box 54.6},
-	annote = {The following values have no corresponding Zotero field:pub-location: Toronto}
+	annote = { ELB{\textbar} Pamphlet Box 54.{\textbar} The following values have no corresponding Zotero field:pub-location: Toronto}
 }

--- a/spec/fixtures/bibliography/phdthesis.bib
+++ b/spec/fixtures/bibliography/phdthesis.bib
@@ -7,6 +7,5 @@
 	author = {Wilson, E. A.},
 	year = {1968},
 	keywords = {dd998pq6752},
-	annote = { NJC},
-	annote = {The following values have no corresponding Zotero field:volume: B.Litt.}
+	annote = { NJC{\textbar} The following values have no corresponding Zotero field:volume: B.Litt.}
 }

--- a/spec/fixtures/bibliography/texifiedtitle.bib
+++ b/spec/fixtures/bibliography/texifiedtitle.bib
@@ -9,6 +9,5 @@
 	year = {2003},
 	keywords = {qd527zm3425},
 	pages = {493--510},
-	annote = { ELB},
-	annote = {The following values have no corresponding Zotero field:custom1: 58}
+	annote = { ELB{\textbar} The following values have no corresponding Zotero field:custom1: 58}
 }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,4 +16,10 @@ describe ApplicationHelper, type: :helper do
       expect(helper.document_collection_title(value: ['foo-|-bar', 'baz-|-bop'])).to eq 'bar and bop'
     end
   end
+
+  describe '#paragraph_wrap' do
+    it 'separates multivalued fields into paragraphs' do
+      expect(helper.paragraph_wrap(value: %w(a b))).to eq '<p>a</p><p>b</p>'
+    end
+  end
 end


### PR DESCRIPTION
Closes #685 
Design #605 

This PR:
- updates our Zotero --> BibTeX --> Traject --> Solr pipeline so that all notes are captured
- updates all fixtures with `annote` values (multiple notes are separated by `\textbar` (`|` in LaTeX land)
- adds paragraph separators to the notes (pending discussion below)

## Todo
- [x] [ Zotero --> BibTeX translator](https://github.com/camillevilla/bibtex-translator) that separates notes with `|` character
  - [ ] PR in zotero/translators
  - [x] Add translator to team Google drive
- [x] BibTeX --> Traject
- [x] update fixtures `annote` section
- [x] Blacklight config / helper for presenting notes on separate lines in show page (1: `<ul>` ideal, 2: `<p>` ok #605)
- [x] bib resource integration tests
- [x] unit test

## Questions:

- [x] How do existing exhibits use the `general_notes_ssim` field? Is this too much top-down control over how notes are displayed? 

- [x] How can I refactor this and make it more Blacklight-ish? 

## Before 
Before [6d38407](https://github.com/sul-dlss/exhibits/pull/715/commits/6d384075ab7c3a41968c05c05f8ce629a1d09fe0) we were only captured one note per bibliography resource
![single_note](https://user-images.githubusercontent.com/5402927/31468661-9743fac2-ae93-11e7-800e-8c34413510a0.png)

Before [18696d1](https://github.com/sul-dlss/exhibits/pull/715/commits/18696d1639063636d9a07b905db4f4b0479e8b27) we had several notes displayed inline, separated by with comma + and separators
![inline_notes](https://user-images.githubusercontent.com/5402927/31468827-644e4482-ae94-11e7-9a94-97f50c7fca65.png)


## After
![paragraph-separated-notes](https://user-images.githubusercontent.com/5402927/31414825-965333ea-add4-11e7-914b-4f34c9f03933.png)
