### PR TITLE
Bugfix: restore related document IDs in Bibliography resources

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,13 +45,15 @@ module ApplicationHelper
   end
 
   def manuscript_link(options = {})
+    return if options[:value].blank?
     druid = options[:value][0]
     document = options[:document]
-    ms_number = document['manuscript_number_tesim']
-    return if druid.blank?
-    return druid if (document['format_main_ssim'] != ['Page details']) || ms_number.blank?
     title = document['title_full_display']
-    title = title.include?(':') ? title.partition(':')[2] : ms_number[0]
-    link_to title, spotlight.exhibit_solr_document_path(current_exhibit, druid)
+    link_title = if document.canvas? && title.include?(':')
+                   title.partition(':')[2]
+                 else
+                   druid
+                 end
+    link_to link_title, spotlight.exhibit_solr_document_path(current_exhibit, druid)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,13 +45,13 @@ module ApplicationHelper
   end
 
   def manuscript_link(options = {})
-    druid = options[:value]
+    druid = options[:value][0]
     document = options[:document]
     ms_number = document['manuscript_number_tesim']
-    return if druid.blank? || ms_number.blank?
-    return druid if document['format_main_ssim'] != ['Page details']
+    return if druid.blank?
+    return druid if (document['format_main_ssim'] != ['Page details']) || ms_number.blank?
     title = document['title_full_display']
     title = title.include?(':') ? title.partition(':')[2] : ms_number[0]
-    link_to title, spotlight.exhibit_solr_document_path(current_exhibit, druid[0])
+    link_to title, spotlight.exhibit_solr_document_path(current_exhibit, druid)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -56,7 +56,9 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe '#manuscript_link' do
-    let(:input) { { value: ['bg021sq9590'], document: document } }
+    let(:druid) { 'bg021sq9590' }
+    let(:input) { { value: [druid], document: document } }
+    let(:show_page) { "/test-flag-exhibit-slug/catalog/#{druid}" }
 
     before do
       helper.extend(Module.new do
@@ -68,7 +70,6 @@ describe ApplicationHelper, type: :helper do
 
     context 'page details' do
       let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
-      let(:show_page) { '/test-flag-exhibit-slug/catalog/bg021sq9590' }
       let(:document) do
         SolrDocument.new(
           title_full_display: "p. 3:#{title}",
@@ -91,7 +92,7 @@ describe ApplicationHelper, type: :helper do
       end
 
       it 'displays druid for Bibliography resources' do
-        expect(helper.manuscript_link(input)).to eq 'bg021sq9590'
+        expect(helper.manuscript_link(input)).to have_link(text: druid, href: show_page)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -56,15 +56,6 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe '#manuscript_link' do
-    let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
-    let(:show_page) { '/test-flag-exhibit-slug/catalog/bg021sq9590' }
-    let(:document) do
-      SolrDocument.new(
-        title_full_display: "p. 3:#{title}",
-        manuscript_number_tesim: ['MS 198'],
-        format_main_ssim: ['Page details']
-      )
-    end
     let(:input) { { value: ['bg021sq9590'], document: document } }
 
     before do
@@ -75,8 +66,33 @@ describe ApplicationHelper, type: :helper do
       end)
     end
 
-    it 'removes page prefix' do
-      expect(helper.manuscript_link(input)).to have_link(text: title, href: show_page)
+    context 'page details' do
+      let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
+      let(:show_page) { '/test-flag-exhibit-slug/catalog/bg021sq9590' }
+      let(:document) do
+        SolrDocument.new(
+          title_full_display: "p. 3:#{title}",
+          manuscript_number_tesim: ['MS 198'],
+          format_main_ssim: ['Page details']
+        )
+      end
+
+      it 'removes page prefix if present' do
+        expect(helper.manuscript_link(input)).to have_link(text: title, href: show_page)
+      end
+    end
+
+    context 'bibilography resource' do
+      let(:document) do
+        SolrDocument.new(
+          title_full_display: 'A Zotero reference',
+          format_main_ssim: ['Bibliography']
+        )
+      end
+
+      it 'displays druid for Bibliography resources' do
+        expect(helper.manuscript_link(input)).to eq 'bg021sq9590'
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #908 

This PR restores expected behavior to the `related_document_ssim` / Manuscript field for Bibliography resources. 

## Before
<img width="1209" alt="screen shot 2017-11-16 at 3 33 23 pm" src="https://user-images.githubusercontent.com/5402927/32921970-c769d092-cae4-11e7-8f79-f994257e1b17.png">

## After
![linked_druid](https://user-images.githubusercontent.com/5402927/32971446-1ce38c80-cba2-11e7-9c72-afb4974d62d5.png)
