### PR TITLE
Set masonry, slideshow, and gallery views to title-only by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updates Exhibits to Spotlight v1.2.0 #1012
 - Added ability to view the index status individual items in an exhibit by autocompleting for druid (only applies to exhibits with > 10 item druids) #1013
 ### Changed
+- Masonry, Gallery, and Slideshow views only display title by default #1011
 ### Deprecated
 ### Removed
 ### Fixed

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -74,13 +74,16 @@ class CatalogController < ApplicationController
 
     config.view.list.thumbnail_field = :thumbnail_square_url_ssm
     config.view.list.partials = [:exhibits_document_header, :index]
+    config.view.gallery.title_only_by_default = true
     config.view.gallery.partials = [:index_header, :index]
     config.view.gallery.default_bibliography_thumbnail = 'default-square-thumbnail-book-large.png'
     config.view.gallery.default_canvas_thumbnail = 'default-square-thumbnail-annotation-large.png'
     config.view.heatmaps.partials = []
     config.view.heatmaps.color_ramp = ['#ffffcc', '#a1dab4', '#41b6c4', '#2c7fb8', '#253494']
+    config.view.masonry.title_only_by_default = true
     config.view.masonry.partials = [:index]
     config.view.masonry.default_bibliography_thumbnail = 'default-square-thumbnail-book-large.png'
+    config.view.slideshow.title_only_by_default = true
     config.view.slideshow.partials = [:index]
     config.view.embed.partials = [:viewer]
     config.view.embed.if = false


### PR DESCRIPTION
Closes #999 
Related: projectblacklight/spotlight#1810, projectblacklight/spotlight#1809, and
projectblacklight/spotlight#1808

- [x] Requires a new release of Spotlight (1.2.0)

This PR sets the masonry, gallery, and slideshow views to title-only by default. The curator can till toggle metadata fields. This just affects the default settings for new exhibits.

## Before
<img width="391" alt="gallery_with_all_metadata" src="https://user-images.githubusercontent.com/5402927/33905083-4db47eb6-df32-11e7-8a3a-75c7dd40f7a4.png">

## After
<img width="401" alt="gallery_title_only" src="https://user-images.githubusercontent.com/5402927/33905082-4d8be9c4-df32-11e7-9c22-0926386fd6a8.png">
