### PR TITLE
Remove Parker-specific manuscript title field and search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -198,7 +198,6 @@ class CatalogController < ApplicationController
     # Fields specific to Parker Exhibit
     config.add_index_field 'incipit_tesim', label: 'Incipit'
     config.add_index_field 'toc_search', label: 'Table of contents', helper_method: :table_of_contents_separator
-    config.add_index_field 'manuscript_titles_tesim', label: 'Manuscript title', helper_method: :manuscript_title
     config.add_index_field 'manuscript_number_tesim', label: 'Manuscript number'
     config.add_index_field 'range_labels_tesim', label: 'Section'
     config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link
@@ -296,17 +295,6 @@ class CatalogController < ApplicationController
         pf: 'incipit_tesim',
         pf3: 'incipit_tesim',
         pf2: 'incipit_tesim'
-      }
-      field.enabled = false
-    end
-
-    config.add_search_field('manuscript_title') do |field|
-      field.label = 'Manuscript title'
-      field.solr_local_parameters = {
-        qf: 'manuscript_titles_tesim',
-        pf: 'manuscript_titles_tesim',
-        pf3: 'manuscript_titles_tesim',
-        pf2: 'manuscript_titles_tesim'
       }
       field.enabled = false
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,13 +35,6 @@ module ApplicationHelper
     end
   end
 
-  def manuscript_title(options = {})
-    return if options[:value].blank?
-    safe_join(options[:value].collect do |title|
-      title.split('-|-').join(' - ')
-    end, ',')
-  end
-
   def table_of_contents_separator(options = {})
     return if options[:value].blank?
     contents = options[:value][0].split('--').map(&:strip)

--- a/lib/traject/dor_config.rb
+++ b/lib/traject/dor_config.rb
@@ -199,24 +199,7 @@ end)
 
 to_field 'manuscript_number_tesim', (accumulate { |resource, *_| resource.smods_rec.location.shelfLocator.try(:text) })
 
-# We need to join the `displayLabel` and titles for all *alternative* titles
-# `title_variant_display` has different behavior
-to_field 'manuscript_titles_tesim', (accumulate { |resource, *_| parse_manuscript_titles(resource) })
 to_field 'incipit_tesim', (accumulate { |resource, *_| parse_incipit(resource) })
-
-# parse titleInfo[type="alternative"]/title into tuples of (displayLabel, title)
-def parse_manuscript_titles(sdb)
-  manuscript_titles = []
-  sdb.smods_rec.title_info.each do |title_info|
-    next unless title_info.attr('type') == 'alternative'
-    display_label = title_info.attr('displayLabel')
-    title_info.at_xpath('*[local-name()="title"]').tap do |title|
-      label_with_title = [display_label, title.content].map(&:to_s).map(&:strip)
-      manuscript_titles << label_with_title.join('-|-')
-    end
-  end
-  manuscript_titles
-end
 
 def parse_incipit(sdb)
   sdb.smods_rec.related_item.each do |item|

--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
 
     it 'has parker-specific fields' do
       expect(document).to include incipit_tesim: ['In illo tempore maria magdalene et maria iacobi et solomae'],
-                                  manuscript_titles_tesim: ['M.R. James Title-|-Gregorii Homiliae'],
                                   manuscript_number_tesim: ['MS 69'],
                                   toc_search: ['Homiliae XL in euangelia'],
                                   url_suppl: ['https://purl.stanford.edu/kd310gm7424', 'https://purl.stanford.edu/dx969tv9730']

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,12 +32,6 @@ describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#manuscript_title' do
-    it 'adds basic support of display label' do
-      expect(helper.manuscript_title(value: ['Label-|-Stuff'])).to eq 'Label - Stuff'
-    end
-  end
-
   describe '#table_of_contents_separator' do
     context 'single value' do
       let(:input) { { document: SolrDocument.new(id: 'cf386wt1778'), value: ['Homiliae'] } }


### PR DESCRIPTION
Closes #872 

This PR deprecates the Parker-specific `Manuscript title` field. This changes the app in the following places:
- removes `Manuscript title` search
- removes `manuscript_titles_tesim` from indexing and catalog controller

**Note:** manuscript titles will still be visible on the show page as `Alternate title` and indexed into `title_variant_display`. Alternative titles with a `displayLabel` value (e.g. **M.R. James Title**) can be found in the metadata modal. 

## Before
### Show page
![screen shot 2017-11-15 at 3 35 09 pm](https://user-images.githubusercontent.com/5402927/32866045-b1aca8f8-ca1a-11e7-8ff4-3b7c03228a9d.png)

## After
### Show page
![screen shot 2017-11-15 at 3 38 47 pm](https://user-images.githubusercontent.com/5402927/32866160-19fdab96-ca1b-11e7-9012-5eac296c2e32.png)

### Modal
<img width="602" alt="screen shot 2017-11-15 at 12 00 51 pm" src="https://user-images.githubusercontent.com/5402927/32857523-f1e85a3e-c9fc-11e7-8ea5-0978bacd17b7.png">