### PR TITLE
reverse the order of the collection and collection druid for sorting …

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
   # Collection titles are indexed as a compound druid + title; we need to
   # unmangle it for display.
   def collection_title(value, separator: '-|-')
-    value.split(separator).last
+    value.split(separator).first
   end
 
   def document_collection_title(value:, **)

--- a/lib/traject/dor_config.rb
+++ b/lib/traject/dor_config.rb
@@ -20,7 +20,7 @@ to_field 'display_type', conditional(->(resource, *_) { !resource.collection? },
 
 to_field 'collection', (accumulate { |resource, *_| resource.collections.map(&:bare_druid) })
 to_field 'collection_with_title', (accumulate do |resource, *_|
-  resource.collections.map { |collection| "#{collection.bare_druid}-|-#{coll_title(collection)}" }
+  resource.collections.map { |collection| "#{coll_title(collection)}-|-#{collection.bare_druid}" }
 end)
 
 # COLLECTION FIELDS

--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
 
     it 'has collection information' do
       expect(document).to include collection: ['ms016pb9280'],
-                                  collection_with_title: ['ms016pb9280-|-Edward A. Feigenbaum papers, 1950-2007 (inclusive)']
+                                  collection_with_title: ['Edward A. Feigenbaum papers, 1950-2007 (inclusive)-|-ms016pb9280']
     end
 
     it 'has feigenbaum-specific fields' do

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -87,7 +87,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -214,7 +214,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -347,7 +347,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -484,7 +484,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -640,7 +640,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -757,7 +757,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -890,7 +890,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "author_no_collector_ssim": [
       "Migeon, J.",
@@ -1021,7 +1021,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "author_no_collector_ssim": [
       "Bussy, J. H. de"
@@ -1181,7 +1181,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -1312,7 +1312,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -1440,7 +1440,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "author_no_collector_ssim": [
       "Rissik, Johann, 1857-1925"
@@ -1572,7 +1572,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "author_no_collector_ssim": [
       "Wyld, James, 1812-1887"
@@ -1715,7 +1715,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -1870,7 +1870,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -1995,7 +1995,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "author_no_collector_ssim": [
       "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
@@ -2154,7 +2154,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -2279,7 +2279,7 @@
       "qb438pg7646"
     ],
     "collection_with_title": [
-      "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
+      "Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865-|-qb438pg7646"
     ],
     "author_no_collector_ssim": [
       "Tallis, John, 1817-1876",
@@ -2423,7 +2423,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -2553,7 +2553,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [
@@ -2690,7 +2690,7 @@
       "ct961sj2730"
     ],
     "collection_with_title": [
-      "ct961sj2730-|-The Caroline Batchelor Map Collection"
+      "The Caroline Batchelor Map Collection-|-ct961sj2730"
     ],
     "box_ssi": null,
     "coordinates_tesim": [

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,17 +5,17 @@ require 'rails_helper'
 describe ApplicationHelper, type: :helper do
   describe '#collection_title' do
     it 'unmangles the collection title from the compound field' do
-      expect(helper.collection_title('foo-|-bar')).to eq 'bar'
+      expect(helper.collection_title('foo-|-bar')).to eq 'foo'
     end
   end
 
   describe '#collection_title_for_index_field' do
     it 'unmangles the collection title from the compound field' do
-      expect(helper.document_collection_title(value: 'foo-|-bar')).to eq 'bar'
+      expect(helper.document_collection_title(value: 'foo-|-bar')).to eq 'foo'
     end
 
     it 'handles multivalued fields' do
-      expect(helper.document_collection_title(value: ['foo-|-bar', 'baz-|-bop'])).to eq 'bar and bop'
+      expect(helper.document_collection_title(value: ['foo-|-bar', 'baz-|-bop'])).to eq 'foo and baz'
     end
   end
 end


### PR DESCRIPTION
…sake

Closes #810 

This also would require a reindex of everything in production. I'm not sure of a better way to do this. Adding a duplicate field (instead of reversing) feels suboptimal too as users will now have two collection fields in there exhibit. We should just do the thing that we want at the end of the day.

## Correct 0-9 A-Z order by title (not druid)
<img width="402" alt="screen shot 2017-12-08 at 1 46 20 pm" src="https://user-images.githubusercontent.com/1656824/33786505-48f45bf6-dc1e-11e7-8bff-4636c4667721.png">
