### PR TITLE
Add non-admin UI elements to i18n keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 ### Changed
+- Adds i18n keys bibliography resources and metadata display modal  #983
 ### Deprecated
 ### Removed
+- Removes i18n keys for deprecated bibliography service #983
 ### Fixed
 ### Security
 

--- a/app/views/bibliography_resources/_form.html.erb
+++ b/app/views/bibliography_resources/_form.html.erb
@@ -1,6 +1,6 @@
 <% if feature_flags.bibliography_resource? %>
   <%= bootstrap_form_for([current_exhibit, @resource.becomes(BibliographyResource)], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-6', as: :resource) do |f| %>
-    <%= f.file_field :bibtex_file, label: 'BibTeX File', class: 'form-control', control_col: 'col-sm-6', required: true, accept: 'application/x-bibtex', help: 'Each BibTeX file entry will be added as an exhibit item with a “Reference” resource type.'  %>
+    <%= f.file_field :bibtex_file, label: t('bibliography_resources.form.label'), class: 'form-control', control_col: 'col-sm-6', required: true, accept: 'application/x-bibtex', help: t('bibliography_resources.form.help') %>
     <div class="form-actions">
       <div class="primary-actions">
         <%= cancel_link @resource, :back, class: 'btn btn-default' %>

--- a/app/views/catalog/_bibliography_buttons_default.html.erb
+++ b/app/views/catalog/_bibliography_buttons_default.html.erb
@@ -1,5 +1,5 @@
 <% if @document.zotero_url.present? %>
   <a href="<%= @document.zotero_url %>" class="btn btn-info btn-view-on-zotero pull-right">
-    View on Zotero site
+    <%= t('bibliography_resources.show.zotero_button') %>
   </a>
 <% end %>

--- a/app/views/catalog/_cited_documents_default.html.erb
+++ b/app/views/catalog/_cited_documents_default.html.erb
@@ -5,7 +5,7 @@
        data-parentid="<%= @document.id %>"
        data-documentids="<%= @document.related_document_ids %>"
   >
-    <h3 class="col-md-9">This reference is found in these document bibliographies</h3>
+    <h3 class="col-md-9"><%= t('bibliography_resources.show.related_documents') %></h3>
     <ul class="col-md-9 cited-documents-list"></ul>
   </div>
 <% end %>

--- a/app/views/catalog/metadata.html.erb
+++ b/app/views/catalog/metadata.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class='modal-footer'>
     <button type='button' class='btn btn-default view-in-modal' data-dismiss='modal'>Close</button>
-    <%= link_to 'Download',
+    <%= link_to t('metadata.download'),
                 solr_document_path(@document, format: 'mods'),
                 class: 'btn btn-primary',
                 download: "#{@document.id}.mods.xml"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,41 +63,6 @@ en:
       passed: "OK      : %{registrant_name} - %{message}"
       failed: "FAILED  : %{registrant_name} - %{message}"
 
-  services:
-    bibliography_service:
-      default_header: Bibliography
-    create:
-      notice: Synchronization with Zotero has started.
-      error: There was a problem saving the bilbiography service settings.
-    edit:
-      api_id:
-        help: See the API section of the your Zotero library's settings for your user or group ID.
-      header: Services
-      instructions: >
-        If items in this exhibit have bibliography references associated with them in a Zotero library,
-        the application can display the associated references when an item's detail page is displayed.
-        The Zotero library must be a public, single (non-nested) collection of reference items in which
-        each item is assigned a separate tag (e.g., "gh328kv5465") for each druid associated with it.
-        When an exhibit visitor navigates to an item details page, all Zotero references tagged with
-        the item's druid are displayed in a named section at the bottom of the item details page.
-      save: 'Save changes'
-      title: Item Bibliography
-      zotero_section_label: Zotero ID type
-      zotero_sync:
-        button: Synchronize with Zotero
-        label: Synchronization status
-        not_synced: Exhibit items have never been synchronized with a Zotero library.
-        status: "Exhibit items were last synced with your Zotero library on %{datetime}"
-        help: >
-          If you have added exhibit items or changed your Zotero library since the last time it
-          was synchronized you can resynchronize to update exhibit item bibliographies.
-    menu_link: Services
-    sync:
-      started: Synchronization with Zotero has started.
-    update:
-      notice: The bibliography service settings have been updated.
-      error: There was a problem udpating the bibliography service settings.
-
   viewers:
     menu_link: Viewers
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,9 +38,14 @@ en:
     form:
       add_item: Add items
       title: BibTeX
+      help: Each BibTeX file entry will be added as an exhibit item with a “Reference” resource type.
+      label: BibTeX File
     create:
       notice: Your bibliography resource has been successfully created.
       error:  There was a problem with adding the BibTeX resource.
+    show:
+      related_documents: This reference is found in these document bibliographies
+      zotero_button: View on Zotero site
 
   admin:
     items:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
         heatmaps: "Map"
   metadata:
     more_details: 'More details »'
+    download: 'Download'
   okcomputer:
     check:
       passed: "OK      : %{registrant_name} - %{message}"


### PR DESCRIPTION
This PR moves strings in the user-facing UI, created during the Parker work cycle, with i18n keys. 

- Removes the bibliography service keys from early Exhibits / Spotlight 2016 work cycle
- Adds keys for the following features:
  - bibliography resource
  - Metadata modal download button
  - ~~search fields (Title, Subject, etc.)~~ --> split off to #1056

### Todo:
- [x]  update to Spotlight 1.2.0 / Blacklight 6.13 (#1012)
- [x] update keys
- [x] update CHANGELOG
- [x] major rebase 😭
~~- [ ] get search field labels working~~