### PR TITLE
Bugfix: isolate collapsible Text title / tableOfContents

### DIFF
--- a/app/assets/javascripts/table_of_contents.js
+++ b/app/assets/javascripts/table_of_contents.js
@@ -2,15 +2,11 @@
 
 Blacklight.onLoad(function() {
 
-  var link = $('.blacklight-text_titles_tesim').find('a');
+  $('.blacklight-text_titles_tesim').on('click', function(){
+    var _this = $(this);
+    var linkText = $(_this).find('span');
 
-  $('#collapseToc').on('show.bs.collapse', function () {
-    $(link).find('.caret').removeClass('caret-right');
-    $(link).html($(link).html().replace('Show', 'Hide'));
-  });
-
-  $('#collapseToc').on('hide.bs.collapse', function () {
-    $(link).html($(link).html().replace('Hide', 'Show'));
-    $(link).find('.caret').addClass('caret-right');
+    $(_this).find('.caret').toggleClass('caret-right');
+    $(linkText).text(linkText.text() == 'Show' ? 'Hide' : 'Show' );
   });
 });

--- a/app/assets/stylesheets/modules/parker.scss
+++ b/app/assets/stylesheets/modules/parker.scss
@@ -2,7 +2,3 @@
 #global-footer {
   display: none;
 }
-
-.caret-right {
-  transform: rotate(-90deg);
-}

--- a/app/assets/stylesheets/modules/table_of_contents.scss
+++ b/app/assets/stylesheets/modules/table_of_contents.scss
@@ -1,0 +1,3 @@
+.caret-right {
+  transform: rotate(-90deg);
+}

--- a/app/assets/stylesheets/sul_theme.scss
+++ b/app/assets/stylesheets/sul_theme.scss
@@ -7,3 +7,4 @@
 @import "modules/blacklight_overrides";
 @import "modules/spotlight_overrides";
 @import "modules/blacklight_heatmaps_overrides";
+@import "modules/table_of_contents";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,6 +43,7 @@ module ApplicationHelper
     return if options[:value].blank?
     contents = options[:value][0].split('--').map(&:strip)
     contents = contents.join('<br />').html_safe
-    render partial: 'catalog/table_of_contents', locals: { contents: contents }
+    id = @document.id
+    render partial: 'catalog/table_of_contents', locals: { contents: contents, collapse_id: "collapseToc-#{id}" }
   end
 end

--- a/app/views/catalog/_table_of_contents.html.erb
+++ b/app/views/catalog/_table_of_contents.html.erb
@@ -1,4 +1,4 @@
-<a role='button' data-toggle='collapse' href='#<%= collapse_id %>' aria-expanded='false' aria-controls='<%= collapse_id %>' >Show<b class='caret caret-right'></b>
+<a role='button' data-toggle='collapse' href='#<%= collapse_id %>' aria-expanded='false' aria-controls='<%= collapse_id %>'><span>Show</span><b class='caret caret-right'></b>
 </a>
 <div class='collapse' id='<%= collapse_id %>'>
   <div class='well'>

--- a/app/views/catalog/_table_of_contents.html.erb
+++ b/app/views/catalog/_table_of_contents.html.erb
@@ -1,6 +1,6 @@
-<a role='button' data-toggle='collapse' href='#collapseToc' aria-expanded='false' aria-controls='collapseToc' >Show<b class='caret caret-right'></b>
+<a role='button' data-toggle='collapse' href='#<%= collapse_id %>' aria-expanded='false' aria-controls='<%= collapse_id %>' >Show<b class='caret caret-right'></b>
 </a>
-<div class='collapse' id='collapseToc'>
+<div class='collapse' id='<%= collapse_id %>'>
   <div class='well'>
   <%= contents %>
   </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,14 +32,15 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe '#table_of_contents_separator' do
+    before { @document = SolrDocument.new(id: 'cf386wt1778') }
     let(:input) { { value: ['Homiliae--euangelia'] } }
 
     it 'separates MODS table of contents' do
       expect(helper.table_of_contents_separator(input)).to match(%r{Homiliae<br \/>euangelia})
     end
 
-    it 'hides contents in a collapsible div' do
-      expect(helper.table_of_contents_separator(input)).to match(/^<a role='button' data-toggle='collapse'/)
+    it 'collapses content' do
+      expect(helper.table_of_contents_separator(input)).to match(/data-toggle='collapse'/)
     end
   end
 end


### PR DESCRIPTION
Closes #856 

This PR
- assigns unique IDs to each instance of collapsing tableOfContents
- fixes JS so that clicking on one `Show` / `Hide` link doesn't affect the others
- moves `.caret-right` class out of Parker theme

## Before
![showhide](https://user-images.githubusercontent.com/1656824/32577431-ef527b1a-c4a7-11e7-9838-220cbb610a70.gif)

## After
![fixed-table-of-contents](https://user-images.githubusercontent.com/5402927/32637473-ce169504-c56e-11e7-9e7a-7174542eadad.gif)
