### PR TITLE
Remove extra title in metadata modal

### DIFF
--- a/app/views/catalog/_metadata.html.erb
+++ b/app/views/catalog/_metadata.html.erb
@@ -1,3 +1,3 @@
-<%= @document.mods.to_html.html_safe %>
+<%= @document.mods.body.html_safe %>
 
 <%= render 'metadata_rights_access' %>

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -13,16 +13,16 @@ RSpec.feature 'Metadata display' do
     it 'view metadata link links through to page' do
       click_link 'View all metadata »'
       expect(page).to have_css 'h3', text: 'Metadata: Afrique Physique.'
-      expect(page).to have_css 'dt', text: /Title/i
-      expect(page).to have_css 'dd', text: 'Afrique Physique.'
+      expect(page).not_to have_css 'dt', text: 'Title:'
+      expect(page).not_to have_css 'dd', text: 'Afrique Physique.'
       expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
     end
     it 'opens view metadata in modal', js: true do
       click_link 'View all metadata »'
       within '#ajax-modal' do
         expect(page).to have_css 'h3', text: 'Metadata: Afrique Physique.'
-        expect(page).to have_css 'dt', text: /Title/i
-        expect(page).to have_css 'dd', text: 'Afrique Physique.'
+        expect(page).not_to have_css 'dt', text: 'Title:'
+        expect(page).not_to have_css 'dd', text: 'Afrique Physique.'
         expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
       end
     end


### PR DESCRIPTION
Closes #922 

This PR removes the `Title` field from the labeled metadata. The title is already displayed in the modal as an `<h3>`. 


## Before
![showing extra title in metadata list](https://user-images.githubusercontent.com/5402927/33093047-bcdc7222-ceb0-11e7-91b3-dde194fbca64.png)

## After
![hiding extra title in metadata list](https://user-images.githubusercontent.com/5402927/33093056-c54e10dc-ceb0-11e7-9be4-544444d2fb6c.png)
