### PR TITLE
updates BlacklightHeatmaps resolving issue with map marker zoom

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,10 +123,10 @@ GEM
     blacklight_advanced_search (6.2.1)
       blacklight (~> 6.0, >= 6.0.1)
       parslet
-    blacklight_heatmaps (0.4.0)
+    blacklight_heatmaps (0.5.0)
       blacklight (~> 6.0)
-      leaflet-rails
-      leaflet-sidebar-rails (~> 0.1.9)
+      leaflet-rails (~> 1.2.0)
+      leaflet-sidebar-rails (~> 0.2)
       rails (>= 4.2.6, < 6)
     blankslate (3.1.3)
     bootstrap-sass (3.3.7)
@@ -327,7 +327,7 @@ GEM
       unicode (~> 0.4)
     leaflet-rails (1.2.0)
       rails (>= 4.2.0)
-    leaflet-sidebar-rails (0.1.9)
+    leaflet-sidebar-rails (0.2.0)
     legato (0.7.0)
       multi_json
     listen (3.0.8)


### PR DESCRIPTION
Closes #505 

This has been a long standing Exhibits bug, finally got all of the dependencies updated to resolve it.

![mapmarker](https://user-images.githubusercontent.com/1656824/32628672-a70ab026-c564-11e7-8155-a3f278cf45c1.gif)
