### PR TITLE
add Annotation data model

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+##
+# Model for a IIIF Annotation
+class Annotation
+  attr_reader :id, :text, :target, :motivation
+  delegate :content, :language, :format, to: :text
+  delegate :xywh, :canvas, :druid, to: :target
+
+  # @param [String] `id`, `text`
+  # @param [Annotation::Target] `target`
+  # @param [Hash] `options`
+  # @option [String] `:language`, `:motivation`
+  def initialize(id, text, target, options = {})
+    @id = id
+    @text = Text.new(text, options[:language] || 'English')
+    @target = target
+    @motivation = options[:motivation] || 'sc:painting'
+  end
+
+  def type
+    'oa:Annotation'
+  end
+
+  def on
+    "#{canvas}#xywh=#{xywh}"
+  end
+
+  # Simple model for the text of an annotation
+  class Text
+    attr_accessor :content, :language, :format
+    def initialize(content, language, format = 'text/plain')
+      @content = content
+      @language = language
+      @format = format
+    end
+  end
+
+  # Simple model for the target of an annotation
+  class Target
+    attr_accessor :xywh, :canvas, :druid
+    def initialize(xywh, canvas, druid)
+      @xywh = xywh
+      @canvas = canvas
+      @druid = druid
+    end
+  end
+end

--- a/app/models/concerns/annotation_concern.rb
+++ b/app/models/concerns/annotation_concern.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+##
+# A concern to be mixed into SolrDocument for accessing a document's
+# annotation
+module AnnotationConcern
+  def annotation?
+    first('format_main_ssim') == 'Annotation'
+  end
+
+  # @return [Annotation]
+  def annotation
+    return unless annotation?
+    Annotation.new(
+      id,
+      first('annotation_tesim'),
+      Annotation::Target.new(
+        first('xywh_ssim'),
+        first('canvas_ssim'),
+        first('related_document_id_ssim')
+      ),
+      language: first('language'),
+      motivation: first('motivation_ssim')
+    )
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -13,6 +13,8 @@ class SolrDocument
 
   include ManifestConcern
 
+  include AnnotationConcern
+
   # self.unique_key = 'id'
 
   # Email uses the semantic field mappings below to generate the body of an email.

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Annotation do
+  subject(:annotation) { described_class.new(id, text, target, options) }
+
+  let(:id) { 'anno123' }
+  let(:text) { 'this is my annotation' }
+  let(:target) { Annotation::Target.new(xywh, canvas, druid) }
+  let(:options) { { language: 'Latin', motivation: 'sc:commenting' } }
+  let(:xywh) { '10,20,30,40' }
+  let(:canvas) { 'canvas456' }
+  let(:druid) { 'aa111bb2222' }
+
+  it '#id' do
+    expect(annotation.id).to eq 'anno123'
+  end
+
+  it '#text' do
+    expect(annotation.text).to be_an(Annotation::Text)
+    expect(annotation.content).to eq 'this is my annotation'
+    expect(annotation.language).to eq 'Latin'
+    expect(annotation.format).to eq 'text/plain'
+  end
+
+  it '#target' do
+    expect(annotation.target).to be_an(Annotation::Target)
+    expect(annotation.xywh).to eq '10,20,30,40'
+    expect(annotation.canvas).to eq 'canvas456'
+    expect(annotation.druid).to eq 'aa111bb2222'
+  end
+
+  it '#motivation' do
+    expect(annotation.motivation).to eq 'sc:commenting'
+  end
+
+  it '#type' do
+    expect(annotation.type).to eq 'oa:Annotation'
+  end
+
+  it '#on' do
+    expect(annotation.on).to eq 'canvas456#xywh=10,20,30,40'
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -43,4 +43,43 @@ describe SolrDocument do
       end
     end
   end
+
+  describe '#annotation' do
+    subject(:annotation) do
+      described_class.new(
+        id: 'anno123',
+        'format_main_ssim' => %w(Annotation),
+        'annotation_tesim' => %w(This\ is\ my\ annotation),
+        'xywh_ssim' => %w(10,20,30,40),
+        'canvas_ssim' => %w(canvas456),
+        'related_document_id_ssim' => %w(aa111bb2222),
+        'language' => %w(Latin),
+        'motivation_ssim' => %w(sc:commenting)
+      ).annotation
+    end
+
+    it 'creates an instance from Solr document' do
+      expect(annotation).to be_an Annotation
+      expect(annotation.id).to eq 'anno123'
+    end
+
+    it 'has text content' do
+      expect(annotation.text).to be_an Annotation::Text
+      expect(annotation.content).to eq 'This is my annotation'
+      expect(annotation.language).to eq 'Latin'
+      expect(annotation.format).to eq 'text/plain'
+    end
+
+    it 'has target content' do
+      expect(annotation.target).to be_an Annotation::Target
+      expect(annotation.xywh).to eq '10,20,30,40'
+      expect(annotation.canvas).to eq 'canvas456'
+      expect(annotation.druid).to eq 'aa111bb2222'
+      expect(annotation.on).to eq 'canvas456#xywh=10,20,30,40'
+    end
+
+    it 'has misc content' do
+      expect(annotation.motivation).to eq 'sc:commenting'
+    end
+  end
 end


### PR DESCRIPTION
This PR closes #754 . It creates an Annotation class for model use purposes, and then an AnnotationConcern for the SolrDocument where you can use `.annotation?` and `.annotation` to get the Annotation object. The specs are both for the model class and the SolrDocument concern.