### PR TITLE
Remove the mirador configuration that prevents the Add Slot control…

### DIFF
--- a/app/views/mirador/index.html.erb
+++ b/app/views/mirador/index.html.erb
@@ -21,7 +21,6 @@
     "windowObjects": [
       {
         "loadedManifest": @manifest,
-        "displayLayout": false,
         "bottomPanelVisible": false,
         "annotationCreation": false,
       }


### PR DESCRIPTION
… from appearing.

Closes #677 

<img width="1200" alt="mirador-layout-options" src="https://user-images.githubusercontent.com/96776/31520232-10012a7c-af5a-11e7-81cb-44308ce961b5.png">
