### PR TITLE
Bugfix: only add IIIF logos to SDR objects with manifests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ AllCops:
 Rails:
   Enabled: true
 
+Metrics/BlockLength:
+  Exclude:
+  - 'spec/models/spotlight/dor/indexer_spec.rb'
+
 Metrics/LineLength:
   Max: 120
   Exclude:

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -40,7 +40,9 @@ module Spotlight::Dor
     private
 
     def add_iiif_manifest_url(sdb, solr_doc)
-      solr_doc['iiif_manifest_url_ssi'] = iiif_manifest_url(sdb.bare_druid)
+      url = iiif_manifest_url(sdb.bare_druid)
+      return unless Faraday.head(url).status == 200
+      solr_doc['iiif_manifest_url_ssi'] = url
     end
 
     def iiif_manifest_url(bare_druid)


### PR DESCRIPTION
Fixes #745 

This PR:
- fixes a bug that was adding IIIF drag-n-drop logos to invalid SDR objects (e.g. a dataset, an email archive)
- adds a check to our SDR indexing pipeline: is the generated IIIF manifest link valid? (i.e. does the URL return a 200 status code)
- removes Rubocop BlockLength limits from our `dor/indexer_spec.rb`

## Test druids
### no manifest
py883nd2578
rj585xk6315

### existing manifest
sg012cr8689

note: the screenshots below are made up of three separate, cropped images 
## Before
![data_before](https://user-images.githubusercontent.com/5402927/31744990-e5872e8e-b415-11e7-9d7d-46e005557e6b.png)
![email_before](https://user-images.githubusercontent.com/5402927/31744989-e56f7064-b415-11e7-9978-5b4c01419483.png)
![valid iiif object before](https://user-images.githubusercontent.com/5402927/31744988-e552df30-b415-11e7-8696-ecdff0a91565.png)

## After
![dataset_after](https://user-images.githubusercontent.com/5402927/31744249-f2ca2874-b412-11e7-85d2-a19bf7fd6d70.png)
![email_after](https://user-images.githubusercontent.com/5402927/31744248-f2b516a0-b412-11e7-8d35-95288558273d.png)
![valid iiif object](https://user-images.githubusercontent.com/5402927/31744270-0a493db4-b413-11e7-92b9-f60325d529bf.png)
