### PR TITLE
permit up to 1000 hits for JSON API

### DIFF
--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SearchBuilder do
+  subject(:builder) { described_class.new(scope).with(blacklight_params) }
+
+  let(:exhibit) { create(:exhibit) }
+  let(:scope) { instance_double('scope', blacklight_config: blacklight_config, current_exhibit: exhibit) }
+  let(:rows) { 999 }
+  let(:blacklight_params) do
+    {
+      format: 'json',
+      rows: rows
+    }.with_indifferent_access
+  end
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.default_per_page = 99
+      config.max_per_page_for_api = 999
+    end
+  end
+
+  before :all do
+    # remove Advanced Search plugin processing due to its required configuration
+    described_class.default_processor_chain.delete(:add_advanced_parse_q_to_solr)
+    described_class.default_processor_chain.delete(:add_advanced_search_to_solr)
+  end
+
+  after :all do
+    # restore
+    described_class.default_processor_chain << :add_advanced_parse_q_to_solr
+    described_class.default_processor_chain << :add_advanced_search_to_solr
+  end
+
+  it 'will allow up to max per page' do
+    expect(builder.to_hash).to include(rows: 999)
+  end
+
+  context 'JSON API is over limit' do
+    let(:rows) { 999_999 }
+
+    it 'cannot exceed max per page' do
+      expect(builder.to_hash).to include(rows: 999)
+    end
+  end
+
+  context 'JSON API configuration is omitted' do
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.configure do |config|
+        config.default_per_page = 99
+      end
+    end
+
+    let(:rows) { 999_999 }
+
+    it 'cannot exceed max per page' do
+      expect(builder.to_hash).to include(rows: 1_000)
+    end
+  end
+
+  context 'JSON API omits limit' do
+    let(:blacklight_params) do
+      {
+        format: 'json'
+      }.with_indifferent_access
+    end
+
+    it 'will become config.default_per_page' do
+      expect(builder.to_hash).to include(rows: 99)
+    end
+  end
+
+  context 'non-JSON API is over limit' do
+    let(:blacklight_params) { { q: 'my query', rows: rows }.with_indifferent_access } # omit format
+
+    it 'cannot exceed config.max_per_page' do
+      expect(builder.to_hash).to include(rows: 100)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #700. It overrides `SearchBuilder#rows` to permit higher max_per_page values for the JSON API.  

Note that I had problems getting the SearchBuilder specs to work with the advanced search configuration so I have a solution for it but it's not ideal.

Note to try this out, load the entire Parker bibliography and then visit http://localhost:3000/test/catalog/mk707wk3350. The full bibliography for that manuscript (200+ references) should show up.

### After
![long-bibliography mov](https://user-images.githubusercontent.com/1861171/31415389-1bd883d2-add8-11e7-9f2b-70926bf67904.gif)
