### PR TITLE
display page and annotations for page-details type

### DIFF
--- a/app/controllers/mirador_controller.rb
+++ b/app/controllers/mirador_controller.rb
@@ -3,23 +3,15 @@
 ##
 # Mirador controller providing an iframeable Mirador
 class MiradorController < ApplicationController
-  before_action :set_manifest
-  before_action :set_canvas
+  before_action :set_mirador_params
   layout false
 
   def index; end
 
   private
 
-  def set_manifest
-    @manifest = mirador_params
-  end
-
-  def set_canvas
-    @canvas = params.require(:canvas) if params.require(:canvas)
-  end
-
-  def mirador_params
-    params.require(:manifest)
+  def set_mirador_params
+    @manifest = params.require(:manifest)
+    @canvas = params.fetch(:canvas, nil)
   end
 end

--- a/app/controllers/mirador_controller.rb
+++ b/app/controllers/mirador_controller.rb
@@ -4,6 +4,7 @@
 # Mirador controller providing an iframeable Mirador
 class MiradorController < ApplicationController
   before_action :set_manifest
+  before_action :set_canvas
   layout false
 
   def index; end
@@ -12,6 +13,10 @@ class MiradorController < ApplicationController
 
   def set_manifest
     @manifest = mirador_params
+  end
+
+  def set_canvas
+    @canvas = params.require(:canvas) if params.require(:canvas)
   end
 
   def mirador_params

--- a/app/models/concerns/canvas_concern.rb
+++ b/app/models/concerns/canvas_concern.rb
@@ -8,7 +8,6 @@ module CanvasConcern
   end
 
   def canvas
-    return unless canvas?
     Canvas.new(
       id,
       first('iiif_canvas_id_ssim'),

--- a/app/models/concerns/manifest_concern.rb
+++ b/app/models/concerns/manifest_concern.rb
@@ -14,7 +14,7 @@ module ManifestConcern
     return manifest if custom_manifest_pattern.blank?
     # Return early if there is not a manifest pattern (a heuristic for a non-image thing)
     return manifest if manifest.blank?
-    custom_manifest_pattern.gsub('{id}', first('canvas_parent_druid_ssi') || first('id'))
+    custom_manifest_pattern.gsub('{id}', first('related_document_id_ssim') || first('id'))
   end
 
   VALID_IIIF_CONTENT_TYPES = %w(image manuscript map book).freeze

--- a/app/views/mirador/index.html.erb
+++ b/app/views/mirador/index.html.erb
@@ -20,8 +20,15 @@
     "windowObjects": [
       {
         "loadedManifest": @manifest,
+        "canvasID": @canvas,
         "bottomPanelVisible": false,
         "annotationCreation": false,
+        "canvasControls": {
+          "annotations": {
+            "annotationLayer": true,
+            "annotationState": "on"
+          }
+        }
       }
     ]
 }) %>

--- a/app/views/viewers/_mirador.html.erb
+++ b/app/views/viewers/_mirador.html.erb
@@ -4,7 +4,7 @@
   <iframe
     src="<%= mirador_index_path(
       manifest: exhibit_specific_manifest,
-      canvas: document['iiif_canvas_id_ssim'].first
+      canvas: document.canvas.iiif_id
     ) %>"
     allowfullscreen="true"
     class="mirador-embed-wrapper"

--- a/app/views/viewers/_mirador.html.erb
+++ b/app/views/viewers/_mirador.html.erb
@@ -3,7 +3,8 @@
 <% if exhibit_specific_manifest %>
   <iframe
     src="<%= mirador_index_path(
-      manifest: exhibit_specific_manifest
+      manifest: exhibit_specific_manifest,
+      canvas: document['iiif_canvas_id_ssim'].first
     ) %>"
     allowfullscreen="true"
     class="mirador-embed-wrapper"

--- a/spec/controllers/mirador_controller_spec.rb
+++ b/spec/controllers/mirador_controller_spec.rb
@@ -4,10 +4,13 @@ require 'rails_helper'
 
 RSpec.describe MiradorController, type: :controller do
   describe '#index' do
-    before { get :index, params: { manifest: 'holla' } }
+    before { get :index, params: { manifest: 'holla', canvas: 'back' } }
     it { expect(response).to be_success }
-    it 'sets @manifest_url' do
+    it 'sets @manifest' do
       expect(assigns(:manifest)).to eq 'holla'
+    end
+    it 'sets @canvas' do
+      expect(assigns(:canvas)).to eq 'back'
     end
   end
 end


### PR DESCRIPTION
## Fixture:
`bg021sq9590`

![opening_to_page](https://user-images.githubusercontent.com/145874/32854276-f5853de2-c9f2-11e7-9858-a1fa6bc25f85.gif)

### To-do
- [x] expose correct data in action controller and indexing concerns
- [x] fix bug with manifest url building
- [x] make it conditional so it doesn't break non-"page-details" viewers 