### PR TITLE
do not save search in history if JSON API

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -267,4 +267,9 @@ class CatalogController < ApplicationController
     config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'
     config.add_sort_field 'title_sort asc, pub_year_isi desc', label: 'title'
   end
+
+  # JSON API queries should not trigger new search histories
+  def start_new_search_session?
+    super && params[:format] != 'json'
+  end
 end

--- a/spec/features/search_histories_spec.rb
+++ b/spec/features/search_histories_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Search histories', type: :feature do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+
+  before do
+    allow(Search).to receive(:create).and_call_original
+
+    # create a search in the history
+    visit spotlight.search_exhibit_catalog_path(exhibit_id: exhibit.slug, q: 'article')
+
+    # do a JSON or non-JSON query to see whether it's also added to the history
+    visit spotlight.search_exhibit_catalog_path(exhibit_id: exhibit.slug,
+                                                q: 'book',
+                                                format: format)
+  end
+
+  context 'when format is JSON' do
+    let(:format) { 'json' }
+
+    scenario 'second query is not added to search history' do
+      expect(Search).to have_received(:create).once
+    end
+  end
+
+  context 'when format is non-JSON' do
+    let(:format) { 'html' }
+
+    scenario 'second query is added to search history' do
+      expect(Search).to have_received(:create).twice
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #701. It overrides the `start_new_search_session?` method for any JSON API search request and sets it to `false` so that the `find_search_session` in Blacklight returns `nil` and thus the `Search` object never gets created.

Works for any JSON API request, so the heatmaps view also works.

### After 

The "Back to Search" and "Search Results" actions have the expected behavior. The bibliography on the manuscript show page uses the JSON API asynchonously.

![search_history mov](https://user-images.githubusercontent.com/1861171/31466217-51525cbe-ae8b-11e7-8d8a-90633916a609.gif)
