### PR TITLE
Update spotlight / Add "resource type" index/show field behind feature flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ end
 
 group :test do
   gem 'rspec-rails'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'capybara'
   gem 'chromedriver-helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,10 +244,10 @@ GEM
     errbase (0.0.3)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -672,7 +672,7 @@ DEPENDENCIES
   devise_invitable
   dlss-capistrano
   dotenv
-  factory_girl_rails
+  factory_bot_rails
   faraday
   friendly_id (~> 5.2.0)
   gdor-indexer (~> 0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight
-  revision: 0929af4e831604ca4aa4847d1efd6782f2ebc34c
+  revision: d11bc4e46086350f4946c3ac018d91b2950a2201
   branch: master
   specs:
     blacklight-spotlight (1.0.0)
@@ -325,7 +325,8 @@ GEM
     kaminari-core (1.1.1)
     latex-decode (0.2.2)
       unicode (~> 0.4)
-    leaflet-rails (1.0.2)
+    leaflet-rails (1.2.0)
+      rails (>= 4.2.0)
     leaflet-sidebar-rails (0.1.9)
     legato (0.7.0)
       multi_json
@@ -349,7 +350,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_magick (4.8.0)
-    mini_mime (0.1.4)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     mirador_rails (0.7.0)

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,8 @@ rescue LoadError
 end
 
 desc 'Run tests in generated test Rails app with generated Solr instance running'
-task ci: [:rubocop, :environment] do
+task ci: [:rubocop, :environment, 'factory_bot:lint'] do
+  # Rake::Task['factory_bot:lint']
   require 'solr_wrapper'
   ENV['environment'] = 'test'
   SolrWrapper.wrap(port: '8983') do |solr|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -172,6 +172,11 @@ class CatalogController < ApplicationController
     config.add_index_field 'location_ssi', label: 'Location'
     config.add_index_field 'donor_tags_ssim', label: 'Donor tags'
     config.add_index_field 'doc_subtype_ssi', label: 'Document Subtype'
+    ##
+    # Add format/Resource type as an index field for exhibits that are whitelisted here
+    config.add_index_field 'format_main_ssim', label: 'Resource type', if: lambda { |context, _field_config, _document|
+      context.feature_flags.add_resource_type_index_field?
+    }
     # Fields added by Zotero API BibTeX import
     config.add_index_field 'volume_ssm', label: 'Volume'
     config.add_index_field 'pages_ssm', label: 'Pages'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,7 @@ feature_flags:
   themes: false
   bibliography_resource: false
   index_related_content: false # A feature that will index related SDR content. Initial implemented for Parker's IIIF AnnotationLists
+  add_resource_type_index_field: false # Should the resource type field be added as an index/show field. For some exhibits this is desirable
 traject:
   processing_thread_pool: 1
 iiif_dnd_base_url: https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?%{query}

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -13,3 +13,4 @@ feature_flags:
   test-flag-exhibit-slug:
     test_thing: true
     index_related_content: true
+    add_resource_type_index_field: true

--- a/lib/tasks/factory_bot.rake
+++ b/lib/tasks/factory_bot.rake
@@ -1,0 +1,13 @@
+namespace :factory_bot do
+  desc 'Verify that all FactoryBot factories are valid'
+  task lint: :environment do
+    if Rails.env.test?
+      DatabaseCleaner.cleaning do
+        FactoryBot.lint
+      end
+    else
+      system("bundle exec rake factory_bot:lint RAILS_ENV='test'")
+      exit $CHILD_STATUS.exitstatus
+    end
+  end
+end

--- a/spec/controllers/bibliography_resources_controller_spec.rb
+++ b/spec/controllers/bibliography_resources_controller_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe BibliographyResourcesController, type: :controller do
   let(:resource) { double }
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
-  let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
+  let(:exhibit) { create(:exhibit) }
+  let(:user) { create(:exhibit_admin, exhibit: exhibit) }
   let(:fixture_file) { fixture_file_upload('spec/fixtures/bibliography/article.bib') }
   let(:attributes) { { bibtex_file: fixture_file } }
 

--- a/spec/controllers/dor_harvester_controller_spec.rb
+++ b/spec/controllers/dor_harvester_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe DorHarvesterController, type: :controller do
   let(:resource) { double }
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
-  let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
+  let(:exhibit) { create(:exhibit) }
+  let(:user) { create(:exhibit_admin, exhibit: exhibit) }
   let(:attributes) { { druid_list: '' } }
 
   before do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,5 +1,5 @@
 # This will guess the User class
-FactoryGirl.define do
+FactoryBot.define do
   factory :curator, class: User do
     sequence(:email) { |n| "curator#{n}@example.com" }
     password 'password'

--- a/spec/factories/viewer.rb
+++ b/spec/factories/viewer.rb
@@ -1,3 +1,3 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :viewer
 end

--- a/spec/features/bibliography_display_manuscript_spec.rb
+++ b/spec/features/bibliography_display_manuscript_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Bibliography display on the manuscript show page', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit, slug: 'default-exhibit') }
+  let(:exhibit) { create(:exhibit, slug: 'default-exhibit') }
   let(:resource_id) { 'gk885tn1705' }
   let(:bibtex_data) do
     Dir.glob('spec/fixtures/bibliography/{article,incollection}.bib').collect do |fn|

--- a/spec/features/bibliography_indexing_spec.rb
+++ b/spec/features/bibliography_indexing_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Bibliography indexing', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:curator) { create(:exhibit_admin, exhibit: exhibit) }
 
   before do

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
   end
 
   let(:file) { 'spec/fixtures/bibliography/article.bib' }
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:title_fields) do
     %w(title_display title_full_display title_uniform_search title_sort)
   end

--- a/spec/features/canvas_resource_integration_spec.rb
+++ b/spec/features/canvas_resource_integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Canvas resource integration test', type: :feature do
   let(:enhanced_canvas) { raw_canvas.merge(manifest_label: 'Awesome sauce!') }
   let(:resource) { CanvasResource.new(exhibit: exhibit, data: enhanced_canvas) }
   let(:file) { 'spec/fixtures/iiif/fh878gz0315-canvas-521.json' }
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:to_solr_hash) { resource.document_builder.to_solr.first }
   let(:annolist_file) { 'spec/fixtures/iiif/fh878g0315-text-f254r.json' }
   let(:annolist_url) { 'https://dms-data.stanford.edu/data/manifests/Parker/fh878gz0315/list/text-f254r.json' }

--- a/spec/features/exhibit_spec.rb
+++ b/spec/features/exhibit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'an exhibit', type: :feature do
-  let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:exhibit) { create(:exhibit) }
 
   it 'loads the home page' do
     visit '/'
@@ -16,7 +16,7 @@ describe 'an exhibit', type: :feature do
   end
 
   describe 'search results' do
-    let(:exhibit) { FactoryGirl.create(:exhibit, slug: 'default-exhibit') }
+    let(:exhibit) { create(:exhibit, slug: 'default-exhibit') }
 
     it 'can run a search' do
       visit spotlight.url_for(exhibit)

--- a/spec/features/gdor_integration_spec.rb
+++ b/spec/features/gdor_integration_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'gdor indexing integration test', type: :feature do
   subject(:dor_harvester) { DorHarvester.new(druid_list: druid, exhibit: exhibit) }
 
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
 
   before do
     stub_const('Harvestdor::PURL_DEFAULT', File.expand_path(File.join('..', '..', 'fixtures'), __FILE__))

--- a/spec/features/manuscript_display_bibliography_spec.rb
+++ b/spec/features/manuscript_display_bibliography_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Cited manuscripts display on the bibliography show page', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit, slug: 'default-exhibit') }
+  let(:exhibit) { create(:exhibit, slug: 'default-exhibit') }
   let(:resource_id) { 'QTWBAWKX' }
   let(:citationsString) { '["gs233db8425", "gk885tn1705", "hj066rn6500"]' }
   let(:bibtex_data) do

--- a/spec/features/search_histories_spec.rb
+++ b/spec/features/search_histories_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Search histories', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
 
   before do
     allow(Search).to receive(:create).and_call_original

--- a/spec/features/viewers_spec.rb
+++ b/spec/features/viewers_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Viewers', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:user) { nil }
 
   before do

--- a/spec/helpers/blacklight/maps_helper_override_spec.rb
+++ b/spec/helpers/blacklight/maps_helper_override_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Blacklight::MapsHelperOverride, type: :helper do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
 
   before do
     helper.extend(Module.new do

--- a/spec/jobs/index_related_content_job_spec.rb
+++ b/spec/jobs/index_related_content_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe IndexRelatedContentJob do
   describe '#perform' do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:exhibit) { create(:exhibit) }
     let(:harvester) { DorHarvester.new(exhibit: exhibit) }
     let(:enqueuer) { instance_double(IiifCanvasIndexer, index_canvases: []) }
 

--- a/spec/models/dor_harvester_spec.rb
+++ b/spec/models/dor_harvester_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe DorHarvester do
   subject(:harvester) { described_class.new druid_list: druid, exhibit: exhibit }
 
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:druid) { 'xf680rd3068' }
   let(:blacklight_solr) { double }
 
@@ -65,7 +65,7 @@ describe DorHarvester do
       context 'when index_related_content is enabled for an exhibit' do
         subject(:harvester) { described_class.new druid_list: druid, exhibit: exhibit }
 
-        let(:exhibit) { FactoryGirl.create(:exhibit, slug: 'test-flag-exhibit-slug') }
+        let(:exhibit) { create(:exhibit, slug: 'test-flag-exhibit-slug') }
 
         it 'enqueues IndexRelatedContentJob' do
           expect { subject.on_success(resource) }.to have_enqueued_job(IndexRelatedContentJob).with(harvester, druid)

--- a/spec/models/iiif_canvas_indexer_spec.rb
+++ b/spec/models/iiif_canvas_indexer_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe IiifCanvasIndexer do
   subject { described_class.new(exhibit, druid) }
 
   let(:viewer) do
-    FactoryGirl.create(
+    create(
       :viewer,
       custom_manifest_pattern: 'http://example.org/iiif/{id}/manifest'
     )
   end
-  let(:exhibit) { FactoryGirl.create(:exhibit, viewer: viewer) }
+  let(:exhibit) { create(:exhibit, viewer: viewer) }
   let(:druid) { 'book1' }
   let(:document) do
     SolrDocument.new(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe User do
-  subject { FactoryGirl.create(:user) }
+  subject { create(:user) }
   describe '#webauth_groups' do
     it 'splits groups on the pipe character' do
       subject.webauth_groups = 'a|b|c'

--- a/spec/models/viewer_spec.rb
+++ b/spec/models/viewer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Viewer do
-  let(:viewer) { FactoryGirl.create(:viewer) }
+  let(:viewer) { create(:viewer) }
 
   it 'belongs to an exhibit' do
     expect(described_class.reflect_on_association(:exhibit).macro).to eq :belongs_to

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,7 +81,6 @@ RSpec.configure do |config|
     begin
       DatabaseCleaner[:active_record].strategy = :transaction
       DatabaseCleaner.clean_with(:truncation)
-      FactoryBot.lint
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 
 require 'selenium-webdriver'
 
@@ -61,7 +61,7 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include RequestSpecHelper
 
   config.before :each do
@@ -81,7 +81,7 @@ RSpec.configure do |config|
     begin
       DatabaseCleaner[:active_record].strategy = :transaction
       DatabaseCleaner.clean_with(:truncation)
-      FactoryGirl.lint
+      FactoryBot.lint
     end
   end
 

--- a/spec/services/dor_solr_document_builder_spec.rb
+++ b/spec/services/dor_solr_document_builder_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe DorSolrDocumentBuilder do
   subject { described_class.new harvester }
 
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:druid) { 'xf680rd3068' }
   let(:harvester) { DorHarvester.new druid_list: druid, exhibit: exhibit }
   let(:resources) { [resource].to_enum }

--- a/spec/services/upload_solr_document_builder_spec.rb
+++ b/spec/services/upload_solr_document_builder_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe UploadSolrDocumentBuilder do
   subject(:builder) { described_class.new resource }
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:featured_image) { instance_double(Spotlight::FeaturedImage) }
   let(:upload_id) { 123 }
   let(:riiif_image) do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,7 +1,7 @@
 module ControllerMacros
   def login_admin
     before do
-      user = FactoryGirl.create(:admin)
+      user = create(:admin)
       @request.env['devise.mapping'] = Devise.mappings[:user]
       sign_in user
     end
@@ -10,7 +10,7 @@ module ControllerMacros
   def login_curator
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      user = FactoryGirl.create(:curator)
+      user = create(:curator)
       sign_in user
     end
   end
@@ -18,7 +18,7 @@ module ControllerMacros
   def login_user
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      user = FactoryGirl.create(:user)
+      user = create(:user)
       sign_in user
     end
   end

--- a/spec/views/dor_harvester/_status.html.erb_spec.rb
+++ b/spec/views/dor_harvester/_status.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'dor_harvester/_status.html.erb', type: :view do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { create(:exhibit) }
   let(:harvester) { DorHarvester.new(druid_list: '', exhibit: exhibit) }
 
   context 'with status information' do


### PR DESCRIPTION
Closes #815 

To resolve this we needed to update Spotlight. Spotlight recently introduced a change from FactoryGirl to FactoryBot so we also needed to make that change locally.

![screen shot 2017-11-08 at 9 53 08 am](https://user-images.githubusercontent.com/1656824/32555416-ad0c0f1a-c46a-11e7-97f2-7caeeb02a88f.png)
