### PR TITLE
must evaluate scss variable in calc function

### DIFF
--- a/app/assets/stylesheets/modules/view_metadata.scss
+++ b/app/assets/stylesheets/modules/view_metadata.scss
@@ -14,7 +14,7 @@
     }
   }
   .modal-body {
-    max-height: calc(100vh - $modal-header-footer-height-guess);
+    max-height: calc(100vh - #{$modal-header-footer-height-guess});
     overflow-y: auto;
   }
 }


### PR DESCRIPTION
Fixes an issue where the max-height wasn't being parsed correctly b/c it needs to be evaluated within the context of a calc function.