### PR TITLE
hide bibtex partial behind feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 ### Changed
+- BibTeX upload form is now only shown for Exhibits in which it is explicitly enabled through a feature flag #946
 ### Deprecated
 ### Removed
 ### Fixed

--- a/app/views/bibliography_resources/_form.html.erb
+++ b/app/views/bibliography_resources/_form.html.erb
@@ -8,4 +8,6 @@
       </div>
     </div>
   <% end if can? :manage, @resource %>
+<% else %>
+  This feature is not currently available for this exhibit.
 <% end %>

--- a/app/views/bibliography_resources/_form.html.erb
+++ b/app/views/bibliography_resources/_form.html.erb
@@ -1,9 +1,11 @@
-<%= bootstrap_form_for([current_exhibit, @resource.becomes(BibliographyResource)], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-6', as: :resource) do |f| %>
-  <%= f.file_field :bibtex_file, label: 'BibTeX File', class: 'form-control', control_col: 'col-sm-6', required: true, accept: 'application/x-bibtex', help: 'Each BibTeX file entry will be added as an exhibit item with a “Reference” resource type.'  %>
-  <div class="form-actions">
-    <div class="primary-actions">
-      <%= cancel_link @resource, :back, class: 'btn btn-default' %>
-      <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
+<% if feature_flags.bibliography_resource? %>
+  <%= bootstrap_form_for([current_exhibit, @resource.becomes(BibliographyResource)], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-6', as: :resource) do |f| %>
+    <%= f.file_field :bibtex_file, label: 'BibTeX File', class: 'form-control', control_col: 'col-sm-6', required: true, accept: 'application/x-bibtex', help: 'Each BibTeX file entry will be added as an exhibit item with a “Reference” resource type.'  %>
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= cancel_link @resource, :back, class: 'btn btn-default' %>
+        <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
+      </div>
     </div>
-  </div>
-<% end if can? :manage, @resource %>
+  <% end if can? :manage, @resource %>
+<% end %>

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -5,8 +5,7 @@ Spotlight::Engine.config.upload_fields = [
   OpenStruct.new(field_name: 'date', solr_field: %w(spotlight_upload_date_tesim date_sort), label: 'Date')
 ]
 Spotlight::Engine.config.default_contact_email = Settings.default_contact_email
-Spotlight::Engine.config.external_resources_partials += ['dor_harvester/form']
-Spotlight::Engine.config.external_resources_partials += ['bibliography_resources/form'] if FeatureFlags.new.bibliography_resource?
+Spotlight::Engine.config.external_resources_partials += ['dor_harvester/form', 'bibliography_resources/form']
 
 Spotlight::Resources::Upload.document_builder_class = ::UploadSolrDocumentBuilder
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -12,5 +12,6 @@ feature_flags:
   bibliography_resource: true
   test-flag-exhibit-slug:
     test_thing: true
+    bibliography_resource: false
     index_related_content: true
     add_resource_type_index_field: true

--- a/spec/features/bibliography_indexing_spec.rb
+++ b/spec/features/bibliography_indexing_spec.rb
@@ -25,4 +25,16 @@ RSpec.feature 'Bibliography indexing', type: :feature do
     expect(page).to have_css 'h5', text: /Quelques/
     expect(page).to have_css '.alert-info', text: 'Your bibliography resource has been successfully created.'
   end
+  context 'when disabled' do
+    let(:exhibit) { create(:exhibit, slug: 'test-flag-exhibit-slug') }
+
+    it 'is not visible' do
+      visit spotlight.new_exhibit_resource_path(exhibit)
+      click_link 'BibTeX'
+      within '#external_resource_tab_1' do
+        expect(page).not_to have_content 'Add items'
+      end
+      expect(page).to have_content 'This feature is not currently available for this exhibit.'
+    end
+  end
 end


### PR DESCRIPTION
This hides the ability for non-configured exhibits to index bibtex files, but unfortunately still shows the "pill" link.

![disablebib](https://user-images.githubusercontent.com/1656824/33445924-6fd46da4-d5cc-11e7-802c-90ddb8a8f05f.gif)
