### PR TITLE
refine multiple notes styling

### DIFF
--- a/app/assets/stylesheets/modules/bibliography.scss
+++ b/app/assets/stylesheets/modules/bibliography.scss
@@ -27,3 +27,7 @@
 .btn-view-on-zotero {
   margin-right: 10px;
 }
+
+.general-notes {
+  padding-left: 15px;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -180,7 +180,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'ref_type_ssm', label: 'Reference Type'
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
-    config.add_index_field 'general_notes_ssim', label: 'Notes', helper_method: :paragraph_wrap
+    config.add_index_field 'general_notes_ssim', label: 'Notes', helper_method: :notes_wrap
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,14 +23,12 @@ module ApplicationHelper
     end
   end
 
-  def paragraph_wrap(options = {})
+  def notes_wrap(options = {})
     return if options[:value].blank?
-    safe_join(options[:value].map do |value|
-      if value.start_with?('<p>')
-        value.html_safe
-      else
-        content_tag('p', value.html_safe)
-      end
-    end)
+    content_tag('ul', class: 'general-notes') do
+      safe_join(options[:value].collect do |note|
+        content_tag('li', note.html_safe)
+      end)
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,9 +17,11 @@ describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#paragraph_wrap' do
-    it 'separates multivalued fields into paragraphs' do
-      expect(helper.paragraph_wrap(value: %w(a b))).to eq '<p>a</p><p>b</p>'
+  describe '#notes_wrap' do
+    let(:output) { '<ul class="general-notes"><li>a</li><li><p>b</p><p>c</p></li><li>d</li></ul>' }
+
+    it 'permits embedded HTML and handles multivalued notes as an unordered list' do
+      expect(helper.notes_wrap(value: %w(a <p>b</p><p>c</p> d))).to eq output
     end
   end
 end


### PR DESCRIPTION
Closes #742 

- [x] replace `<p>` separators with a `<ul>` 
- [x] differentiating styling suggestions from @ggeisler 

## Before
<img width="659" alt="before_full_note" src="https://user-images.githubusercontent.com/5402927/31568290-5d52104c-b028-11e7-87f1-ffe578db87c6.png">

## After
<img width="656" alt="first_iteration_full_note" src="https://user-images.githubusercontent.com/5402927/31568289-5d39177c-b028-11e7-9fcc-2136692bd929.png"> #