### PR TITLE
Adds fielded search for Parker specific fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -185,6 +185,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
     # Fields specific to Parker Exhibit
     config.add_index_field 'incipit_tesim', label: 'Incipit'
+    config.add_index_field 'text_titles_tesim', label: 'Text title'
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #
@@ -278,6 +279,16 @@ class CatalogController < ApplicationController
         pf: 'incipit_tesim',
         pf3: 'incipit_tesim',
         pf2: 'incipit_tesim'
+      }
+    end
+
+    config.add_search_field('text_title') do |field|
+      field.label = 'Text title'
+      field.solr_local_parameters = {
+        qf: 'text_titles_tesim',
+        pf: 'text_titles_tesim',
+        pf3: 'text_titles_tesim',
+        pf2: 'text_titles_tesim'
       }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -186,6 +186,7 @@ class CatalogController < ApplicationController
     # Fields specific to Parker Exhibit
     config.add_index_field 'incipit_tesim', label: 'Incipit'
     config.add_index_field 'text_titles_tesim', label: 'Text title'
+    config.add_index_field 'manuscript_titles_tesim', label: 'Manuscript title', helper_method: :manuscript_title
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #
@@ -289,6 +290,16 @@ class CatalogController < ApplicationController
         pf: 'text_titles_tesim',
         pf3: 'text_titles_tesim',
         pf2: 'text_titles_tesim'
+      }
+    end
+
+    config.add_search_field('manuscript_title') do |field|
+      field.label = 'Manuscript title'
+      field.solr_local_parameters = {
+        qf: 'manuscript_titles_tesim',
+        pf: 'manuscript_titles_tesim',
+        pf3: 'manuscript_titles_tesim',
+        pf2: 'manuscript_titles_tesim'
       }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -258,6 +258,17 @@ class CatalogController < ApplicationController
         pf2: '$pf2_full_text'
       }
     end
+
+    config.add_search_field('table_of_contents') do |field|
+      field.label = 'Table of contents'
+      field.solr_local_parameters = {
+        qf: '$qf_toc_search',
+        pf: '$pf_toc_search',
+        pf3: '$pf3_toc_search',
+        pf2: '$pf2_toc_search'
+      }
+    end
+
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -183,6 +183,8 @@ class CatalogController < ApplicationController
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
     config.add_index_field 'general_notes_ssim', label: 'Notes', helper_method: :notes_wrap
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
+    # Fields specific to Parker Exhibit
+    config.add_index_field 'incipit_tesim', label: 'Incipit'
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,6 +272,7 @@ class CatalogController < ApplicationController
         pf3: '$pf3_toc_search',
         pf2: '$pf2_toc_search'
       }
+      field.enabled = false
     end
 
     config.add_search_field('incipit') do |field|
@@ -282,6 +283,7 @@ class CatalogController < ApplicationController
         pf3: 'incipit_tesim',
         pf2: 'incipit_tesim'
       }
+      field.enabled = false
     end
 
     config.add_search_field('text_title') do |field|
@@ -292,6 +294,7 @@ class CatalogController < ApplicationController
         pf3: 'text_titles_tesim',
         pf2: 'text_titles_tesim'
       }
+      field.enabled = false
     end
 
     config.add_search_field('manuscript_title') do |field|
@@ -302,6 +305,7 @@ class CatalogController < ApplicationController
         pf3: 'manuscript_titles_tesim',
         pf2: 'manuscript_titles_tesim'
       }
+      field.enabled = false
     end
 
     config.add_search_field('manuscript_number') do |field|
@@ -312,6 +316,7 @@ class CatalogController < ApplicationController
         pf3: 'manuscript_number_tesim',
         pf2: 'manuscript_number_tesim'
       }
+      field.enabled = false
     end
 
     # "sort results by" select (pulldown)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -269,6 +269,16 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field('incipit') do |field|
+      field.label = 'Incipit'
+      field.solr_local_parameters = {
+        qf: 'incipit_tesim',
+        pf: 'incipit_tesim',
+        pf3: 'incipit_tesim',
+        pf2: 'incipit_tesim'
+      }
+    end
+
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -187,6 +187,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'incipit_tesim', label: 'Incipit'
     config.add_index_field 'text_titles_tesim', label: 'Text title'
     config.add_index_field 'manuscript_titles_tesim', label: 'Manuscript title', helper_method: :manuscript_title
+    config.add_index_field 'manuscript_number_tesim', label: 'Manuscript number'
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #
@@ -300,6 +301,16 @@ class CatalogController < ApplicationController
         pf: 'manuscript_titles_tesim',
         pf3: 'manuscript_titles_tesim',
         pf2: 'manuscript_titles_tesim'
+      }
+    end
+
+    config.add_search_field('manuscript_number') do |field|
+      field.label = 'Manuscript number'
+      field.solr_local_parameters = {
+        qf: 'manuscript_number_tesim',
+        pf: 'manuscript_number_tesim',
+        pf3: 'manuscript_number_tesim',
+        pf2: 'manuscript_number_tesim'
       }
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,11 @@ module ApplicationHelper
       end)
     end
   end
+
+  def manuscript_title(options = {})
+    return if options[:value].blank?
+    safe_join(options[:value].collect do |title|
+      title.split('-|-').join(' - ')
+    end, ',')
+  end
 end

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -305,7 +305,7 @@ module Spotlight::Dor
       def add_manuscript_titles(sdb, solr_doc)
         manuscript_titles = parse_manuscript_titles(sdb)
         return if manuscript_titles.blank?
-        insert_field solr_doc, 'manuscript_titles', manuscript_titles, :symbol # this is a _ssim field
+        insert_field solr_doc, 'manuscript_titles', manuscript_titles, :stored_searchable # this is a _tesim field
       end
 
       def add_text_titles(sdb, solr_doc)

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -317,7 +317,7 @@ module Spotlight::Dor
       def add_incipit(sdb, solr_doc)
         incipit = parse_incipit(sdb)
         return if incipit.blank?
-        insert_field solr_doc, 'incipit', incipit, :symbol # this is a _ssim field
+        insert_field solr_doc, 'incipit', incipit, :stored_searchable # this is a _tesim field
       end
 
       # parse titleInfo[type="alternative"]/title into tuples of (displayLabel, title)

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -297,7 +297,7 @@ module Spotlight::Dor
       def add_manuscript_number(sdb, solr_doc)
         manuscript_number = sdb.smods_rec.location.shelfLocator.try(:text)
         return if manuscript_number.blank?
-        insert_field solr_doc, 'manuscript_number', manuscript_number, :symbol
+        insert_field solr_doc, 'manuscript_number', manuscript_number, :stored_searchable # this is a _tesim field
       end
 
       # We need to join the `displayLabel` and titles for all *alternative* titles

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -311,7 +311,7 @@ module Spotlight::Dor
       def add_text_titles(sdb, solr_doc)
         text_titles = sdb.smods_rec.tableOfContents.try(:content)
         return if text_titles.blank?
-        insert_field solr_doc, 'text_titles', text_titles, :symbol # this is a _ssim field
+        insert_field solr_doc, 'text_titles', text_titles, :stored_searchable # this is a _tesim field
       end
 
       def add_incipit(sdb, solr_doc)

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -730,6 +730,22 @@
         full_text_search^2
       </str>
 
+      <str name="qf_toc_search">
+        toc_unstem_search^5
+        toc_search
+      </str>
+      <str name="pf_toc_search">
+        toc_unstem_search^25
+        toc_search^5
+      </str>
+      <str name="pf3_toc_search">
+        toc_unstem_search^15
+        toc_search^3
+      </str>
+      <str name="pf2_toc_search">
+        toc_unstem_search^10
+        toc_search^2
+      </str>
 
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,4 +24,9 @@ describe ApplicationHelper, type: :helper do
       expect(helper.notes_wrap(value: %w(a <p>b</p><p>c</p> d))).to eq output
     end
   end
+  describe '#manuscript_title' do
+    it 'adds basic support of display label' do
+      expect(helper.manuscript_title(value: ['Label-|-Stuff'])).to eq 'Label - Stuff'
+    end
+  end
 end

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -826,7 +826,7 @@ describe Spotlight::Dor::Indexer do
       end
 
       it 'handles missing metadata' do
-        expect(solr_doc['manuscript_titles_ssim']).to be_blank
+        expect(solr_doc['manuscript_titles_tesim']).to be_blank
       end
 
       context 'with no alternative titles' do
@@ -841,7 +841,7 @@ describe Spotlight::Dor::Indexer do
         end
 
         it 'is blank' do
-          expect(solr_doc['manuscript_titles_ssim']).to be_blank
+          expect(solr_doc['manuscript_titles_tesim']).to be_blank
         end
       end
 
@@ -868,7 +868,7 @@ describe Spotlight::Dor::Indexer do
         end
 
         it 'extracts the titles' do
-          expect(solr_doc['manuscript_titles_ssim']).to eq(['-|-Liber Arabicus', 'My Label-|-My Title'])
+          expect(solr_doc['manuscript_titles_tesim']).to eq(['-|-Liber Arabicus', 'My Label-|-My Title'])
         end
       end
     end

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -741,7 +741,7 @@ describe Spotlight::Dor::Indexer do
   end # full text indexing concern
 
   context 'Parker specific indexing' do
-    let(:manuscript_number_field) { 'manuscript_number_ssim' }
+    let(:manuscript_number_field) { 'manuscript_number_tesim' }
 
     describe '#add_manuscript_number' do
       before do

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -815,7 +815,7 @@ describe Spotlight::Dor::Indexer do
         end
 
         it 'extracts the incipit' do
-          expect(solr_doc['incipit_ssim']).to eq(['In illo tempore maria magdalene et maria iacobi et solomae'])
+          expect(solr_doc['incipit_tesim']).to eq(['In illo tempore maria magdalene et maria iacobi et solomae'])
         end
       end
     end

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -777,7 +777,7 @@ describe Spotlight::Dor::Indexer do
       end
 
       it 'handles missing metadata' do
-        expect(solr_doc['text_titles_ssim']).to be_blank
+        expect(solr_doc['text_titles_tesim']).to be_blank
       end
 
       context 'with metadata' do
@@ -786,7 +786,7 @@ describe Spotlight::Dor::Indexer do
         end
 
         it 'extracts the titles' do
-          expect(solr_doc['text_titles_ssim']).to eq(['Homiliae XL in euangelia'])
+          expect(solr_doc['text_titles_tesim']).to eq(['Homiliae XL in euangelia'])
         end
       end
     end


### PR DESCRIPTION
- [x] Marked **WIP** due to deployment concerns

Closes #772 (see more spun off design needed + implementation in #791)
Closes #723 
Partially addresses #721 
Closes #725 
Closes #778
Is connected to #781 

## ~~Caution: This will add search fields to all exhibits. Perhaps we should figure out enabled /configuration first?~~ Resolved upstream

![searchfields](https://user-images.githubusercontent.com/1656824/31956538-baa145b2-b8b9-11e7-9f2d-c338ff2fcdbe.gif)

![searchfields](https://user-images.githubusercontent.com/1656824/32021022-1e454a1e-b9a0-11e7-9d18-c7e942243383.gif)

