### PR TITLE
Add missing migration from Spotlight that migrates sidecar taggings…

### DIFF
--- a/db/migrate/20171017223044_migrate_tags_to_sidecars.spotlight.rb
+++ b/db/migrate/20171017223044_migrate_tags_to_sidecars.spotlight.rb
@@ -1,0 +1,18 @@
+# This migration comes from spotlight (originally 20170803152134)
+class MigrateTagsToSidecars < ActiveRecord::Migration[5.0]
+  def up
+    Spotlight::SolrDocumentSidecar.reset_column_information
+    ActsAsTaggableOn::Tagging.reset_column_information
+
+    ActsAsTaggableOn::Tagging.where(taggable_type: 'SolrDocument', tagger_type: 'Spotlight::Exhibit').find_each do |e|
+      sidecar = Spotlight::SolrDocumentSidecar.find_or_create_by(document_id: e.taggable_id, document_type: 'SolrDocument', exhibit_id: e.tagger_id)
+      e.update(taggable: sidecar)
+    end
+  end
+  
+  def down
+    ActsAsTaggableOn::Tagging.where(taggable_type: 'Spotlight::SolrDocumentSidecar').find_each do |e|
+      e.update(taggable: e.taggable.document)
+    end
+  end
+end


### PR DESCRIPTION
… from SolrDocument id to Sidecar (AR) id.

Fixes #753 

I haven't tested this fix out yet, so somebody should deploy this to stage and re-index the harrison exhibit to see if the traggings remain after re-index.