### PR TITLE
add tableOfContents to MODS indexing

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -144,6 +144,7 @@ class CatalogController < ApplicationController
 
     config.add_index_field 'title_full_display', label: 'Title'
     config.add_index_field 'title_variant_display', label: 'Alternate Title'
+    config.add_index_field 'text_titles_ssim', label: 'Table of Contents'
     config.add_index_field 'author_person_full_display', label: 'Author' # includes Collectors
     config.add_index_field 'author_no_collector_ssim', label: 'Author (no Collectors)'
     config.add_index_field 'editor_ssim', label: 'Editor'

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -281,12 +281,19 @@ module Spotlight::Dor
     concerning :ParkerIndexing do
       included do
         before_index :add_manuscript_number
+        before_index :add_text_titles
       end
 
       def add_manuscript_number(sdb, solr_doc)
         manuscript_number = sdb.smods_rec.location.shelfLocator.try(:text)
         return if manuscript_number.blank?
         insert_field solr_doc, 'manuscript_number', manuscript_number, :symbol
+      end
+
+      def add_text_titles(sdb, solr_doc)
+        text_titles = sdb.smods_rec.tableOfContents.try(:content)
+        return if text_titles.blank?
+        insert_field solr_doc, 'text_titles', text_titles, :symbol # this is a _ssim field
       end
     end
 

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -770,5 +770,25 @@ describe Spotlight::Dor::Indexer do
         end
       end
     end # add_manuscript_number
+
+    context '#add_text_titles' do
+      before do
+        subject.send(:add_text_titles, resource, solr_doc)
+      end
+
+      it 'handles missing metadata' do
+        expect(solr_doc['text_titles_ssim']).to be_blank
+      end
+
+      context 'with metadata' do
+        let(:modsbody) do
+          '<tableOfContents displayLabel="Contents">Homiliae XL in euangelia</tableOfContents>'
+        end
+
+        it 'extracts the titles' do
+          expect(solr_doc['text_titles_ssim']).to eq(['Homiliae XL in euangelia'])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is connected to #723. It indexes the MODS `tableOfContents` into `text_titles_ssim`.