### PR TITLE
enforce IIIF manifest availability by using contentMetadata type

### DIFF
--- a/app/models/concerns/manifest_concern.rb
+++ b/app/models/concerns/manifest_concern.rb
@@ -3,7 +3,9 @@
 # convenient accessors for IIIF manifests embeded in a SolrDocument
 module ManifestConcern
   def manifest
-    fetch('iiif_manifest_url_ssi', nil)
+    manifest_url = fetch('iiif_manifest_url_ssi', nil)
+    return if manifest_url.blank? || !manifest_available?
+    manifest_url
   end
 
   def exhibit_specific_manifest(custom_manifest_pattern)
@@ -11,5 +13,13 @@ module ManifestConcern
     # Return early if there is not a manifest pattern (a heuristic for a non-image thing)
     return manifest if manifest.blank?
     custom_manifest_pattern.gsub('{id}', first('id'))
+  end
+
+  VALID_IIIF_CONTENT_TYPES = %w(image manuscript map book).freeze
+
+  # even if a URL is present we need to check the contentMetadata type
+  # to determine whether the manifest will resolve at runtime.
+  def manifest_available?
+    VALID_IIIF_CONTENT_TYPES.include?(first('content_metadata_type_ssm').to_s)
   end
 end

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -40,9 +40,8 @@ module Spotlight::Dor
     private
 
     def add_iiif_manifest_url(sdb, solr_doc)
-      url = iiif_manifest_url(sdb.bare_druid)
-      return unless Faraday.head(url).status == 200
-      solr_doc['iiif_manifest_url_ssi'] = url
+      # NOTE that the manifest URL may not work at runtime - so we need to check the contentMetadata type then
+      solr_doc['iiif_manifest_url_ssi'] = iiif_manifest_url(sdb.bare_druid)
     end
 
     def iiif_manifest_url(bare_druid)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -19,7 +19,8 @@ describe SolrDocument do
     subject do
       described_class.new(
         id: 'abc123',
-        'iiif_manifest_url_ssi' => 'http://www.example.com/default/'
+        'iiif_manifest_url_ssi' => 'http://www.example.com/default/',
+        'content_metadata_type_ssm' => %w(image)
       )
     end
 
@@ -40,6 +41,20 @@ describe SolrDocument do
 
       it 'returns nil' do
         expect(subject.exhibit_specific_manifest('present')).to be_nil
+      end
+    end
+    context 'without a whitelisted contentMetadata type' do
+      subject do
+        described_class.new(
+          id: 'abc123',
+          'iiif_manifest_url_ssi' => 'http://www.example.com/default/',
+          'content_metadata_type_ssm' => %w(notanimage)
+        )
+      end
+
+      it 'returns nil' do
+        expect(subject.exhibit_specific_manifest(nil)).to be_nil
+        expect(subject.exhibit_specific_manifest('https://www.example.com/new/{id}')).to be_nil
       end
     end
   end

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 describe Spotlight::Dor::Indexer do
   subject { described_class.new }
 
-  let(:fake_druid) { 'oo000oo0000' }
-  let(:real_druid) { 'yy901zw2656' }
-  let(:resource) { Harvestdor::Indexer::Resource.new(double, fake_druid) }
+  let(:druid) { 'oo000oo0000' }
+  let(:resource) { Harvestdor::Indexer::Resource.new(double, druid) }
   let(:solr_doc) { {} }
   let(:modsbody) { '' }
   let(:mods) do
@@ -23,7 +22,7 @@ describe Spotlight::Dor::Indexer do
     i.logger.level = Logger::WARN
     allow(resource).to receive(:indexer).and_return i
     allow(resource).to receive(:mods).and_return(mods)
-    allow(resource).to receive(:bare_druid).and_return(fake_druid)
+    allow(resource).to receive(:bare_druid).and_return(druid)
   end
 
   describe '#add_iiif_manifest_url' do
@@ -31,30 +30,8 @@ describe Spotlight::Dor::Indexer do
       subject.send(:add_iiif_manifest_url, resource, solr_doc)
     end
 
-    context 'with an invalid IIIF manifest URL' do
-      before do
-        allow(Faraday).to receive(:head).with('myurl').and_return(instance_double(Faraday::Response, status: 404))
-      end
-
-      it 'does not add URL' do
-        expect(Faraday).not_to have_received(:head).with('myurl')
-        expect(solr_doc['iiif_manifest_url_ssi']).to be_nil
-      end
-    end
-
-    context 'with valid IIIF manifest' do
-      let(:valid_url) { 'https://purl.stanford.edu/yy901zw2656/iiif/manifest' }
-
-      before do
-        allow(resource).to receive(:bare_druid).and_return(real_druid)
-        allow(Faraday).to receive(:head).with(valid_url).and_return(instance_double(Faraday::Response, status: 200))
-        subject.send(:add_iiif_manifest_url, resource, solr_doc)
-      end
-
-      it 'adds a reference to the IIIF manifest' do
-        expect(Faraday).to have_received(:head).with(valid_url)
-        expect(solr_doc['iiif_manifest_url_ssi']).to eq valid_url
-      end
+    it 'adds a reference to the IIIF manifest' do
+      expect(solr_doc['iiif_manifest_url_ssi']).to eq 'https://purl.stanford.edu/oo000oo0000/iiif/manifest'
     end
   end
 
@@ -62,7 +39,7 @@ describe Spotlight::Dor::Indexer do
     before do
       allow(resource).to receive(:public_xml).and_return(public_xml)
       # stacks url calculations require the druid
-      solr_doc[:id] = fake_druid
+      solr_doc[:id] = druid
       subject.send(:add_content_metadata_fields, resource, solr_doc)
     end
 

--- a/spec/views/catalog/_exhibits_document_header_default.html.erb_spec.rb
+++ b/spec/views/catalog/_exhibits_document_header_default.html.erb_spec.rb
@@ -16,11 +16,25 @@ describe 'catalog/_exhibits_document_header_default', type: :view do
   end
 
   describe 'IIIF Drag-n-Drop Icon' do
-    context 'when the document has a manifest' do
-      let(:document) { SolrDocument.new(iiif_manifest_url_ssi: 'https://purl.stanford.edu/bc853rd3116/iiif/manifest') }
+    context 'when the document has a manifest and a valid contentMetadata type' do
+      let(:document) do
+        SolrDocument.new(iiif_manifest_url_ssi: 'https://purl.stanford.edu/bc853rd3116/iiif/manifest',
+                         content_metadata_type_ssm: %w(image))
+      end
 
-      it 'rendres the icon' do
+      it 'renders the icon' do
         expect(rendered).to have_css('a.iiif-dnd')
+      end
+    end
+
+    context 'when the document has a manifest but not a valid contentMetadata type' do
+      let(:document) do
+        SolrDocument.new(iiif_manifest_url_ssi: 'https://purl.stanford.edu/bc853rd3116/iiif/manifest',
+                         content_metadata_type_ssm: %w(unknown))
+      end
+
+      it 'does not render the icon' do
+        expect(rendered).not_to have_css('a.iiif-dnd')
       end
     end
 

--- a/spec/views/viewers/_mirador.html.erb_spec.rb
+++ b/spec/views/viewers/_mirador.html.erb_spec.rb
@@ -4,7 +4,8 @@ describe 'viewers/_mirador.html.erb', type: :view do
   let(:document) do
     SolrDocument.new(
       'id' => 'abc123',
-      'iiif_manifest_url_ssi' => 'https://purl.stanford.edu/bc853rd3116?manifest'
+      'iiif_manifest_url_ssi' => 'https://purl.stanford.edu/bc853rd3116?manifest',
+      'content_metadata_type_ssm' => %w(image)
     )
   end
   let(:current_exhibit) { create(:exhibit) }


### PR DESCRIPTION
This PR fixes #745 by reducing the time indexing takes (avoiding a fetch on the IIIF manifest to determine validity).

It uses the contentMetadata type attribute to determine whether a resource will have a valid IIIF manifest. The `iiif_manifest_url_ssi` is always present as it's just the location of where the manifest _should_ be. The affected specs are both in the SolrDocument and the views.

cc: @camillevilla @mejackreed 