### PR TITLE
Render a typeahead to search for index status based on item druid …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Added ability to view the index status individual items in an exhibit by autocompleting for druid (only applies to exhibits with > 10 item druids) #1013
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed timeout issue on Add Items page for exhibits with large number of items #1013
 ### Security
 
 ## [1.12.0] - 2017-12-12

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require blacklight_gallery
 //= require blacklight_heatmaps
 //= require blacklight_oembed
+//= require index_status_typeahead
 //= require nested_related_items
 //= require openseadragon
 //= require spotlight

--- a/app/assets/javascripts/index_status_typeahead.js
+++ b/app/assets/javascripts/index_status_typeahead.js
@@ -1,0 +1,117 @@
+/* global Blacklight */
+/* global Bloodhound */
+/* global IndexStatusTypeahead */
+
+(function (global) {
+  var IndexStatusTypeahead;
+
+  IndexStatusTypeahead = {
+    itemStatusRemoteUrl: null,
+    typeaheadRemoteUrl: null,
+    typeaheadOptions: { hint: true, highlight: true, minLength: 1 },
+
+    indexStatusTable: function() {
+      return $('[data-behavior="index-status-typeahead-table"]');
+    },
+
+    init: function (el) {
+      var _this = this;
+      _this.itemStatusRemoteUrl = el.data().typeaheadRemoteUrl;
+      _this.typeaheadRemoteUrl = el.data().typeaheadRemoteUrl + '?q=%QUERY';
+      el.typeahead(_this.typeaheadOptions, _this.typeaheadSources());
+
+      el.bind('typeahead:selected', function(e, suggestion) {
+        _this.addIndexStatusRow(suggestion);
+      });
+    },
+
+    typeaheadSources: function() {
+      var bloodhound = this.bloodhoundEngine();
+      bloodhound.initialize();
+      return {
+        name: 'druid',
+        displayKey: 'druid',
+        source: bloodhound.ttAdapter(),
+        templates: {
+          empty: [
+            '<div class="no-items">',
+            'No matches found',
+            '</div>'
+          ].join('\n')
+        }
+      };
+    },
+
+    addIndexStatusRow: function(suggestion) {
+      if(this.indexStatusRow(suggestion.druid).length > 0) {
+        return; // Return if there is already an index status row present
+      }
+
+      this.indexStatusTable().show(); // Ensure the table is shown
+      this.indexStatusTable().find('tbody').append(
+        [
+          '<tr data-index-status-id="' + suggestion.druid + '">',
+            '<td>' + suggestion.druid + '</td>',
+            '<td data-behavior="index-item-status"></td>',
+          '</tr>'
+        ].join('\n')
+      );
+
+      this.updateItemIndexStatus(suggestion.druid);
+    },
+
+    // Getter for an index status row given a druid
+    indexStatusRow: function(druid) {
+      return $('tr[data-index-status-id="' + druid + '"]');
+    },
+
+    updateItemIndexStatus: function(druid) {
+      var _this = this;
+      $.ajax({ url: _this.itemStatusRemoteUrl + '/' + druid })
+       .success(function(data) {
+         var row = _this.indexStatusRow(druid);
+
+         if (!data.status.ok) {
+           row.addClass('danger');
+         }
+
+         var itemStatusCell = row.find('td[data-behavior="index-item-status"]');
+         itemStatusCell.text(
+           data.status.ok ? 'Published' : data.status.message
+         );
+      });
+    },
+
+    druids: function() {
+      return $('[data-index-status-content]').data('index-status-content');
+    },
+
+    bloodhoundEngine: function() {
+      return new Bloodhound({
+        limit: 10,
+        remote: {
+          url: this.typeaheadRemoteUrl,
+          filter: function (druids) {
+            return $.map(druids, function (druid) {
+              return { druid: druid };
+            });
+          }
+        },
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        datumTokenizer: function(d) {
+          return Bloodhound.tokenizers.whitespace(d);
+        }
+      });
+    }
+  };
+
+  global.IndexStatusTypeahead = IndexStatusTypeahead;
+}(this));
+
+Blacklight.onLoad(function () {
+  'use strict';
+
+  $('[data-behavior="index-status-typeahead"]').each(function (i, element) {
+    IndexStatusTypeahead.init($(element)); // eslint-disable-line no-undef
+  });
+});

--- a/app/controllers/index_statuses_controller.rb
+++ b/app/controllers/index_statuses_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+##
+# A controller to list/filter document druids and display that items indexing status
+class IndexStatusesController < ApplicationController
+  before_action :authenticate_user!
+  load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
+  before_action :build_resource
+
+  before_action do
+    # This is what authorize_resource should be doing for us, but does not work for :index
+    authorize!(params[:action].to_sym, @resource)
+  end
+
+  def show
+    document = @resource.solr_document_sidecars.where(document_id: params[:id]).first
+    raise ActionController::RoutingError, "No document with id \"#{params[:id]}\" found" unless document
+
+    render json: {
+      id: params[:id],
+      status: document.index_status
+    }
+  end
+
+  def index
+    render json: filtered_solr_document_ids
+  end
+
+  private
+
+  def build_resource
+    @resource = DorHarvester.instance(current_exhibit)
+  end
+
+  def filtered_solr_document_ids
+    document_ids = @resource.solr_document_sidecars.pluck(:document_id)
+    return document_ids unless params[:q]
+    index_query_param = params[:q].downcase
+
+    document_ids.select { |id| id.include?(index_query_param) }
+  end
+end

--- a/app/views/dor_harvester/_index_statuses.html.erb
+++ b/app/views/dor_harvester/_index_statuses.html.erb
@@ -1,0 +1,23 @@
+<p><%= t('admin.items.object-druids-help_html') %></p>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Druid</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% harvester.solr_document_sidecars.each do |sidecar| %>
+      <tr class="<%= 'danger' unless sidecar.index_status[:ok] %>">
+        <td><%= sidecar.document_id %></td>
+        <td>
+          <% if sidecar.index_status[:ok] %>
+            Published
+          <% else %>
+            <%= sidecar.index_status[:message] %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/dor_harvester/_many_index_statuses.html.erb
+++ b/app/views/dor_harvester/_many_index_statuses.html.erb
@@ -1,0 +1,16 @@
+<p><%= t('admin.items.many-object-druids-help_html', count: harvester.solr_document_sidecars.count) %></p>
+
+<%= bootstrap_form_for('object', layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-6') do |f| %>
+  <%= f.text_field :druid, data: { behavior: 'index-status-typeahead' , typeahead_remote_url: exhibit_dor_harvester_index_statuses_path(current_exhibit)}%>
+<% end %>
+
+<table style="display: none;" class="table table-striped" data-behavior="index-status-typeahead-table">
+  <thead>
+    <tr>
+      <th>Druid</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+  </tbody>
+</table>

--- a/app/views/dor_harvester/_status.html.erb
+++ b/app/views/dor_harvester/_status.html.erb
@@ -24,29 +24,11 @@
             </div>
             <div id="sdr-status-inner-items" class="panel-collapse collapse">
               <div class="panel-body">
-                <p><%= t('admin.items.object-druids-help_html') %></p>
-                <table class="table table-striped">
-                  <thead>
-                    <tr>
-                      <th>Druid</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <% harvester.solr_document_sidecars.each do |sidecar| %>
-                      <tr class="<%= 'danger' unless sidecar.index_status[:ok] %>">
-                        <td><%= sidecar.document_id %></td>
-                        <td>
-                          <% if sidecar.index_status[:ok] %>
-                            Published
-                          <% else %>
-                            <%= sidecar.index_status[:message] %>
-                          <% end %>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
+                <% if harvester.solr_document_sidecars.count > Settings.index_status_threshold %>
+                  <%= render 'dor_harvester/many_index_statuses', { harvester: harvester } %>
+                <% else %>
+                  <%= render 'dor_harvester/index_statuses', { harvester: harvester } %>
+                <% end %>
               </div>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
       item-submission-help_html: "To add SDR items to the exhibit, enter collection or item druids below, one per line (e.g. qb438pg7646)."
       object-druids: "Object druids"
       object-druids-help_html: "Items below with the status of <em>published</em> were added to the exhibit. Items must be published (i.e., have a valid PURL) before they can be added to the exhibit."
+      many-object-druids-help_html: "<p>There are %{count} object druids indexed in this exhibit. To determine whether a particular item is indexed in this exhibit, or to check the indexing status of an item, begin typing the object druid below.</p><p>Items displayed with a status of published were added to the exhibit. Items must be published (i.e. have a valid PURL) before they can be added to the exhibit.</p>"
       collection-druids: "Collection druids"
       collection-druids-help_html: "Items associated with the collection druids below were added to the exhibit. If the number of items associated with a collection druid does not match your expectation, verify that all of its associated items have been published (i.e., have a valid PURL)."
   blacklight:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,9 @@ Exhibits::Application.routes.draw do
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :exhibits, path: '/', only: [] do
-    resource :dor_harvester, controller: :"dor_harvester", only: [:create, :update]
+    resource :dor_harvester, controller: :"dor_harvester", only: [:create, :update] do
+      resources :index_statuses, only: [:index, :show]
+    end
     resource :bibliography_resources, only: [:create, :update]
     resource :viewers, only: [:create, :edit, :update]
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,4 @@ gdor:
 slack_notifications:
   default_channel: '#spotlight-service-team'
   api_token: 'your-api-token-here'
+index_status_threshold: 10

--- a/spec/features/adding_items_spec.rb
+++ b/spec/features/adding_items_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Adding items to an exhibit', type: :feature do
+  let(:exhibit) { create(:exhibit) }
+  let(:user) { create(:exhibit_admin, exhibit: exhibit) }
+  let(:number_of_resources) { 5 }
+  let(:resource) { DorHarvester.create(exhibit: exhibit) }
+
+  before do
+    sign_in user
+
+    number_of_resources.times do |i|
+      Spotlight::SolrDocumentSidecar.create(
+        exhibit: exhibit,
+        resource: resource,
+        document: SolrDocument.new(id: "abc#{i}"),
+        index_status: { ok: true }
+      )
+    end
+  end
+
+  context 'when the number of documents is below the threshold', js: true do
+    it 'displays the item statuses as a table' do
+      visit spotlight.new_exhibit_resource_path(exhibit)
+
+      within '#sdr-item-status' do
+        click_link 'Item status'
+      end
+
+      within '#status-accordion' do
+        click_link 'Object druids'
+
+        expect(page).to have_css('table th', text: 'Druid')
+        expect(page).to have_css('table th', text: 'Status')
+        expect(page).to have_css('table tbody tr', count: number_of_resources)
+      end
+    end
+  end
+
+  context 'when the number of documents is above the threshold', js: true do
+    let(:number_of_resources) { 11 }
+
+    it 'displays a form input that allows users to search for a druid' do
+      visit spotlight.new_exhibit_resource_path(exhibit)
+
+      within('#sdr-item-status') { click_link 'Item status' }
+
+      within '#status-accordion' do
+        click_link 'Object druids'
+
+        expect(page).to have_content("There are #{number_of_resources} object druids indexed in this exhibit")
+
+        fill_in_typeahead_field with: 'abc1'
+
+        expect(page).to have_css('tr[data-index-status-id="abc1"] td', text: 'abc1', visible: true)
+        expect(page).to have_css('td[data-behavior="index-item-status"]', text: 'Published')
+      end
+    end
+
+    context 'when an indexing error occurs' do
+      before do
+        Spotlight::SolrDocumentSidecar.create(
+          exhibit: exhibit,
+          resource: resource,
+          document: SolrDocument.new(id: 'xyz'),
+          index_status: { ok: false, message: 'There was a problem indexing' }
+        )
+      end
+
+      it 'renders the message as a status' do
+        visit spotlight.new_exhibit_resource_path(exhibit)
+
+        within('#sdr-item-status') { click_link 'Item status' }
+
+        within '#status-accordion' do
+          click_link 'Object druids'
+
+          fill_in_typeahead_field with: 'xyz'
+
+          expect(page).to have_css('tr.danger[data-index-status-id="xyz"] td', text: 'xyz', visible: true)
+          expect(page).to have_css('td[data-behavior="index-item-status"]', text: 'There was a problem indexing')
+        end
+      end
+    end
+  end
+end
+
+# Stolen/simplified from Spotlight
+def fill_in_typeahead_field(opts = {})
+  page.execute_script <<-JS
+    $("[data-behavior='index-status-typeahead']:visible").val("#{opts[:with]}").trigger("input");
+    $("[data-behavior='index-status-typeahead']:visible").typeahead("open");
+    $(".tt-suggestion").click();
+  JS
+
+  find('.tt-suggestion', text: opts[:with], match: :first).click
+end

--- a/spec/requests/index_statuses_requests_spec.rb
+++ b/spec/requests/index_statuses_requests_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Index Statuses', type: :request do
+  let(:exhibit) { create(:exhibit) }
+  let(:user) { nil }
+  let(:resource) { DorHarvester.create(exhibit: exhibit) }
+
+  before do
+    sign_in user
+
+    5.times do |i|
+      Spotlight::SolrDocumentSidecar.create(
+        exhibit: exhibit,
+        resource: resource,
+        document: SolrDocument.new(id: "abc#{i}"),
+        index_status: { ok: true }
+      )
+    end
+  end
+
+  context 'for an exhibit admin' do
+    let(:user) { create(:exhibit_admin, exhibit: exhibit) }
+
+    describe '#show' do
+      it "renders json including details about the item's indexing status" do
+        get "/#{exhibit.slug}/dor_harvester/index_statuses/abc1"
+
+        response_json = JSON.parse(response.body)
+        expect(response_json['id']).to eq 'abc1'
+        expect(response_json['status']).to eq('ok' => true)
+      end
+
+      it 'raises a not found error when the document id does not exist' do
+        expect do
+          get "/#{exhibit.slug}/dor_harvester/index_statuses/not-a-real-id"
+        end.to raise_error(ActionController::RoutingError, 'No document with id "not-a-real-id" found')
+      end
+    end
+
+    describe '#index' do
+      it 'renders a json artray of all the document ids, filtered by a q parameter' do
+        get "/#{exhibit.slug}/dor_harvester/index_statuses?q=abc"
+
+        response_json = JSON.parse(response.body)
+        expect(response_json.length).to eq 5
+        expect(response_json.first).to eq 'abc0'
+        expect(response_json.last).to eq 'abc4'
+
+        get "/#{exhibit.slug}/dor_harvester/index_statuses?q=3"
+
+        response_json = JSON.parse(response.body)
+        expect(response_json).to eq(['abc3'])
+      end
+    end
+  end
+
+  context 'for an anonymous user' do
+    let(:user) { create(:user) }
+
+    describe '#show' do
+      it do
+        expect do
+          get "/#{exhibit.slug}/dor_harvester/index_statuses/abc1"
+        end.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    describe '#index' do
+      it do
+        expect do
+          get "/#{exhibit.slug}/dor_harvester/index_statuses?q=abc"
+        end.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+end


### PR DESCRIPTION
…when there are over a certain number of items.

Closes #811 

_**Notes:**_
* _I had a local config change to make the threshold under 10.  Normally the number that shows up in the screenshot would not currently invoke an autocomplete interface._
* _The additional space to the left of the druid seems to be really difficult to get rid of.  It's the space reserved for a thumbnail which exists in all our autocompletes (regardless of if it has a thumb or not). Even providing our own custom template for the suggestion still yields this spacing.  Happy to work more on that if it is deemed a priority._

![druid-autocomplete](https://user-images.githubusercontent.com/96776/33923009-5e7d2f94-df83-11e7-849b-af0fdced6782.gif)

