### PR TITLE
add Purl-like styling for MODS metadata display dl/dt/dd

### DIFF
--- a/app/assets/stylesheets/modules/view_metadata.scss
+++ b/app/assets/stylesheets/modules/view_metadata.scss
@@ -5,6 +5,28 @@
   .view-in-modal {
     display: none;
   }
+
+  .modal-body {
+    dl {
+      margin-bottom: 2em;
+    }
+
+    dt {
+      color: $gray-41-percent;
+      font-size: 0.9em;
+      font-weight: normal;
+      padding-right: 1em;
+      padding-top: 0.15em;
+      text-transform: uppercase !important;
+      width: 12em;
+    }
+
+    dd {
+      margin-bottom: 0.5em;
+      margin-left: 2em;
+      max-width: 45em;
+    }
+  }
 }
 
 #ajax-modal {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -7,6 +7,7 @@ $sul-masthead-bg-color: $color-beige-10;
 $sul-masthead-border-color: $color-beige-20;
 $brand-primary: $color-cardinal-red;
 $black: $color-blackish;
+$gray-41-percent: #696969;
 $color-gray-80: #ccc;
 
 // Make default a beige button

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Metadata display' do
   it 'view metadata link links through to page' do
     click_link 'View all metadata »'
     expect(page).to have_css 'h3', text: 'Metadata: Afrique Physique.'
-    expect(page).to have_css 'dt', text: 'Title'
+    expect(page).to have_css 'dt', text: /Title/i
     expect(page).to have_css 'dd', text: 'Afrique Physique.'
     expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
   end
@@ -20,7 +20,7 @@ RSpec.feature 'Metadata display' do
     click_link 'View all metadata »'
     within '#ajax-modal' do
       expect(page).to have_css 'h3', text: 'Metadata: Afrique Physique.'
-      expect(page).to have_css 'dt', text: 'Title'
+      expect(page).to have_css 'dt', text: /Title/i
       expect(page).to have_css 'dd', text: 'Afrique Physique.'
       expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
     end


### PR DESCRIPTION
This PR partially addresses #910 . It updates the dt/dl/dd styling for the MODS display modal to be more like SW/Purl.

### Before
<img width="589" alt="screen shot 2017-11-17 at 5 33 20 pm" src="https://user-images.githubusercontent.com/5402927/32975693-d4bd18fa-cbbe-11e7-89df-643d3898b8b5.png">


### After
![screen shot 2017-11-17 at 12 20 13 pm](https://user-images.githubusercontent.com/1861171/32967232-b87d97d2-cb91-11e7-9c1e-bd504d5ddc8f.png)
