### PR TITLE
single notes should not be wrapped in a ul/li

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,7 @@ module ApplicationHelper
 
   def notes_wrap(options = {})
     return if options[:value].blank?
+    return options[:value].first if options[:value].count == 1
     content_tag('ul', class: 'general-notes') do
       safe_join(options[:value].collect do |note|
         content_tag('li', note.html_safe)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,6 +23,11 @@ describe ApplicationHelper, type: :helper do
     it 'permits embedded HTML and handles multivalued notes as an unordered list' do
       expect(helper.notes_wrap(value: %w(a <p>b</p><p>c</p> d))).to eq output
     end
+    context 'single note' do
+      it 'returns the note' do
+        expect(helper.notes_wrap(value: %w(<p>stuff</p>))).to eq '<p>stuff</p>'
+      end
+    end
   end
 
   describe '#manuscript_title' do


### PR DESCRIPTION
Closes #865 

### Fixtures
`qr683hn3144`

Could not find a fixture w/ multiple notes though.. anyone know of one handy?

<img width="467" alt="screen shot 2017-11-10 at 3 34 58 pm" src="https://user-images.githubusercontent.com/1656824/32681447-ceec9622-c62c-11e7-8d05-e79d5e393271.png">
