### PR TITLE
Change 'Text title' field to 'Table of contents'

### DIFF
--- a/app/assets/javascripts/table_of_contents.js
+++ b/app/assets/javascripts/table_of_contents.js
@@ -2,7 +2,7 @@
 
 Blacklight.onLoad(function() {
 
-  $('.blacklight-text_titles_tesim').on('click', function(){
+  $('.blacklight-toc_search').on('click', function(){
     var _this = $(this);
     var linkText = $(_this).find('span');
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -150,7 +150,6 @@ class CatalogController < ApplicationController
 
     config.add_index_field 'title_full_display', label: 'Title'
     config.add_index_field 'title_variant_display', label: 'Alternate Title'
-    config.add_index_field 'text_titles_ssim', label: 'Table of Contents'
     config.add_index_field 'author_person_full_display', label: 'Author' # includes Collectors
     config.add_index_field 'author_no_collector_ssim', label: 'Author (no Collectors)'
     config.add_index_field 'editor_ssim', label: 'Editor'
@@ -196,7 +195,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
     # Fields specific to Parker Exhibit
     config.add_index_field 'incipit_tesim', label: 'Incipit'
-    config.add_index_field 'text_titles_tesim', label: 'Text title', helper_method: :table_of_contents_separator
+    config.add_index_field 'toc_search', label: 'Table of contents', helper_method: :table_of_contents_separator
     config.add_index_field 'manuscript_titles_tesim', label: 'Manuscript title', helper_method: :manuscript_title
     config.add_index_field 'manuscript_number_tesim', label: 'Manuscript number'
     config.add_index_field 'range_labels_tesim', label: 'Section'
@@ -295,17 +294,6 @@ class CatalogController < ApplicationController
         pf: 'incipit_tesim',
         pf3: 'incipit_tesim',
         pf2: 'incipit_tesim'
-      }
-      field.enabled = false
-    end
-
-    config.add_search_field('text_title') do |field|
-      field.label = 'Text title'
-      field.solr_local_parameters = {
-        qf: 'text_titles_tesim',
-        pf: 'text_titles_tesim',
-        pf3: 'text_titles_tesim',
-        pf2: 'text_titles_tesim'
       }
       field.enabled = false
     end

--- a/lib/traject/dor_config.rb
+++ b/lib/traject/dor_config.rb
@@ -229,12 +229,6 @@ to_field 'manuscript_titles_tesim' do |resource, accumulator, _context|
   end
 end
 
-to_field 'text_titles_tesim' do |resource, accumulator, _context|
-  Array(resource.smods_rec.tableOfContents.try(:content)).each do |v|
-    accumulator << v
-  end
-end
-
 to_field 'incipit_tesim' do |resource, accumulator, _context|
   Array(parse_incipit(resource)).each do |v|
     accumulator << v

--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
 
     it 'has parker-specific fields' do
       expect(document).to include incipit_tesim: ['In illo tempore maria magdalene et maria iacobi et solomae'],
-                                  text_titles_tesim: ['Homiliae XL in euangelia'],
                                   manuscript_titles_tesim: ['M.R. James Title-|-Gregorii Homiliae'],
                                   manuscript_number_tesim: ['MS 69'],
                                   toc_search: ['Homiliae XL in euangelia'],


### PR DESCRIPTION
Closes #828 

This PR:
- fixes a redundancy by removing the `text_titles_tesim` field in favor of the pre-existing `toc_search` field
- removes the `Text title` search field

## Todo
- [x] check equivalent searches
- [x] what to do with `toc_search` in `solr/config`? 

## Fixtures 
fh878gz0315
bg021sq9590
**Note:** enable annotation indexing too

## Example searches
**Everything: 'sacramento'** returns 1 manuscript, 5 page details
![everything_search_sacramento](https://user-images.githubusercontent.com/5402927/32811943-4c98c0f0-c957-11e7-9eae-9c885b14b104.png)

**Table of contents: 'sacramento'** returns 1 manuscript
![toc_search_sacramento](https://user-images.githubusercontent.com/5402927/32811942-4c6c85e4-c957-11e7-9a78-22c2e4d5481c.png)

**Everything: 'homilies'** returns 1 manuscript, 11 page details
![everything_search_homilies](https://user-images.githubusercontent.com/5402927/32811946-4cdf6b36-c957-11e7-89fe-80bebba619aa.png)

**Table of contents: 'homilies'** returns 1 manuscript
![toc_search_homilies](https://user-images.githubusercontent.com/5402927/32811945-4cb25f24-c957-11e7-80eb-7f32c1fad47b.png)
