### PR TITLE
add Mirador page jumper plugin ++ @aeschylus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Users can now quickly navigate pages in Mirador using a drop down selection #937
 ### Changed
 ### Deprecated
 ### Removed

--- a/app/assets/javascripts/mirador_bundle.js
+++ b/app/assets/javascripts/mirador_bundle.js
@@ -1,1 +1,2 @@
 //= require mirador
+//= require jump_to_page

--- a/app/assets/stylesheets/mirador_bundle.scss
+++ b/app/assets/stylesheets/mirador_bundle.scss
@@ -1,3 +1,9 @@
 @import "font-awesome";
 @import "material_icons";
 @import "mirador-combined";
+
+.mirador-viewer {
+  .page-select {
+    margin-right: 5px;
+  }
+}

--- a/vendor/assets/javascripts/jump_to_page.js
+++ b/vendor/assets/javascripts/jump_to_page.js
@@ -1,0 +1,32 @@
+(function() {
+  var originalWindowInit = Mirador.Window.prototype.init;
+
+  var template = Mirador.Handlebars.compile([
+    '<select class="{{selectClassName}}">',
+    '{{#canvases}}',
+    '<option value="{{id}}">{{label}}</option>',
+    '{{/canvases}}',
+    '</select>'
+  ].join(''));
+
+  Mirador.Window.prototype.init = function(){
+    var windowObj = this;
+
+    originalWindowInit.apply(windowObj);
+
+    var canvases = windowObj.imagesList.map(function(canvas){
+      canvas.id = canvas['@id'];
+      return canvas;
+    });
+
+    windowObj.element.find('.window-manifest-navigation').prepend(template({
+      'selectClassName': 'page-select',
+      'canvases': canvases
+    }));
+
+    windowObj.element.find('.page-select').on('change', function(event) {
+      var canvasID = jQuery(this).val();
+      windowObj.eventEmitter.publish('SET_CURRENT_CANVAS_ID.' + windowObj.id, canvasID);
+    });
+  };
+})();


### PR DESCRIPTION
Closes #929 
Closes #771 

![pagejumper](https://user-images.githubusercontent.com/1656824/33147811-40c0318c-cf97-11e7-84b7-db21fa283328.gif)

All of the credit here goes to @aeschylus  for creating a Mirador plugin. This just integrates it into exhibits.