### PR TITLE
for specs stub out oembed async requests

### DIFF
--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -1,0 +1,5 @@
+if Rails.env.test?
+  require 'webmock/rspec'
+  WebMock.allow_net_connect!
+  WebMock.stub_request(:get, /embed\.json/) # For async page loads for oEmbed
+end


### PR DESCRIPTION
This PR is to fix the following warnings on Travis builds. AFAICT this needs to be done at the server initializer stage.

```
.2017-11-28 21:48:54 +0000: Rack app error handling request { GET /oembed/embed }
#<WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://purl.stanford.edu/embed.json?hide_title=true&url=https://purl.stanford.edu/xy658qf4887 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Mozilla/5.0 (compatible; ruby-oembed/0.12.0)'}
You can stub this request with the following snippet:
stub_request(:get, "http://purl.stanford.edu/embed.json?hide_title=true&url=https://purl.stanford.edu/xy658qf4887").
  with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Mozilla/5.0 (compatible; ruby-oembed/0.12.0)'}).
  to_return(status: 200, body: "", headers: {})
```