### PR TITLE
Index the identifier from the SolrDocument into the Canvas document.

### DIFF
--- a/app/models/iiif_canvas_indexer.rb
+++ b/app/models/iiif_canvas_indexer.rb
@@ -26,6 +26,7 @@ class IiifCanvasIndexer
         # so we do this by enhancing the stored Hash with needed fields.
         enhanced_canvas = JSON.parse(canvas.to_json)
         enhanced_canvas['manifest_label'] = manifest.label
+        enhanced_canvas['parent_identifier'] = document.fetch('identifier_ssim', nil)
         canvas_resource.data = enhanced_canvas
         canvas_resource.save_and_index
       end

--- a/lib/traject/canvas_config.rb
+++ b/lib/traject/canvas_config.rb
@@ -16,6 +16,7 @@ end
 to_field 'id', extract_canvas_id
 to_field 'iiif_canvas_id_ssim', extract_canvas_iiif_id
 to_field 'format_main_ssim', literal('Page details')
+to_field 'identifier_ssim', extract_canvas_parent_identifier
 
 to_fields %w(title_display title_full_display title_uniform_search), extract_canvas_label
 to_field 'title_sort', extract_canvas_label_sort

--- a/lib/traject/macros/canvas.rb
+++ b/lib/traject/macros/canvas.rb
@@ -37,6 +37,14 @@ module Macros
       end
     end
 
+    def extract_canvas_parent_identifier
+      lambda do |record, accumulator, _context|
+        return if record['parent_identifier'].blank?
+
+        accumulator.push(*record['parent_identifier'])
+      end
+    end
+
     def extract_canvas_annotation_list_urls
       lambda do |record, accumulator, _context|
         return if record['otherContent'].blank?

--- a/spec/models/iiif_canvas_indexer_spec.rb
+++ b/spec/models/iiif_canvas_indexer_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe IiifCanvasIndexer do
     SolrDocument.new(
       id: druid,
       content_metadata_type_ssm: ['image'],
-      iiif_manifest_url_ssi: 'http://example.com'
+      iiif_manifest_url_ssi: 'http://example.com',
+      identifier_ssim: %w(ABC 123 xyz)
     )
   end
   let(:mani_url) { 'http://example.org/iiif/book1/manifest' }
@@ -47,6 +48,7 @@ RSpec.describe IiifCanvasIndexer do
     it 'enhances the JSON of the canvas with additional needed fields' do
       subject.index_canvases
       expect(CanvasResource.first.data['manifest_label']).to eq 'Book 1'
+      expect(CanvasResource.first.data['parent_identifier']).to eq(%w(ABC 123 xyz))
     end
 
     it 'enqueues the same number of jobs as otherContent annotationLists' do


### PR DESCRIPTION
Closes #832 

## canvas-3f47f78ba92d14dd09ebe23bde585da0
<img width="600" alt="canvas-3f47f78ba92d14dd09ebe23bde585da0" src="https://user-images.githubusercontent.com/96776/32529110-8d966e7a-c3eb-11e7-9760-d24fe68e3718.png">

In this PR I simply just took the same array of notes and indexed them into the same field (this way they have the same behavior).  I think this may be undesirable behavior in that it is using Blacklight's default joining behavior (which causes values to be joined with comas and an "and").

A few possible approaches to deal with this:

1. Configure `identifier_ssim` to not be joined using Blacklight's default behavior.
    * This will affect any other documents with multiple identifiers, however maybe that's desirable for this kind of data?  Not sure.
1. Concatenate the identifiers for canvas/page detail documents into a single string.
    * This won't affect the identifier display for the manuscript itself however.
1. Index the identifier into a separate field for configuration.
    * This also won't affect the identifier display for the manuscript document itself.
1. Other ideas?