### PR TITLE
Adjust responsive behavior in small List view

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -73,7 +73,7 @@
       @extend .col-xs-8;
       @extend .col-md-9;
       @extend .col-xs-offset-3;
-      @extend .col-md-offset-2;
+      @extend .col-sm-offset-2;
     }
 
     .document-thumbnail {


### PR DESCRIPTION
Closes #736 

This PR adjusts the document metadata offset in Small view (between 768px and 992 px). 

## Before
![small_view_before](https://user-images.githubusercontent.com/5402927/32352662-61fc0c4e-bfdf-11e7-8512-803d6fe8a45d.png)

## After
![small_view_after](https://user-images.githubusercontent.com/5402927/32352661-61e761d6-bfdf-11e7-8b9a-0267c22af8fe.png)

## Demo
![responsive-behavior-after](https://user-images.githubusercontent.com/5402927/32352683-7904e01e-bfdf-11e7-8cca-fedb2cda3030.gif)
