### PR TITLE
Spotlight update: add saved searches widget

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight
-  revision: d11bc4e46086350f4946c3ac018d91b2950a2201
+  revision: 46f48f197c70a0d45a1cc404f38fecdbc71753f2
   branch: master
   specs:
-    blacklight-spotlight (1.0.0)
+    blacklight-spotlight (1.1.0)
       acts-as-taggable-on (~> 5.0)
       almond-rails (~> 0.1)
       autoprefixer-rails
@@ -462,7 +462,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.2.1)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -490,9 +490,9 @@ GEM
       roar (~> 1.1.0)
       test_xml (>= 0.1.6)
       uber (< 0.2.0)
-    rsolr (2.0.2)
+    rsolr (2.1.0)
       builder (>= 2.1.2)
-      faraday
+      faraday (>= 0.9.0)
     rspec-core (3.7.0)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -748,4 +748,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
This PR updates exhibits to Spotlight 1.1.0. This adds the Saved Searches to available widgets.

<img width="922" alt="screen shot 2017-11-16 at 12 40 35 pm" src="https://user-images.githubusercontent.com/5402927/32914757-84368c02-cacb-11e7-8165-6ba91676a700.png">
