### PR TITLE
[WIP] Add locale-based routing and a locale picker in the navbar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,14 @@ class ApplicationController < ActionController::Base
     @feature_flags ||= FeatureFlags.for(current_exhibit)
   end
   helper_method :feature_flags
+
+  before_action :set_locale
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def default_url_options
+    { locale: I18n.locale }
+  end
 end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,4 +1,5 @@
 <ul class="nav navbar-nav pull-right">
+  <%= render '/shared/locale_picker' %>
   <% if current_user %>
     <li class="dropdown">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%=current_user%> <b class="caret"></b></a>

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,0 +1,14 @@
+<% if Rails.application.config.available_locales.many? %>
+  <li class="dropdown">
+    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+      <%= t :"locale_picker.#{I18n.locale}" %> <b class="caret"></b>
+    </a>
+    <ul class="dropdown-menu">
+      <% Rails.application.config.available_locales.each do |l| %>
+        <li>
+          <%= link_to t(:"locale_picker.#{l}"), (url_for(locale: l) rescue blacklight.url_for(locale: nil, script_name: "/#{l}")), class: 'dropdown-item' %>
+        </li>
+      <% end %>
+    </ul>
+  </li>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,10 @@ module Exhibits
     end
 
     config.druid_regex = /([a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4})/
+
+    config.available_locales = %w(en)
+    config.action_dispatch.rescue_responses.merge!(
+      "I18n::InvalidLocale" => :not_found
+    )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,9 @@ en:
       passed: "OK      : %{registrant_name} - %{message}"
       failed: "FAILED  : %{registrant_name} - %{message}"
 
+  locale_picker:
+    en: 'English'
+
   services:
     bibliography_service:
       default_header: Bibliography


### PR DESCRIPTION
This adds a slightly more sophisticated version of the locale picker from the blacklight demo.

Note that the locale picker only shows up if there are multiple options to pick; right now I've only added `en`, so this is effectively a no-op for our users.

Fixes #984 

<img width="375" alt="screen shot 2017-12-07 at 08 08 30" src="https://user-images.githubusercontent.com/111218/33725033-d5fd6e42-db25-11e7-95c3-f18a40bd4a0b.png">
