### PR TITLE
Add collapsible tableOfContents

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,3 +29,4 @@
 //= require openseadragon
 //= require spotlight
 //= require sul-exhibits-template
+//= require table_of_contents

--- a/app/assets/javascripts/table_of_contents.js
+++ b/app/assets/javascripts/table_of_contents.js
@@ -1,0 +1,16 @@
+/* global Blacklight */
+
+Blacklight.onLoad(function() {
+
+  var link = $('.blacklight-text_titles_tesim').find('a');
+
+  $('#collapseToc').on('show.bs.collapse', function () {
+    $(link).find('.caret').removeClass('caret-right');
+    $(link).html($(link).html().replace('Show', 'Hide'));
+  });
+
+  $('#collapseToc').on('hide.bs.collapse', function () {
+    $(link).html($(link).html().replace('Hide', 'Show'));
+    $(link).find('.caret').addClass('caret-right');
+  });
+});

--- a/app/assets/stylesheets/modules/parker.scss
+++ b/app/assets/stylesheets/modules/parker.scss
@@ -2,3 +2,7 @@
 #global-footer {
   display: none;
 }
+
+.caret-right {
+  transform: rotate(-90deg);
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -186,7 +186,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
     # Fields specific to Parker Exhibit
     config.add_index_field 'incipit_tesim', label: 'Incipit'
-    config.add_index_field 'text_titles_tesim', label: 'Text title'
+    config.add_index_field 'text_titles_tesim', label: 'Text title', helper_method: :table_of_contents_separator
     config.add_index_field 'manuscript_titles_tesim', label: 'Manuscript title', helper_method: :manuscript_title
     config.add_index_field 'manuscript_number_tesim', label: 'Manuscript number'
     # "fielded" search configuration. Used by pulldown among other places.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,11 @@ module ApplicationHelper
       title.split('-|-').join(' - ')
     end, ',')
   end
+
+  def table_of_contents_separator(options = {})
+    return if options[:value].blank?
+    contents = options[:value][0].split('--').map(&:strip)
+    contents = contents.join('<br />').html_safe # rubocop:disable Rails/OutputSafety
+    render partial: 'catalog/table_of_contents', locals: { contents: contents }
+  end
 end

--- a/app/views/catalog/_table_of_contents.html.erb
+++ b/app/views/catalog/_table_of_contents.html.erb
@@ -1,0 +1,7 @@
+<a role='button' data-toggle='collapse' href='#collapseToc' aria-expanded='false' aria-controls='collapseToc' >Show<b class='caret caret-right'></b>
+</a>
+<div class='collapse' id='collapseToc'>
+  <div class='well'>
+  <%= contents %>
+  </div>
+</div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,9 +24,22 @@ describe ApplicationHelper, type: :helper do
       expect(helper.notes_wrap(value: %w(a <p>b</p><p>c</p> d))).to eq output
     end
   end
+
   describe '#manuscript_title' do
     it 'adds basic support of display label' do
       expect(helper.manuscript_title(value: ['Label-|-Stuff'])).to eq 'Label - Stuff'
+    end
+  end
+
+  describe '#table_of_contents_separator' do
+    let(:input) { { value: ['Homiliae--euangelia'] } }
+
+    it 'separates MODS table of contents' do
+      expect(helper.table_of_contents_separator(input)).to match(%r{Homiliae<br \/>euangelia})
+    end
+
+    it 'hides contents in a collapsible div' do
+      expect(helper.table_of_contents_separator(input)).to match(/^<a role='button' data-toggle='collapse'/)
     end
   end
 end


### PR DESCRIPTION
Closes #784 

This PR takes the content in `MODS:tableOfContents` / `text_titles_tesim` and puts it in a collapsing div.

## Todo
- [x] refactor from helper to a partial
- [x] write a JS function for Show ➡️ / Hide 🔽
- [x] write specs
- [x] figure out why I can't change the label from `Text title` to `Table of contents`? 
Note: the default label for the field is `Text title`. The label has manually been changed to `Table of Contents` in `Curation > Metadata` here. This will be resolved by #828.

## Fixtures
[tx112pf2826](https://purl.stanford.edu/tx112pf2826.mods) (medium)
[sg197kx6643](https://purl.stanford.edu/sg197kx6643.mods) (long)

## Demo
### Before
![before_toc](https://user-images.githubusercontent.com/5402927/32470626-e772049c-c30d-11e7-9839-f77acac36950.png)

### After
#### Closed
![after_closed](https://user-images.githubusercontent.com/5402927/32470618-d5d148e2-c30d-11e7-837d-5139685283c1.png)
#### Open
![after_open](https://user-images.githubusercontent.com/5402927/32470617-d5ab0efc-c30d-11e7-9dee-eafa18cc3a84.png)

