### PR TITLE
add manifest label/title to page detail title

### DIFF
--- a/lib/traject/canvas_reader.rb
+++ b/lib/traject/canvas_reader.rb
@@ -2,7 +2,7 @@
 
 # Reads in Canvas records for traject
 class CanvasReader
-  # @param input_stream [File|IO]
+  # @param input_stream [File|IO] An enhanced IIIF Canvas object
   # @param settings [Traject::Indexer::Settings]
   def initialize(input_stream, settings)
     @settings = Traject::Indexer::Settings.new settings

--- a/lib/traject/macros/canvas.rb
+++ b/lib/traject/macros/canvas.rb
@@ -17,9 +17,13 @@ module Macros
       end
     end
 
+    ##
+    # Note: This method assumes an "enhanced" canvas with additional properties
+    # added beyond the IIIF Canvas model.
     def extract_canvas_label
       lambda do |record, accumulator, _context|
-        accumulator << record['label'].to_s
+        labels = [record['label'].to_s, record['manifest_label'].to_s].reject(&:empty?)
+        accumulator << labels.join(': ')
       end
     end
 

--- a/spec/features/canvas_resource_integration_spec.rb
+++ b/spec/features/canvas_resource_integration_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe 'Canvas resource integration test', type: :feature do
   subject(:document) { SolrDocument.new(to_solr_hash) }
 
-  let(:resource) { CanvasResource.new(exhibit: exhibit, data: JSON.parse(File.read(file))) }
+  let(:raw_canvas) { JSON.parse(File.read(file)) }
+  let(:enhanced_canvas) { raw_canvas.merge(manifest_label: 'Awesome sauce!') }
+  let(:resource) { CanvasResource.new(exhibit: exhibit, data: enhanced_canvas) }
   let(:file) { 'spec/fixtures/iiif/fh878gz0315-canvas-521.json' }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:to_solr_hash) { resource.document_builder.to_solr.first }
@@ -40,7 +42,7 @@ RSpec.describe 'Canvas resource integration test', type: :feature do
     it 'has canvas attributes' do
       expect(canvas.id).to eq 'canvas-0fa395980b05e493948e0e2b50debd42'
       expect(canvas.iiif_id).to eq 'https://dms-data.stanford.edu/data/manifests/Parker/fh878gz0315/canvas/canvas-521'
-      expect(canvas.label).to eq 'f. 254 r'
+      expect(canvas.label).to eq 'f. 254 r: Awesome sauce!'
     end
 
     it 'has canvas annotations' do

--- a/spec/models/iiif_canvas_indexer_spec.rb
+++ b/spec/models/iiif_canvas_indexer_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe IiifCanvasIndexer do
       expect(CanvasResource.last.data['@id']).to eq 'http://example.org/iiif/book1/canvas/p3'
     end
 
+    it 'enhances the JSON of the canvas with additional needed fields' do
+      subject.index_canvases
+      expect(CanvasResource.first.data['manifest_label']).to eq 'Book 1'
+    end
+
     it 'enqueues the same number of jobs as otherContent annotationLists' do
       expect do
         subject.index_canvases


### PR DESCRIPTION
Closes #831 

This PR enhances a  canvas object that is passed into the traject indexer with the "manifest_label" AKA title. This is needed to create the "Page detail" title outlined in designs for Page detail search and show pages.

Fixture object: `bg021sq9590`

![screen shot 2017-11-07 at 2 06 02 pm](https://user-images.githubusercontent.com/1656824/32512376-d5561cc8-c3c4-11e7-94a2-23f709a0f5f5.png)
![screen shot 2017-11-07 at 2 05 54 pm](https://user-images.githubusercontent.com/1656824/32512377-d567c630-c3c4-11e7-9051-9a15e1aada0d.png)

