### PR TITLE
Display single value Table of contents inline

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,6 +45,7 @@ module ApplicationHelper
   def table_of_contents_separator(options = {})
     return if options[:value].blank?
     contents = options[:value][0].split('--').map(&:strip)
+    return contents.join if contents.length == 1
     contents = safe_join(contents.map { |v| "<li>#{v}</li>".html_safe })
     id = options[:document].id
     render partial: 'catalog/table_of_contents', locals: { contents: contents, collapse_id: "collapseToc-#{id}" }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -39,14 +39,25 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe '#table_of_contents_separator' do
-    let(:input) { { document: SolrDocument.new(id: 'cf386wt1778'), value: ['Homiliae--euangelia'] } }
+    context 'single value' do
+      let(:input) { { document: SolrDocument.new(id: 'cf386wt1778'), value: ['Homiliae'] } }
 
-    it 'separates MODS table of contents' do
-      expect(helper.table_of_contents_separator(input)).to match(%r{<li>Homiliae</li><li>euangelia</li>})
+      it 'presents content inline' do
+        expect(helper.table_of_contents_separator(input)).to eq 'Homiliae'
+        expect(helper.table_of_contents_separator(input)).not_to match(/data-toggle='collapse'/)
+      end
     end
 
-    it 'collapses content' do
-      expect(helper.table_of_contents_separator(input)).to match(/data-toggle='collapse'/)
+    context 'multi-valued' do
+      let(:input) { { document: SolrDocument.new(id: 'cf386wt1778'), value: ['Homiliae--euangelia'] } }
+
+      it 'separates MODS table of contents' do
+        expect(helper.table_of_contents_separator(input)).to match(%r{<li>Homiliae</li><li>euangelia</li>})
+      end
+
+      it 'collapses content' do
+        expect(helper.table_of_contents_separator(input)).to match(/data-toggle='collapse'/)
+      end
     end
   end
 


### PR DESCRIPTION
Closes #869 

This PR changes how we handle the `Table of contents` field. Single-valued ToCs are use default display; multi-valued ToCs are hidden in a collapsing div. 

## Before
<img width="750" alt="toc_before" src="https://user-images.githubusercontent.com/5402927/32920021-a46ea82c-cadc-11e7-9839-18856d9e586a.png">

## After
<img width="653" alt="toc_after" src="https://user-images.githubusercontent.com/5402927/32920022-a4824df0-cadc-11e7-86e6-0a47e177c10c.png">
