### PR TITLE
Remove media-query to help results thumbnail alignment.

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -81,10 +81,6 @@
       height: 0;
       margin: 0;
       padding: 0;
-
-      @media (max-width: $screen-sm-min) {
-        height: auto;
-      }
     }
   }
 


### PR DESCRIPTION
Nice catch @camillevilla!  Does this look better?

## Before
<img width="520" alt="before" src="https://user-images.githubusercontent.com/96776/31522699-145c3134-af64-11e7-9b60-0e0b80836d19.png">

## After
<img width="522" alt="after" src="https://user-images.githubusercontent.com/96776/31522700-1474b39e-af64-11e7-9462-1eaa337a20ee.png">
