### PR TITLE
Allow nested items JS execution in metadata modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixes a bug in the metadata modal where nested related items toggle was unavailable #965
 ### Security
 
 ## [1.10.0] - 2017-11-27

--- a/app/assets/javascripts/nested_related_items.js
+++ b/app/assets/javascripts/nested_related_items.js
@@ -87,6 +87,14 @@
 Blacklight.onLoad(function () {
   'use strict';
 
+  // Load JS in Bootstrap modal
+  $('#ajax-modal').on('shown.bs.modal', function () {
+    $('.mods_display_nested_related_items').each(function (i, element) {
+      NestedRelatedItems.init($(element)); // eslint-disable-line no-undef
+    });
+  });
+
+  // Metadata page
   $('.mods_display_nested_related_items').each(function (i, element) {
     NestedRelatedItems.init($(element)); // eslint-disable-line no-undef
   });

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -42,31 +42,47 @@ RSpec.feature 'Metadata display' do
   end
 
   describe 'nested related items', js: true do
-    before do
-      visit metadata_exhibit_solr_document_path(exhibit_id: exhibit.slug, id: 'gk885tn1705')
-    end
-
-    it 'are togglable' do
-      within '.mods_display_nested_related_items' do
-        expect(page).to have_css('dl', visible: false)
-        expect(page).to have_css('li a', text: 'Constituent Title')
-        click_link 'Constituent Title'
-        expect(page).to have_css('dl', visible: true)
-        expect(page).to have_css('dt', text: /Note:/i)
-        expect(page).to have_css('dd', text: 'Constituent note')
+    context 'in modal' do
+      it 'are togglable' do
+        visit spotlight.exhibit_solr_document_path(exhibit_id: exhibit.slug, id: 'gk885tn1705')
+        click_link 'View all metadata »'
+        within '#ajax-modal' do
+          within '.mods_display_nested_related_items' do
+            expect(page).to have_css('dl', visible: false)
+            click_link 'Constituent Title'
+            expect(page).to have_css('dl', visible: true)
+          end
+        end
       end
     end
 
-    it 'can toggle all' do
-      click_link 'Expand all'
-      within '.mods_display_nested_related_items' do
-        expect(page).to have_css('dl', visible: true)
-        expect(page).to have_css('dt', text: /Note:/i)
+    context 'metadata page' do
+      before do
+        visit metadata_exhibit_solr_document_path(exhibit_id: exhibit.slug, id: 'gk885tn1705')
       end
-      click_link 'Collapse all'
-      within '.mods_display_nested_related_items' do
-        expect(page).to have_css('dl', visible: false)
-        expect(page).to have_css('li a', text: 'Constituent Title')
+
+      it 'are togglable' do
+        within '.mods_display_nested_related_items' do
+          expect(page).to have_css('dl', visible: false)
+          expect(page).to have_css('li a', text: 'Constituent Title')
+          click_link 'Constituent Title'
+          expect(page).to have_css('dl', visible: true)
+          expect(page).to have_css('dt', text: /Note:/i)
+          expect(page).to have_css('dd', text: 'Constituent note')
+        end
+      end
+
+      it 'can toggle all' do
+        click_link 'Expand all'
+        within '.mods_display_nested_related_items' do
+          expect(page).to have_css('dl', visible: true)
+          expect(page).to have_css('dt', text: /Note:/i)
+        end
+        click_link 'Collapse all'
+        within '.mods_display_nested_related_items' do
+          expect(page).to have_css('dl', visible: false)
+          expect(page).to have_css('li a', text: 'Constituent Title')
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #963 

This PR fixes JS loading in the metadata modal, which makes collapsing / expanding nested related items available. 

**Note**: [info on Bootstrap modal events](https://getbootstrap.com/docs/3.3/javascript/#modals-events)

## pm049bv8195
### Before
![non_collapsed_nested_items](https://user-images.githubusercontent.com/5402927/33455843-2e7ad842-d5d2-11e7-94fc-a230cafbd0d7.png)

### After
![collapsed_nested_items](https://user-images.githubusercontent.com/5402927/33455844-2e93a9b2-d5d2-11e7-8d2b-144901f014ef.png)
