### PR TITLE
add incipit to MODS indexing

### DIFF
--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -284,6 +284,7 @@ module Spotlight::Dor
       included do
         before_index :add_manuscript_number
         before_index :add_text_titles
+        before_index :add_incipit
       end
 
       def add_manuscript_number(sdb, solr_doc)
@@ -297,6 +298,22 @@ module Spotlight::Dor
         return if text_titles.blank?
         insert_field solr_doc, 'text_titles', text_titles, :symbol # this is a _ssim field
       end
+
+      def add_incipit(sdb, solr_doc)
+        incipit = parse_incipit(sdb)
+        return if incipit.blank?
+        insert_field solr_doc, 'incipit', incipit, :symbol # this is a _ssim field
+      end
+
+      def parse_incipit(sdb)
+        sdb.smods_rec.related_item.each do |item|
+          item.note.each do |note|
+            return note.text.strip if note.attr('type') == 'incipit'
+          end
+        end
+        nil
+      end
+      private :parse_incipit
     end
 
     def insert_field(solr_doc, field, values, *args)

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -813,5 +813,34 @@ describe Spotlight::Dor::Indexer do
         end
       end
     end
+
+    context '#add_incipit' do
+      before do
+        subject.send(:add_incipit, resource, solr_doc)
+      end
+
+      it 'handles missing metadata' do
+        expect(solr_doc['incipit_ssim']).to be_blank
+      end
+
+      context 'with metadata' do
+        let(:modsbody) do # from cf386wt1778
+          <<-EOF
+          <relatedItem type="something">
+            <note/>
+          </relatedItem>
+          <relatedItem type="constituent">
+            <note displayLabel="Incipit" type="incipit">
+              In illo tempore maria magdalene et maria iacobi et solomae
+            </note>
+          </relatedItem>
+          EOF
+        end
+
+        it 'extracts the incipit' do
+          expect(solr_doc['incipit_ssim']).to eq(['In illo tempore maria magdalene et maria iacobi et solomae'])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is connected to #725. It adds `incipit_ssim` to the index.