### PR TITLE
[WIP] Add a separate field for each value of /mods/note/@displayLabel in an exhibit

### DIFF
--- a/app/assets/stylesheets/modules/labeled_notes.scss
+++ b/app/assets/stylesheets/modules/labeled_notes.scss
@@ -1,0 +1,6 @@
+dd,
+dt {
+  &.blacklight-labeled_notes_ssim {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/sul_theme.scss
+++ b/app/assets/stylesheets/sul_theme.scss
@@ -7,3 +7,4 @@
 @import "modules/blacklight_overrides";
 @import "modules/spotlight_overrides";
 @import "modules/blacklight_heatmaps_overrides";
+@import "modules/labeled_notes";

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -183,6 +183,7 @@ class CatalogController < ApplicationController
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
     config.add_index_field 'general_notes_ssim', label: 'Notes', helper_method: :notes_wrap
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
+    config.add_index_field 'labeled_notes_ssim', label: 'Labeled Notes', helper_method: :labeled_mods_notes
     # Fields specific to Parker Exhibit
     config.add_index_field 'incipit_tesim', label: 'Incipit'
     config.add_index_field 'text_titles_tesim', label: 'Text title'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,15 @@ module ApplicationHelper
       title.split('-|-').join(' - ')
     end, ',')
   end
+
+  def labeled_mods_notes(options = {})
+    return if options[:value].blank?
+    results = []
+    options[:value].each do |note|
+      field, text = note.split('-|-')
+      results << content_tag('dt', field)
+      results << content_tag('dd', text)
+    end
+    safe_join(results)
+  end
 end

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -325,7 +325,7 @@ module Spotlight::Dor
         notes = parse_notes(sdb)
         return if notes.blank?
         notes.each do |key, value|
-          insert_field solr_doc, key, value.join('-|-'), :symbol
+          insert_field solr_doc, key, value, :symbol
         end
       end
 
@@ -362,8 +362,14 @@ module Spotlight::Dor
       return nil if nodeset.empty?
       nodeset.each do |note|
         next if note.attr('displayLabel').blank?
-        type = note.attr('type')
-        notes[type] = [note.attr('displayLabel'), note.text.strip]
+        # convert MODS camel case types to snake case
+        type = note.attr('type').underscore
+        label_with_title = [note.attr('displayLabel'), note.text.strip].join('-|-')
+        if notes.include?(type)
+          notes[type] << label_with_title
+        else
+          notes[type] = [label_with_title]
+        end
       end
       notes
     end

--- a/app/models/spotlight/dor/indexer.rb
+++ b/app/models/spotlight/dor/indexer.rb
@@ -357,12 +357,13 @@ module Spotlight::Dor
 
     def parse_notes(sdb)
       notes = {}
-      sdb.smods_rec.related_item.each do |item|
-        item.note.each do |note|
-          next if note.attr('displayLabel').blank?
-          type = note.attr('type') # rubric
-          notes[type] = [note.attr('displayLabel'), note.text.strip]
-        end
+      # gather notes from <relatedItem> and <physicalDescription>
+      nodeset = sdb.smods_rec.related_item.note + sdb.smods_rec.physical_description.note
+      return nil if nodeset.empty?
+      nodeset.each do |note|
+        next if note.attr('displayLabel').blank?
+        type = note.attr('type')
+        notes[type] = [note.attr('displayLabel'), note.text.strip]
       end
       notes
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,9 +24,16 @@ describe ApplicationHelper, type: :helper do
       expect(helper.notes_wrap(value: %w(a <p>b</p><p>c</p> d))).to eq output
     end
   end
+
   describe '#manuscript_title' do
     it 'adds basic support of display label' do
       expect(helper.manuscript_title(value: ['Label-|-Stuff'])).to eq 'Label - Stuff'
+    end
+  end
+
+  describe '#labeled_mods_notes' do
+    it 'parses notes displayLabel and text' do
+      expect(helper.labeled_mods_notes(value: ['Material-|-Vellum'])).to eq '<dt>Material</dt><dd>Vellum</dd>'
     end
   end
 end

--- a/spec/models/spotlight/dor/indexer_spec.rb
+++ b/spec/models/spotlight/dor/indexer_spec.rb
@@ -872,5 +872,32 @@ describe Spotlight::Dor::Indexer do
         end
       end
     end
+
+    context '#add_labeled_notes' do
+      before do
+        subject.send(:add_labeled_notes, resource, solr_doc)
+      end
+
+      context 'with displayLabels' do
+        let(:modsbody) do # from cf386wt1778
+          <<-MODS
+            <physicalDescription>
+              <note displayLabel="Material" type="material">Vellum</note>
+            </physicalDescription>
+            <relatedItem type="constituent">
+              <note displayLabel="Explicit" type="explicit">uidebitis sicut dixit uobis</note>
+            </relatedItem>
+          MODS
+        end
+
+        it 'extracts physicalDescription notes' do
+          expect(solr_doc['labeled_notes_ssim']).to include 'Material-|-Vellum'
+        end
+
+        it 'extracts relatedItem notes' do
+          expect(solr_doc['labeled_notes_ssim']).to include 'Explicit-|-uidebitis sicut dixit uobis'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Addresses part of #544 

Sample record:
[https://purl.stanford.edu/cf386wt1778.mods](https://purl.stanford.edu/cf386wt1778.mods)

## [WIP]
- [x] write some tests 
### ~~Option 1 - index notes as separate fields~~
- [x] Get SOME working solr_fields indexed
- [x] add both `<relatedItem>` and `<physicalDescription>` notes
- [ ] use displayLabel for the field label
- [x] figure out how to handle multiple notes of the same type 
e.g. 
```
<note displayLabel="Height" type="dimensions">300 mm</note>
<note displayLabel="Width" type="dimensions">215 mm</note>
<note displayLabel="Dimensions" type="dimensions">12 x 8.7 in</note>
```
### Option 2 - index notes in the same field, but display separately
- [x] Throw notes into a `labeled_notes_ssim` field and add a helper for displaying things as separate fields
- [x] Hide `Labeled notes`
- [ ] Implement #799 