### PR TITLE
Fix number of arguments bug in resource type index field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -175,7 +175,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'doc_subtype_ssi', label: 'Document Subtype'
     ##
     # Add format/Resource type as an index field for exhibits that are whitelisted here
-    config.add_index_field 'format_main_ssim', label: 'Resource type', if: lambda { |context, _field_config, _document|
+    config.add_index_field 'format_main_ssim', label: 'Resource type', if: lambda { |context, *_args|
       context.feature_flags.add_resource_type_index_field?
     }
     # Fields added by Zotero API BibTeX import


### PR DESCRIPTION
This fixes a number of arguments error thrown by `format_main_ssim` that was making `Configuration > Metadata` inaccessible.

Note: I had to use `*_args` instead `*args` to appease RuboCop.