### PR TITLE
Bugfix: collapsible ToC should only respond to Bootstrap events

### DIFF
--- a/app/assets/javascripts/table_of_contents.js
+++ b/app/assets/javascripts/table_of_contents.js
@@ -1,8 +1,7 @@
 /* global Blacklight */
 
 Blacklight.onLoad(function() {
-
-  $('.blacklight-toc_search').on('click', function(){
+  $('.blacklight-toc_search').on('show.bs.collapse hide.bs.collapse', function(){
     var _this = $(this);
     var linkText = $(_this).find('span');
 


### PR DESCRIPTION
Closes #877 

This PR fixes a bug in the collapsible `Table of contents` where Show / Hide could be toggled by clicking on the div's contents.

## Before
![toc_bug](https://user-images.githubusercontent.com/5402927/32812837-ee11f7b8-c95b-11e7-89a8-e070d109cd9c.gif)

## After
![fixed_toc](https://user-images.githubusercontent.com/5402927/32812838-ef9340ce-c95b-11e7-95e2-2d905273d08b.gif)
