### PR TITLE
Allow for exhibit specific manifest URL patterns to be used for our oembed tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added support for highlighting matching query terms from full-text content in search results #1030
 - Adds Stanford-specific helptext to the add admin/curator form #1040
+- Added support for using the exhibit specific manifest URL configuration to configure the SUL Embed environment to be used #1042
 ### Changed
 ### Deprecated
 ### Removed

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,8 @@ module ApplicationHelper
   # @param [SolrDocument] document
   # @param [Integer] canvas_index
   def custom_render_oembed_tag_async(document, canvas_index)
-    url = document.first(blacklight_config.show.oembed_field)
+    url = document.exhibit_specific_manifest(current_exhibit.required_viewer.custom_manifest_pattern)
+    url ||= document.first(blacklight_config.show.oembed_field)
 
     content_tag :div, '', data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_index: canvas_index) }
   end

--- a/config/initializers/oembed_providers.rb
+++ b/config/initializers/oembed_providers.rb
@@ -6,4 +6,9 @@ purl_provider = OEmbed::Provider.new('http://purl.stanford.edu/embed.{format}?&h
 purl_provider << 'http://purl.stanford.edu/*'
 purl_provider << 'https://purl.stanford.edu/*'
 purl_provider << 'http://searchworks.stanford.edu/*'
+
+purl_uat_provider = OEmbed::Provider.new('http://sul-purl-uat.stanford.edu/embed.{format}?&hide_title=true')
+purl_uat_provider << 'https://sul-purl-uat.stanford.edu/*'
+
 OEmbed::Providers.register(purl_provider)
+OEmbed::Providers.register(purl_uat_provider)


### PR DESCRIPTION
This allows us to configure, on a per exhibit basis, to use a different oEmbed environment.

Attempt to close #1038 

Hoping to start a conversation about the approach here.

In order to test this out, ensure your local exhibit's viewer is set to SUL Embed (the default) and set a IIIF url in the other tab to `https://sul-purl-uat.stanford.edu/{id}`. (note, if we want to use the Mirador viewer, we simply modify that URL to be `https://sul-purl-uat.stanford.edu/{id}/iiif/manifest`).

Then index an object that advertises our content search implementation in uat (e.g. cc842mn9348)

<img width="1234" alt="viewer-w-search-service" src="https://user-images.githubusercontent.com/96776/34235646-e03ef196-e5a7-11e7-898b-3133076d12e8.png">

One side-note about how this works is that due to the current logic in `ManifestConcern`, this will still bail out and use the production Embed for objects that are not image-like (image, manuscript, map, book).  That's probably okay for our current purposes (given that this is intended to be temporary to allow us to begin poking at content search), but we may want to keep it in mind moving forward.