### PR TITLE
Add toggle all link to nested related items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Adds an "Expand all" link to nested related items in the full metadata display #960
 ### Changed
 ### Deprecated
 ### Removed

--- a/app/assets/javascripts/nested_related_items.js
+++ b/app/assets/javascripts/nested_related_items.js
@@ -14,18 +14,19 @@
         _this.addToggleLink($(this));
       });
 
-      _this.addToggleAll();
-      _this.toggleAll();
+      _this.addToggleAll(el);
+      _this.toggleAll(el);
     },
 
     listItems: function(list) {
       return list.find(this.options.itemSelector);
     },
 
-    addToggleAll: function() {
-      var title = $('dt[title="Contains"]');
-      $(title).append('<a href="javascript:;" id="toggleAll" class="mods_display_related_item_label">Expand all</a>');
-      $(title).attr('id', 'mods_display_related_item_dt');
+    addToggleAll: function(content) {
+      // find the preceding <dt>
+      var title = $(content).parents('dd').prev();
+      title.append('<a href="javascript:;" id="toggleAll" class="mods_display_related_item_label">Expand all</a>');
+      title.attr('id', 'mods_display_related_item_dt');
     },
 
     addToggleLink: function(content) {
@@ -53,20 +54,19 @@
       return link;
     },
 
-    toggleAll: function() {
+    toggleAll: function(content) {
       var _this = this;
-
       $('#toggleAll').on('click', function(){
         var toggleLink  = $(this);
         toggleLink.toggleClass('open');
-        toggleLink.text(($(this).text() == 'Collapse all') ? 'Expand all' : 'Collapse all');
-        var links =  $('.mods_display_nested_related_item');
+        toggleLink.text((toggleLink.text() == 'Collapse all') ? 'Expand all' : 'Collapse all');
+        var links =  _this.listItems(content);
 
         // Handle mixed lists of open / closed items
         if (toggleLink.hasClass('open')){
-          links = $(links).not('.open').find('a');
+          links = links.not('.open').find('a');
         } else {
-          links = $(links).filter($('.open')).find('a');
+          links = links.filter($('.open')).find('a');
         }
         links.each(function(){
           _this.toggleMetadata($(this));

--- a/app/assets/javascripts/nested_related_items.js
+++ b/app/assets/javascripts/nested_related_items.js
@@ -13,10 +13,19 @@
         $(this).removeClass('open');
         _this.addToggleLink($(this));
       });
+
+      _this.addToggleAll();
+      _this.toggleAll();
     },
 
     listItems: function(list) {
       return list.find(this.options.itemSelector);
+    },
+
+    addToggleAll: function() {
+      var title = $('dt[title="Contains"]');
+      $(title).append('<a href="javascript:;" id="toggleAll" class="mods_display_related_item_label">Expand all</a>');
+      $(title).attr('id', 'mods_display_related_item_dt');
     },
 
     addToggleLink: function(content) {
@@ -42,6 +51,27 @@
       });
 
       return link;
+    },
+
+    toggleAll: function() {
+      var _this = this;
+
+      $('#toggleAll').on('click', function(){
+        var toggleLink  = $(this);
+        toggleLink.toggleClass('open');
+        toggleLink.text(($(this).text() == 'Collapse all') ? 'Expand all' : 'Collapse all');
+        var links =  $('.mods_display_nested_related_item');
+
+        // Handle mixed lists of open / closed items
+        if (toggleLink.hasClass('open')){
+          links = $(links).not('.open').find('a');
+        } else {
+          links = $(links).filter($('.open')).find('a');
+        }
+        links.each(function(){
+          _this.toggleMetadata($(this));
+        });
+      });
     },
 
     toggleMetadata: function(item) {

--- a/app/assets/stylesheets/modules/related_item.scss
+++ b/app/assets/stylesheets/modules/related_item.scss
@@ -1,19 +1,32 @@
+@mixin toggle-arrow {
+  &::before {
+    content: "\00BB ";
+    display: inline-block;
+    font-size: 1.2em;
+    padding-right: 5px;
+  }
+
+  &.open::before {
+    transform: rotate(90deg);
+  }
+}
+
+#mods_display_related_item_dt {
+  width: 20em;
+}
+
+.mods_display_related_item_label {
+  @include toggle-arrow;
+  display: inline-block;
+  margin-left: 0.5em;
+}
+
 .mods_display_nested_related_items {
   list-style: none;
   padding-left: 0;
 
   .mods_display_nested_related_item {
-    &::before {
-      content: "\00BB ";
-      display: inline-block;
-      font-size: 1.2em;
-      padding-right: 5px;
-    }
-
-    &.open::before {
-      transform: rotate(90deg);
-    }
-
+    @include toggle-arrow;
     dl {
       margin-bottom: 0;
       margin-left: 12px;

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -56,5 +56,18 @@ RSpec.feature 'Metadata display' do
         expect(page).to have_css('dd', text: 'Constituent note')
       end
     end
+
+    it 'can toggle all' do
+      click_link 'Expand all'
+      within '.mods_display_nested_related_items' do
+        expect(page).to have_css('dl', visible: true)
+        expect(page).to have_css('dt', text: /Note:/i)
+      end
+      click_link 'Collapse all'
+      within '.mods_display_nested_related_items' do
+        expect(page).to have_css('dl', visible: false)
+        expect(page).to have_css('li a', text: 'Constituent Title')
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #947

This PR adds an "Expand / Collapse all" link to nested related items in the metadata display.

Todo: 
- [x]  update specs
- [x] appease 🐺 and 👮
- [x]  update Changelog

## Before
![nested-related-items](https://user-images.githubusercontent.com/96776/33156438-9a1f4f80-cfae-11e7-823d-d550dabad4a7.gif)


## After
![toggle-all](https://user-images.githubusercontent.com/5402927/33396527-a1033696-d4fd-11e7-95af-5e521af89fb6.gif)
