### PR TITLE
Change confirmation instructions email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added ability to view the index status individual items in an exhibit by autocompleting for druid (only applies to exhibits with > 10 item druids) #1013
 ### Changed
 - Masonry, Gallery, and Slideshow views only display title by default #1011
+- Changes text of confirmation email for new curators / admins #976
 ### Deprecated
 ### Removed
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'letter_opener'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,11 +345,15 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     latex-decode (0.3.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     leaflet-rails (1.2.0)
       rails (>= 4.2.0)
     leaflet-sidebar-rails (0.2.0)
     legato (0.7.0)
       multi_json
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -718,6 +722,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   jsonpath
+  letter_opener
   listen (>= 3.0.5, < 3.2)
   mirador_rails
   mods_display

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -13,4 +13,11 @@
 
 <p><%= t("spotlight.#{key}.invitation_instructions.ignore_html", exhibit_name: @resource.roles.first.resource.title) %></p>
 
-<p><%= t("spotlight.#{key}.invitation_instructions.reference_links_text_html", :href => link_to(t("spotlight.#{key}.invitation_instructions.reference_links_href"), "http://exhibits.stanford.edu"), :mailto => mail_to(t("spotlight.#{key}.invitation_instructions.mail_to_href"))) %></p>
+<p><%= t("spotlight.#{key}.invitation_instructions.spotlight_at_sul_html", :href => link_to(t("spotlight.#{key}.invitation_instructions.spotlight_at_sul_href"), t("spotlight.#{key}.invitation_instructions.about_spotlight_href"))) %></p>
+
+
+<p><%= t("spotlight.#{key}.invitation_instructions.all_exhibits_html", :href => link_to(t("spotlight.#{key}.invitation_instructions.all_exhibits_href"), t("spotlight.#{key}.invitation_instructions.all_exhibits_href"))) %></p>
+
+<p><%= t("spotlight.#{key}.invitation_instructions.get_help_html",  :mailto => mail_to(t("spotlight.#{key}.invitation_instructions.mail_to_href"))) %></p>
+
+<p><%= t("spotlight.#{key}.invitation_instructions.closing_html", :mailto => mail_to(t("spotlight.#{key}.invitation_instructions.mail_to_href"))) %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,6 +26,9 @@ Exhibits::Application.configure do
     config.cache_store = :null_store
   end
 
+  # Open emails in a web browser
+  config.action_mailer.delivery_method = :letter_opener
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       confirmation_instructions:
         subject: "Confirmation instructions"
       invitation_instructions:
-        subject: 'SUL exhibit invitation instructions'
+        subject: 'Spotlight at Stanford Exhibits - Confirmation Instructions'
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -2,12 +2,27 @@ en:
   spotlight:
     invitation_mailer:
       invitation_instructions:
-        someone_invited_you: 'The SUL Exhibits Administrator has invited you to help work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking the link below.'
-        ignore_html: "If you don't want to accept the invitation, please ignore this email. You won't be added to the \"%{exhibit_name}\" exhibit team until you access the link above."
-        reference_links_text_html: "If you have questions about this invitation or SUL Exhibits, send an email to %{mailto}. To see examples of exhibits created by other SUL exhibit curators, visit the %{href} page."
+        hello: Welcome to Spotlight at Stanford, an application for showcasing digital content in easy-to-produce exhibits.
+        someone_invited_you: The Spotlight at Stanford Exhibits Administrator has invited you to work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking on the link below.
+        accept: Accept invitation
+        ignore_html: If you don’t want to accept the invitation, just ignore this email. You won’t be added to the "%{exhibit_name}" exhibit team until you click the invitation link above.
+        spotlight_at_sul_html: For more information about Spotlight at Stanford, visit %{href}
+        all_exhibits_html: To view existing Spotlight at Stanford exhibits, visit %{href}
+        get_help_html: Questions? Contact the Spotlight at Stanford service team by sending an email to %{mailto}
+        closing_html: "Happy exhibit building! <p>Spotlight at Stanford Service Team<br>%{mailto}</p>"
         mail_to_href: "exhibits-feedback@lists.stanford.edu"
-        reference_links_href: "SUL Online Exhibits"
+        all_exhibits_href: "https://exhibits.stanford.edu"
+        spotlight_at_sul_href: "http://library.stanford.edu/research/spotlight"
     exhibits_admin_invitation_mailer:
       invitation_instructions:
-        someone_invited_you: "The SUL Exhibits Administrator has invited you to join the administrative group that manages the SUL online exhibits. You can accept this invitation by clicking the link below."
-        ignore_html: "If you don't want to accept the invitation, please ignore this email. You won't be made a SUL online exhibits administrator until you access the link above."
+        hello: Welcome to Spotlight at Stanford, an application for showcasing digital content in easy-to-produce exhibits.
+        someone_invited_you: The Spotlight at Stanford Exhibits Administrator has invited you to work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking on the link below.
+        accept: Accept invitation
+        ignore_html: If you don’t want to accept the invitation, just ignore this email. You won’t be added to the "%{exhibit_name}" exhibit team until you click the invitation link above.
+        spotlight_at_sul_html: For more information about Spotlight at Stanford, visit %{href}
+        all_exhibits_html: To view existing Spotlight at Stanford exhibits, visit %{href}
+        get_help_html: Questions? Contact the Spotlight at Stanford service team by sending an email to %{mailto}
+        closing_html: "Happy exhibit building! <p>Spotlight at Stanford Service Team<br>%{mailto}</p>"
+        mail_to_href: "exhibits-feedback@lists.stanford.edu"
+        all_exhibits_href: "https://exhibits.stanford.edu"
+        spotlight_at_sul_href: "http://library.stanford.edu/research/spotlight"


### PR DESCRIPTION
Closes #531 

This PR changes the confirmation emails for new curators and admins.

Todo:
- [x] Depends on projectblacklight/spotlight#1868 getting merged
- [x] difference between `confirmation_instructions` vs. `invitation_instructions`?
- [x] install letter_opener for local development? 
- [x] add CHANGELOG mesage
- [x] Spotlight release
- [x] update CHANGELOG
- [x] update exhibits Spotlight version (#1012)

## Before
![before_email](https://user-images.githubusercontent.com/5402927/33635382-9d1dfb0a-d9cc-11e7-9487-e7c0fba0dfd2.png)

## After
![after_email](https://user-images.githubusercontent.com/5402927/33635384-9f47a1b0-d9cc-11e7-9328-36c750f24498.png)
