### PR TITLE
Show Mirador full screen button at smaller widths

### DIFF
--- a/app/assets/stylesheets/mirador_bundle.scss
+++ b/app/assets/stylesheets/mirador_bundle.scss
@@ -5,5 +5,16 @@
 .mirador-viewer {
   .page-select {
     margin-right: 5px;
+    max-width: 50%;
+  }
+
+  .window-manifest-navigation {
+    @media screen and (max-width: 768px) {
+      min-width: 42%;
+    }
+
+    @media screen and (max-width: 575px) {
+      min-width: 50%;
+    }
   }
 }


### PR DESCRIPTION
Fixes #1017

This fixes a bug where the Mirador fullscreen button was hidden by the page picker widget. 

**Note:** @blalbrit this is quick fix that only applies to a Mirador viewer with 1 slot. Getting the CSS to work with multiple slots would be a more involved solution. 

## Fixtures
pm049bv8195
kz540zc7240

**Note:** annotation indexing must be enabled in settings.yml to get these longer canvas labels (e.g. "Front outside bindings") from the custom manifests

## Screenshots

### Before

![before_narrow](https://user-images.githubusercontent.com/5402927/34016321-44891eaa-e0d6-11e7-8406-84b66d3377ea.png)
![before_wide](https://user-images.githubusercontent.com/5402927/34016322-44a02014-e0d6-11e7-83f3-8e486a19139b.png)

### After
![after_narrow](https://user-images.githubusercontent.com/5402927/34016323-44b56e10-e0d6-11e7-9e8b-54f3e0c26ef5.png)
![after_wide](https://user-images.githubusercontent.com/5402927/34016324-44c94bce-e0d6-11e7-83d9-485c65f24068.png)
