### PR TITLE
only show view all metadata when mods-xml is present

### DIFF
--- a/app/views/catalog/_metadata_button_default.html.erb
+++ b/app/views/catalog/_metadata_button_default.html.erb
@@ -1,12 +1,14 @@
-<div class='container'>
-  <div class='row'>
-    <% # Using the Bootstrap container/row/col structure here to easily get this on its own line %>
-    <div class='col-md-12'>
-      <%= link_to 'View all metadata »',
-                  metadata_exhibit_solr_document_path(current_exhibit, document),
-                  data: { ajax_modal: 'trigger' },
-                  class: 'btn btn-default'
-      %>
+<% if @document.fetch(:modsxml, nil) %>
+  <div class='container'>
+    <div class='row'>
+      <% # Using the Bootstrap container/row/col structure here to easily get this on its own line %>
+      <div class='col-md-12'>
+        <%= link_to 'View all metadata »',
+                    metadata_exhibit_solr_document_path(current_exhibit, @document),
+                    data: { ajax_modal: 'trigger' },
+                    class: 'btn btn-default'
+        %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/spec/views/catalog/_metadata_button_default.html.erb_spec.rb
+++ b/spec/views/catalog/_metadata_button_default.html.erb_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'catalog/_metadata_button_default', type: :view do
+  let(:document) { SolrDocument.new(modsxml: 'stuff', id: 'abc') }
+  let(:current_exhibit) { create(:exhibit) }
+
+  before do
+    assign(:document, document)
+  end
+
+  context 'when modsxml is available' do
+    it do
+      expect(view).to receive_messages(current_exhibit: current_exhibit)
+      render
+      expect(rendered).to have_css 'a', text: 'View all metadata »'
+    end
+  end
+
+  context 'when modsxml is missing' do
+    let(:document) { SolrDocument.new }
+
+    it do
+      render
+      expect(rendered).not_to have_css 'a', text: 'View all metadata »'
+    end
+  end
+end


### PR DESCRIPTION
This makes sure the link doesn't show up on pages like canvases and bib items