### PR TITLE
Add manuscript link

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -197,6 +197,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'text_titles_tesim', label: 'Text title', helper_method: :table_of_contents_separator
     config.add_index_field 'manuscript_titles_tesim', label: 'Manuscript title', helper_method: :manuscript_title
     config.add_index_field 'manuscript_number_tesim', label: 'Manuscript number'
+    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,9 +49,12 @@ module ApplicationHelper
   end
 
   def manuscript_link(options = {})
-    return if options[:value].blank?
-    title = options[:document]['title_full_display']
-    title = title.partition(':')[2] if title.include?(':')
+    document = options[:document]
+    ms_number = document['manuscript_number_tesim']
+    return if options[:value].blank? || ms_number.blank?
+    return options[:value] if document['format_main_ssim'] != ['Page details']
+    title = document['title_full_display']
+    title = title.include?(':') ? title.partition(':')[2] : ms_number[0]
     link_to title, spotlight.exhibit_solr_document_path(@exhibit, options[:value][0])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,8 +53,7 @@ module ApplicationHelper
     ms_number = document['manuscript_number_tesim']
     return if options[:value].blank? || ms_number.blank?
     return options[:value] if document['format_main_ssim'] != ['Page details']
-    title = document['title_full_display']
-    title = title.include?(':') ? title.partition(':')[2] : ms_number[0]
-    link_to title, spotlight.exhibit_solr_document_path(@exhibit, options[:value][0])
+    title = document['title_full_display'].include?(':') ? document['title_full_display'] : ms_number[0]
+    link_to title, spotlight.exhibit_solr_document_path(current_exhibit, options[:value][0])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,4 +47,11 @@ module ApplicationHelper
     id = options[:document].id
     render partial: 'catalog/table_of_contents', locals: { contents: contents, collapse_id: "collapseToc-#{id}" }
   end
+
+  def manuscript_link(options = {})
+    return if options[:value].blank?
+    title = options[:document]['title_full_display']
+    title = title.partition(':')[2] if title.include?(':')
+    link_to title, spotlight.exhibit_solr_document_path(@exhibit, options[:value][0])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,11 +49,13 @@ module ApplicationHelper
   end
 
   def manuscript_link(options = {})
+    druid = options[:value]
     document = options[:document]
     ms_number = document['manuscript_number_tesim']
-    return if options[:value].blank? || ms_number.blank?
-    return options[:value] if document['format_main_ssim'] != ['Page details']
-    title = document['title_full_display'].include?(':') ? document['title_full_display'] : ms_number[0]
-    link_to title, spotlight.exhibit_solr_document_path(current_exhibit, options[:value][0])
+    return if druid.blank? || ms_number.blank?
+    return druid if document['format_main_ssim'] != ['Page details']
+    title = document['title_full_display']
+    title = title.include?(':') ? title.partition(':')[2] : ms_number[0]
+    link_to title, spotlight.exhibit_solr_document_path(current_exhibit, druid[0])
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,12 +62,13 @@ describe ApplicationHelper, type: :helper do
 
     before do
       helper.extend(Module.new do
-        def current_exhibit; end
+        def current_exhibit
+          FactoryBot.create(:exhibit, slug: 'test-flag-exhibit-slug')
+        end
       end)
     end
 
     it 'removes page prefix' do
-      allow(helper).to receive(:current_exhibit).and_return(create(:exhibit, slug: 'test-flag-exhibit-slug'))
       expect(helper.manuscript_link(input)).to have_link(text: title, href: show_page)
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,7 +49,6 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe '#manuscript_link' do
-    let(:druid) { ['bg021sq9590'] }
     let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
     let(:show_page) { '/test-flag-exhibit-slug/catalog/bg021sq9590' }
     let(:document) do
@@ -59,10 +58,16 @@ describe ApplicationHelper, type: :helper do
         format_main_ssim: ['Page details']
       )
     end
-    let(:input) { { value: druid, document: document } }
+    let(:input) { { value: ['bg021sq9590'], document: document } }
+
+    before do
+      helper.extend(Module.new do
+        def current_exhibit; end
+      end)
+    end
 
     it 'removes page prefix' do
-      @exhibit = create(:exhibit, slug: 'test-flag-exhibit-slug')
+      allow(helper).to receive(:current_exhibit).and_return(create(:exhibit, slug: 'test-flag-exhibit-slug'))
       expect(helper.manuscript_link(input)).to have_link(text: title, href: show_page)
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -47,4 +47,16 @@ describe ApplicationHelper, type: :helper do
       expect(helper.table_of_contents_separator(input)).to match(/data-toggle='collapse'/)
     end
   end
+
+  describe '#manuscript_link' do
+    let(:druid) { ['bg021sq9590'] }
+    let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
+    let(:full_title) { { 'title_full_display' => ["p. 3:#{title}"] } }
+    let(:show_page) { '/test-flag-exhibit-slug/catalog/bg021sq9590' }
+
+    it 'removes page prefix' do
+      @exhibit = create(:exhibit, slug: 'test-flag-exhibit-slug')
+      expect(helper.manuscript_link(value: druid, document: full_title)).to have_link(text: title, href: show_page)
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,12 +51,19 @@ describe ApplicationHelper, type: :helper do
   describe '#manuscript_link' do
     let(:druid) { ['bg021sq9590'] }
     let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
-    let(:full_title) { { 'title_full_display' => ["p. 3:#{title}"] } }
     let(:show_page) { '/test-flag-exhibit-slug/catalog/bg021sq9590' }
+    let(:document) do
+      SolrDocument.new(
+        title_full_display: "p. 3:#{title}",
+        manuscript_number_tesim: ['MS 198'],
+        format_main_ssim: ['Page details']
+      )
+    end
+    let(:input) { { value: druid, document: document } }
 
     it 'removes page prefix' do
       @exhibit = create(:exhibit, slug: 'test-flag-exhibit-slug')
-      expect(helper.manuscript_link(value: druid, document: full_title)).to have_link(text: title, href: show_page)
+      expect(helper.manuscript_link(input)).to have_link(text: title, href: show_page)
     end
   end
 end


### PR DESCRIPTION
Closes #843 
Design #727 

This PR adds a link to the related manuscript in `Page details`. This PR uses work in #844 to get the title of the manuscript. This requires a manifest with a `label` to get the appropriate formatting.

## Todo
- [x] working link
- [x] change link text to manuscript title
- [x] discuss fallback behavior with Gary 
- [x] specs
- [x] figure out why this is causing ~~an error in `manuscript_display_bibliography_spec`~~ SEEMINGLY UNRELATED SPECS TO FAIL
- [x] update screenshots
- [x] restore partition and appease RuboCop ABC 

## Fixtures
[bg021sq9590](http://dms-data.stanford.edu/data/manifests/Parker/bg021sq9590/manifest.json)
[fh878gz0315](http://dms-data.stanford.edu/data/manifests/Parker/fh878gz0315/manifest.json)

## Demo
### Working fixture (bg021sq9590)
![working_link](https://user-images.githubusercontent.com/5402927/32524444-8b7e5bc8-c3d4-11e7-81ef-f5fa872da3fa.png)

### Fallback behavior (fh878gz0315) 
![fallback_behavior](https://user-images.githubusercontent.com/5402927/32748725-f2e090be-c871-11e7-973b-d2885c34130c.png)
