### PR TITLE
Suppress 'Contents' in Parker metadata modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 ### Deprecated
 ### Removed
+- Table of contents will not be displayed in the Parker exhibit metadata modal #944
 ### Fixed
 ### Security
 

--- a/app/assets/stylesheets/modules/parker.scss
+++ b/app/assets/stylesheets/modules/parker.scss
@@ -2,3 +2,10 @@
 #global-footer {
   display: none;
 }
+
+.view-metadata {
+  dt[title='Contents'],
+  dt[title='Contents'] + dd {
+    display: none;
+  }
+}


### PR DESCRIPTION
Discussion #910 
Closes #941

This PR suppresses "Contents" in the Parker exhibit metadata modal. The information is made redundant by "Related Items". This approach adds a CSS rule to the Parker-only theme. 

## Before
![contents_showing](https://user-images.githubusercontent.com/5402927/33285765-2188bd78-d368-11e7-8afe-93b0a0241133.png)

## After
![contents_suppressed](https://user-images.githubusercontent.com/5402927/33285767-219d37a8-d368-11e7-9d5a-350c246b7391.png)

