### PR TITLE
Remove 'Metadata:' from modal title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Users can now quickly navigate pages in Mirador using a drop down selection #937
 ### Changed
+- Removed "Metadata: " from metadata modal title #943
 ### Deprecated
 ### Removed
 ### Fixed

--- a/app/views/catalog/metadata.html.erb
+++ b/app/views/catalog/metadata.html.erb
@@ -1,7 +1,7 @@
 <div class='view-metadata'>
   <div class='modal-header'>
     <button type='button' class='ajax-modal-close close' data-dismiss='modal' aria-hidden='true'>×</button>
-    <h3 class='modal-title'>Metadata: <%= presenter(@document).heading %></h3>
+    <h3 class='modal-title'><%= presenter(@document).heading %></h3>
   </div>
   <div class='modal-body'>
     <%= render partial: 'metadata' %>

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Metadata display' do
 
     it 'view metadata link links through to page' do
       click_link 'View all metadata »'
-      expect(page).to have_css 'h3', text: 'Metadata: Afrique Physique.'
+      expect(page).to have_css 'h3', text: 'Afrique Physique.'
       expect(page).not_to have_css 'dt', text: 'Title:'
       expect(page).not_to have_css 'dd', text: 'Afrique Physique.'
       expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
@@ -20,7 +20,7 @@ RSpec.feature 'Metadata display' do
     it 'opens view metadata in modal', js: true do
       click_link 'View all metadata »'
       within '#ajax-modal' do
-        expect(page).to have_css 'h3', text: 'Metadata: Afrique Physique.'
+        expect(page).to have_css 'h3', text: 'Afrique Physique.'
         expect(page).not_to have_css 'dt', text: 'Title:'
         expect(page).not_to have_css 'dd', text: 'Afrique Physique.'
         expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'


### PR DESCRIPTION
Closes #940 

This PR removes "Metadata:" from our metadata modal title. 

## Before
![before_metdata_modal](https://user-images.githubusercontent.com/5402927/33284870-51934a54-d365-11e7-8ae5-598edebf56ee.png)

## After
![after_metadata_modal](https://user-images.githubusercontent.com/5402927/33284869-5175274a-d365-11e7-8fba-8becf2528075.png)
