### PR TITLE
Update background color of body for Parker theme

### DIFF
--- a/app/assets/stylesheets/modules/parker.scss
+++ b/app/assets/stylesheets/modules/parker.scss
@@ -1,3 +1,7 @@
+body {
+  background-color: $color-beige-05;
+}
+
 .sul-footer,
 #global-footer {
   display: none;


### PR DESCRIPTION
As part of #443, this just changes the background color of the body element in the Parker exhibit to 1) make Parker a bit distinct from the regular SUL exhibits, and 2) use a background color that complements the predominant "mansuscripty" colors of the Parker exhibit.

<img width="604" alt="bgcolor-beige-05" src="https://user-images.githubusercontent.com/101482/33449930-701fc1b4-d5c7-11e7-985a-ce650a8ca834.png">
