### PR TITLE
Add a POC for indexing ALTO 2/3 OCR XML.

### DIFF
--- a/app/models/full_text_parser.rb
+++ b/app/models/full_text_parser.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+##
+# FullTextParser takes in a purl object resources and knows
+# how to find full-text resources (either plain-text or ALTO xml)
+# and can return an array of OCR strings (one element in the array for every OCR file).
+class FullTextParser
+  attr_reader :druid, :purl_object
+  delegate :public_xml, to: :purl_object
+
+  def initialize(purl_object)
+    @purl_object = purl_object
+    @druid = purl_object.bare_druid
+  end
+
+  def ocr_files
+    @ocr_files ||= xpath.flat_map { |xp| public_xml.xpath(xp) }
+  end
+
+  # TODO: Support .rtf (and .xml?) files, scrubbing/converting as necessary to get plain text
+  def to_text
+    ocr_files.map do |resource|
+      url = full_text_url(resource['id'])
+      content = full_text_content(url)
+      if ['application/xml', 'application/alto+xml'].include?(resource['mimetype'])
+        alto_xml_string_content(content)
+      else # plain text
+        content.scrub.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').gsub(/\s+/, ' ')
+      end
+    end
+  end
+
+  private
+
+  def full_text_content(url)
+    Faraday.get(url).body
+  rescue Faraday::Error::ConnectionFailed
+    logger.error("Error indexing full text - couldn't load file #{url}")
+    ''
+  end
+
+  def full_text_url(file_name)
+    "#{::Settings.stacks.file_url}/#{druid}/#{CGI.escape(file_name)}"
+  end
+
+  def alto_xml_string_content(content)
+    return [] if content.blank?
+    alto = Nokogiri::XML.parse(content)
+    alto_ns = alto.namespaces.values.first { |ns| ns =~ %r{standards/alto/ns} }
+    namespace = { alto: alto_ns || 'http://www.loc.gov/standards/alto/ns-v3#' }
+    alto.xpath('//alto:String/@CONTENT', namespace).map(&:text).join(' ')
+  end
+
+  # full text in druid.txt named for druid (feigenbaum) and ALTO OCR xml in page resources
+  def xpath
+    [
+      "//contentMetadata/resource/file[@id=\"#{druid}.txt\"]",
+      "//contentMetadata/resource[@type='page']/file[@mimetype='application/xml' or @mimetype='application/alto+xml']"
+    ]
+  end
+end

--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
 
   before do
     stub_request(:post, /update/)
-    %w(xf680rd3068 dx969tv9730 rk684yq9989 ms016pb9280 cf386wt1778).each do |fixture|
+    %w(xf680rd3068 dx969tv9730 rk684yq9989 ms016pb9280 cf386wt1778 cc842mn9348 kh392jb5994).each do |fixture|
       stub_request(:get, "https://purl.stanford.edu/#{fixture}.xml").to_return(
         body: File.new(File.join(FIXTURES_PATH, "#{fixture}.xml")), status: 200
       )
@@ -134,6 +134,30 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
 
     it 'indexes full text content' do
       expect(document).to include full_text_tesimv: ['full text']
+    end
+  end
+
+  context 'an item with ALTO OCR' do
+    subject(:document) do
+      dor_harvester.document_builder.to_solr.first
+    end
+
+    let(:druid) { 'cc842mn9348' }
+
+    before do
+      fixture_file = File.new(File.join(FIXTURES_PATH, 'cc842mn9348_ocr_1.xml'))
+      stub_request(
+        :get,
+        'https://stacks.stanford.edu/file/cc842mn9348/EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment_0001.xml'
+      ).to_return(body: fixture_file, status: 200)
+    end
+
+    it 'indexes all strings from the ALTO files into the full text field' do
+      fulltext = document[:full_text_tesimv]
+      expect(fulltext).to be_a Array
+      expect(fulltext.length).to eq 1
+      expect(fulltext.first).to start_with 'INTRODUCTION 1 The trial of'
+      expect(fulltext.first).to end_with 'rendering of the decision.'
     end
   end
 

--- a/spec/fixtures/cc842mn9348.mods
+++ b/spec/fixtures/cc842mn9348.mods
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+  <titleInfo>
+    <title>
+      CE-SPSC Final Decisions/2001/04b-2001 Sabino Gouveia Leite Judgment.pdf
+    </title>
+  </titleInfo>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>Virtual Tribunals: East Timor</title>
+    </titleInfo>
+    <location>
+      <url>https://purl.stanford.edu/kh392jb5994</url>
+    </location>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">TBD</accessCondition>
+</mods>

--- a/spec/fixtures/cc842mn9348.xml
+++ b/spec/fixtures/cc842mn9348.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:cc842mn9348" published="2017-12-13T21:19:30Z" publishVersion="dor-services/5.23.1">
+  <identityMetadata>
+    <sourceId source="virtualtribunals">
+      EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment
+    </sourceId>
+    <objectId>druid:cc842mn9348</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>
+      CE-SPSC Final Decisions/2001/04b-2001 Sabino Gouveia Leite Judgment.pdf
+    </objectLabel>
+    <objectType>item</objectType>
+    <otherId name="label"/>
+    <otherId name="uuid">3597ee82-c0cc-11e7-8508-0050569b2d90</otherId>
+    <tag>Process : Content Type : File</tag>
+    <tag>Project : Virtual Tribunals : East Timor</tag>
+    <tag>JIRA : PROJQUEUE-312</tag>
+    <tag>Registered By : matienzo</tag>
+  </identityMetadata>
+  <contentMetadata objectId="cc842mn9348" type="book">
+    <resource id="cc842mn9348_1" sequence="1" type="object">
+      <label>Object 1</label>
+      <file id="EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment.pdf" mimetype="application/pdf" size="2532980"></file>
+    </resource>
+    <resource id="cc842mn9348_2" sequence="2" type="page">
+      <label>Page 1</label>
+      <file id="EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment_0001.xml" mimetype="application/xml" size="17009"></file>
+      <file id="EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment_0001.jp2" mimetype="image/jp2" size="447995">
+        <imageData width="2510" height="3550"/>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <copyright>
+      <human>TBD</human>
+    </copyright>
+    <use>
+      <human type="useAndReproduction">TBD</human>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:cc842mn9348">
+      <fedora:isMemberOf rdf:resource="info:fedora/druid:kh392jb5994"/>
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:kh392jb5994"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:srw_dc="info:srw/schema/1/dc-schema"
+    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>
+      CE-SPSC Final Decisions/2001/04b-2001 Sabino Gouveia Leite Judgment.pdf
+    </dc:title>
+    <dc:relation type="collection">Virtual Tribunals: East Timor</dc:relation>
+  </oai_dc:dc>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+    <titleInfo>
+      <title>
+        CE-SPSC Final Decisions/2001/04b-2001 Sabino Gouveia Leite Judgment.pdf
+      </title>
+    </titleInfo>
+    <relatedItem type="host">
+      <titleInfo>
+        <title>Virtual Tribunals: East Timor</title>
+      </titleInfo>
+      <location>
+        <url>https://purl.stanford.edu/kh392jb5994</url>
+      </location>
+      <typeOfResource collection="yes"/>
+    </relatedItem>
+    <accessCondition type="useAndReproduction">TBD</accessCondition>
+  </mods>
+  <thumb>
+    cc842mn9348/EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment_0001.jp2
+  </thumb>
+</publicObject>

--- a/spec/fixtures/cc842mn9348_ocr_1.xml
+++ b/spec/fixtures/cc842mn9348_ocr_1.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v3#">
+  <!-- Created by Innodata R.E.D. Nuremberg tool (ver 20160602-39): 2017-11-30 15:40:23.632737 -->
+  <Description>
+    <MeasurementUnit>pixel</MeasurementUnit>
+    <sourceImageInformation>
+      <fileName>
+        EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment_0002.tif
+      </fileName>
+    </sourceImageInformation>
+  </Description>
+  <Layout>
+    <Page HEIGHT="3534.00" ID="PG_2" PHYSICAL_IMG_NR="2" WIDTH="2488.00">
+      <PrintSpace HEIGHT="3534.00" HPOS="0" ID="PS_2" VPOS="0" WIDTH="2488.00">
+        <TextBlock HEIGHT="40.00" HPOS="275.00" ID="BL_2.1" VPOS="304.00" WIDTH="461.00">
+          <TextLine HEIGHT="40.00" HPOS="275.00" ID="TL_2.1.1" VPOS="304.00" WIDTH="461.00">
+            <String CONTENT="INTRODUCTION" HEIGHT="40.00" HPOS="275.00" ID="ST_2.1.1.1" VPOS="304.00" WIDTH="461.00"/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="535.00" HPOS="280.00" ID="BL_2.2" VPOS="446.00" WIDTH="1943.00">
+          <TextLine HEIGHT="35.67" HPOS="280.00" ID="TL_2.2.1" VPOS="446.00" WIDTH="1708.90">
+            <String CONTENT="1" HEIGHT="35.67" HPOS="280.00" ID="ST_2.2.1.1" VPOS="446.00" WIDTH="23.41"/>
+            <SP HPOS="303.41" ID="SP_2.2.1.2" VPOS="446.00" WIDTH="70.23"/>
+            <String CONTENT="The" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.1.3" VPOS="446.00" WIDTH="70.23"/>
+            <SP HPOS="443.87" ID="SP_2.2.1.4" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="trial" HEIGHT="35.67" HPOS="467.28" ID="ST_2.2.1.5" VPOS="446.00" WIDTH="117.05"/>
+            <SP HPOS="584.33" ID="SP_2.2.1.6" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="607.73" ID="ST_2.2.1.7" VPOS="446.00" WIDTH="46.82"/>
+            <SP HPOS="654.55" ID="SP_2.2.1.8" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="Sabino" HEIGHT="35.67" HPOS="677.96" ID="ST_2.2.1.9" VPOS="446.00" WIDTH="140.46"/>
+            <SP HPOS="818.42" ID="SP_2.2.1.10" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="Gouveia" HEIGHT="35.67" HPOS="841.83" ID="ST_2.2.1.11" VPOS="446.00" WIDTH="163.87"/>
+            <SP HPOS="1005.70" ID="SP_2.2.1.12" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="Leite" HEIGHT="35.67" HPOS="1029.11" ID="ST_2.2.1.13" VPOS="446.00" WIDTH="117.05"/>
+            <SP HPOS="1146.16" ID="SP_2.2.1.14" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="(aged" HEIGHT="35.67" HPOS="1169.57" ID="ST_2.2.1.15" VPOS="446.00" WIDTH="117.05"/>
+            <SP HPOS="1286.61" ID="SP_2.2.1.16" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="42," HEIGHT="35.67" HPOS="1310.02" ID="ST_2.2.1.17" VPOS="446.00" WIDTH="70.23"/>
+            <SP HPOS="1380.25" ID="SP_2.2.1.18" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="married," HEIGHT="35.67" HPOS="1403.66" ID="ST_2.2.1.19" VPOS="446.00" WIDTH="187.28"/>
+            <SP HPOS="1590.94" ID="SP_2.2.1.20" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="born" HEIGHT="35.67" HPOS="1614.35" ID="ST_2.2.1.21" VPOS="446.00" WIDTH="93.64"/>
+            <SP HPOS="1707.99" ID="SP_2.2.1.22" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="on" HEIGHT="35.67" HPOS="1731.40" ID="ST_2.2.1.23" VPOS="446.00" WIDTH="46.82"/>
+            <SP HPOS="1778.22" ID="SP_2.2.1.24" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="1801.63" ID="ST_2.2.1.25" VPOS="446.00" WIDTH="70.23"/>
+            <SP HPOS="1871.86" ID="SP_2.2.1.26" VPOS="446.00" WIDTH="23.41"/>
+            <String CONTENT="15th" HEIGHT="35.67" HPOS="1895.27" ID="ST_2.2.1.27" VPOS="446.00" WIDTH="93.64"/>
+          </TextLine>
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.2" VPOS="517.33" WIDTH="1755.72">
+            <String CONTENT="September" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.2.1" VPOS="517.33" WIDTH="210.69"/>
+            <SP HPOS="584.33" ID="SP_2.2.2.2" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="1960" HEIGHT="35.67" HPOS="607.73" ID="ST_2.2.2.3" VPOS="517.33" WIDTH="93.64"/>
+            <SP HPOS="701.37" ID="SP_2.2.2.4" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="in" HEIGHT="35.67" HPOS="724.78" ID="ST_2.2.2.5" VPOS="517.33" WIDTH="46.82"/>
+            <SP HPOS="771.60" ID="SP_2.2.2.6" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="Lolotoe," HEIGHT="35.67" HPOS="795.01" ID="ST_2.2.2.7" VPOS="517.33" WIDTH="187.28"/>
+            <SP HPOS="982.29" ID="SP_2.2.2.8" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="District" HEIGHT="35.67" HPOS="1005.70" ID="ST_2.2.2.9" VPOS="517.33" WIDTH="187.28"/>
+            <SP HPOS="1192.98" ID="SP_2.2.2.10" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="1216.39" ID="ST_2.2.2.11" VPOS="517.33" WIDTH="46.82"/>
+            <SP HPOS="1263.20" ID="SP_2.2.2.12" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="Bobonaro," HEIGHT="35.67" HPOS="1286.61" ID="ST_2.2.2.13" VPOS="517.33" WIDTH="210.69"/>
+            <SP HPOS="1497.30" ID="SP_2.2.2.14" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="East" HEIGHT="35.67" HPOS="1520.71" ID="ST_2.2.2.15" VPOS="517.33" WIDTH="93.64"/>
+            <SP HPOS="1614.35" ID="SP_2.2.2.16" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="Timor," HEIGHT="35.67" HPOS="1637.76" ID="ST_2.2.2.17" VPOS="517.33" WIDTH="140.46"/>
+            <SP HPOS="1778.22" ID="SP_2.2.2.18" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="former" HEIGHT="35.67" HPOS="1801.63" ID="ST_2.2.2.19" VPOS="517.33" WIDTH="140.46"/>
+            <SP HPOS="1942.08" ID="SP_2.2.2.20" VPOS="517.33" WIDTH="23.41"/>
+            <String CONTENT="village" HEIGHT="35.67" HPOS="1965.49" ID="ST_2.2.2.21" VPOS="517.33" WIDTH="163.87"/>
+          </TextLine>
+
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.3" VPOS="588.67" WIDTH="1849.36">
+            <String CONTENT="chief" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.3.1" VPOS="588.67" WIDTH="117.05"/>
+            <SP HPOS="490.69" ID="SP_2.2.3.2" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="514.10" ID="ST_2.2.3.3" VPOS="588.67" WIDTH="46.82"/>
+            <SP HPOS="560.92" ID="SP_2.2.3.4" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="Guda" HEIGHT="35.67" HPOS="584.33" ID="ST_2.2.3.5" VPOS="588.67" WIDTH="93.64"/>
+            <SP HPOS="677.96" ID="SP_2.2.3.6" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="Village," HEIGHT="35.67" HPOS="701.37" ID="ST_2.2.3.7" VPOS="588.67" WIDTH="187.28"/>
+            <SP HPOS="888.65" ID="SP_2.2.3.8" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="in" HEIGHT="35.67" HPOS="912.06" ID="ST_2.2.3.9" VPOS="588.67" WIDTH="46.82"/>
+            <SP HPOS="958.88" ID="SP_2.2.3.10" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="Lolotoe" HEIGHT="35.67" HPOS="982.29" ID="ST_2.2.3.11" VPOS="588.67" WIDTH="163.87"/>
+            <SP HPOS="1146.16" ID="SP_2.2.3.12" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="Su-District)" HEIGHT="35.67" HPOS="1169.57" ID="ST_2.2.3.13" VPOS="588.67" WIDTH="280.92"/>
+            <SP HPOS="1450.48" ID="SP_2.2.3.14" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="before" HEIGHT="35.67" HPOS="1473.89" ID="ST_2.2.3.15" VPOS="588.67" WIDTH="140.46"/>
+            <SP HPOS="1614.35" ID="SP_2.2.3.16" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="1637.76" ID="ST_2.2.3.17" VPOS="588.67" WIDTH="70.23"/>
+            <SP HPOS="1707.99" ID="SP_2.2.3.18" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="Special" HEIGHT="35.67" HPOS="1731.40" ID="ST_2.2.3.19" VPOS="588.67" WIDTH="163.87"/>
+            <SP HPOS="1895.27" ID="SP_2.2.3.20" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="Panel" HEIGHT="35.67" HPOS="1918.67" ID="ST_2.2.3.21" VPOS="588.67" WIDTH="117.05"/>
+            <SP HPOS="2035.72" ID="SP_2.2.3.22" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="for" HEIGHT="35.67" HPOS="2059.13" ID="ST_2.2.3.23" VPOS="588.67" WIDTH="70.23"/>
+            <SP HPOS="2129.36" ID="SP_2.2.3.24" VPOS="588.67" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="2152.77" ID="ST_2.2.3.25" VPOS="588.67" WIDTH="70.23"/>
+          </TextLine>
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.4" VPOS="660.00" WIDTH="1825.95">
+            <String CONTENT="trial" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.4.1" VPOS="660.00" WIDTH="117.05"/>
+            <SP HPOS="490.69" ID="SP_2.2.4.2" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="514.10" ID="ST_2.2.4.3" VPOS="660.00" WIDTH="46.82"/>
+            <SP HPOS="560.92" ID="SP_2.2.4.4" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="Serious" HEIGHT="35.67" HPOS="584.33" ID="ST_2.2.4.5" VPOS="660.00" WIDTH="163.87"/>
+            <SP HPOS="748.19" ID="SP_2.2.4.6" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="Crimes" HEIGHT="35.67" HPOS="771.60" ID="ST_2.2.4.7" VPOS="660.00" WIDTH="140.46"/>
+            <SP HPOS="912.06" ID="SP_2.2.4.8" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="in" HEIGHT="35.67" HPOS="935.47" ID="ST_2.2.4.9" VPOS="660.00" WIDTH="46.82"/>
+            <SP HPOS="982.29" ID="SP_2.2.4.10" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="1005.70" ID="ST_2.2.4.11" VPOS="660.00" WIDTH="70.23"/>
+            <SP HPOS="1075.93" ID="SP_2.2.4.12" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="District" HEIGHT="35.67" HPOS="1099.34" ID="ST_2.2.4.13" VPOS="660.00" WIDTH="187.28"/>
+            <SP HPOS="1286.61" ID="SP_2.2.4.14" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="Court" HEIGHT="35.67" HPOS="1310.02" ID="ST_2.2.4.15" VPOS="660.00" WIDTH="117.05"/>
+            <SP HPOS="1427.07" ID="SP_2.2.4.16" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="1450.48" ID="ST_2.2.4.17" VPOS="660.00" WIDTH="46.82"/>
+            <SP HPOS="1497.30" ID="SP_2.2.4.18" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="Dili" HEIGHT="35.67" HPOS="1520.71" ID="ST_2.2.4.19" VPOS="660.00" WIDTH="93.64"/>
+            <SP HPOS="1614.35" ID="SP_2.2.4.20" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="(hereafter:" HEIGHT="35.67" HPOS="1637.76" ID="ST_2.2.4.21" VPOS="660.00" WIDTH="257.51"/>
+            <SP HPOS="1895.27" ID="SP_2.2.4.22" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="1918.67" ID="ST_2.2.4.23" VPOS="660.00" WIDTH="70.23"/>
+            <SP HPOS="1988.90" ID="SP_2.2.4.24" VPOS="660.00" WIDTH="23.41"/>
+            <String CONTENT="Special" HEIGHT="35.67" HPOS="2012.31" ID="ST_2.2.4.25" VPOS="660.00" WIDTH="187.28"/>
+          </TextLine>
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.5" VPOS="731.33" WIDTH="1755.72">
+            <String CONTENT="Panel)," HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.5.1" VPOS="731.33" WIDTH="187.28"/>
+            <SP HPOS="560.92" ID="SP_2.2.5.2" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="responsible" HEIGHT="35.67" HPOS="607.73" ID="ST_2.2.5.3" VPOS="731.33" WIDTH="257.51"/>
+            <SP HPOS="865.24" ID="SP_2.2.5.4" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="for" HEIGHT="35.67" HPOS="912.06" ID="ST_2.2.5.5" VPOS="731.33" WIDTH="70.23"/>
+            <SP HPOS="982.29" ID="SP_2.2.5.6" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="1029.11" ID="ST_2.2.5.7" VPOS="731.33" WIDTH="70.23"/>
+            <SP HPOS="1099.34" ID="SP_2.2.5.8" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="handling" HEIGHT="35.67" HPOS="1146.16" ID="ST_2.2.5.9" VPOS="731.33" WIDTH="187.28"/>
+            <SP HPOS="1333.43" ID="SP_2.2.5.10" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="1380.25" ID="ST_2.2.5.11" VPOS="731.33" WIDTH="46.82"/>
+            <SP HPOS="1427.07" ID="SP_2.2.5.12" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="serious" HEIGHT="35.67" HPOS="1473.89" ID="ST_2.2.5.13" VPOS="731.33" WIDTH="163.87"/>
+            <SP HPOS="1637.76" ID="SP_2.2.5.14" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="criminal" HEIGHT="35.67" HPOS="1684.58" ID="ST_2.2.5.15" VPOS="731.33" WIDTH="187.28"/>
+            <SP HPOS="1871.86" ID="SP_2.2.5.16" VPOS="731.33" WIDTH="46.82"/>
+            <String CONTENT="offences," HEIGHT="35.67" HPOS="1918.67" ID="ST_2.2.5.17" VPOS="731.33" WIDTH="210.69"/>
+          </TextLine>
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.6" VPOS="802.67" WIDTH="1615.27">
+            <String CONTENT="commenced" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.6.1" VPOS="802.67" WIDTH="210.69"/>
+            <SP HPOS="584.33" ID="SP_2.2.6.2" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="on" HEIGHT="35.67" HPOS="607.73" ID="ST_2.2.6.3" VPOS="802.67" WIDTH="46.82"/>
+            <SP HPOS="654.55" ID="SP_2.2.6.4" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="677.96" ID="ST_2.2.6.5" VPOS="802.67" WIDTH="70.23"/>
+            <SP HPOS="748.19" ID="SP_2.2.6.6" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="4th" HEIGHT="35.67" HPOS="771.60" ID="ST_2.2.6.7" VPOS="802.67" WIDTH="70.23"/>
+            <SP HPOS="841.83" ID="SP_2.2.6.8" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="March" HEIGHT="35.67" HPOS="865.24" ID="ST_2.2.6.9" VPOS="802.67" WIDTH="117.05"/>
+            <SP HPOS="982.29" ID="SP_2.2.6.10" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="2002," HEIGHT="35.67" HPOS="1005.70" ID="ST_2.2.6.11" VPOS="802.67" WIDTH="117.05"/>
+            <SP HPOS="1122.75" ID="SP_2.2.6.12" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="was" HEIGHT="35.67" HPOS="1146.16" ID="ST_2.2.6.13" VPOS="802.67" WIDTH="70.23"/>
+            <SP HPOS="1216.39" ID="SP_2.2.6.14" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="suspended" HEIGHT="35.67" HPOS="1239.80" ID="ST_2.2.6.15" VPOS="802.67" WIDTH="210.69"/>
+            <SP HPOS="1450.48" ID="SP_2.2.6.16" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="many" HEIGHT="35.67" HPOS="1473.89" ID="ST_2.2.6.17" VPOS="802.67" WIDTH="93.64"/>
+            <SP HPOS="1567.53" ID="SP_2.2.6.18" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="times" HEIGHT="35.67" HPOS="1590.94" ID="ST_2.2.6.19" VPOS="802.67" WIDTH="117.05"/>
+            <SP HPOS="1707.99" ID="SP_2.2.6.20" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="including" HEIGHT="35.67" HPOS="1731.40" ID="ST_2.2.6.21" VPOS="802.67" WIDTH="210.69"/>
+            <SP HPOS="1942.08" ID="SP_2.2.6.22" VPOS="802.67" WIDTH="23.41"/>
+            <String CONTENT="a" HEIGHT="35.67" HPOS="1965.49" ID="ST_2.2.6.23" VPOS="802.67" WIDTH="23.41"/>
+          </TextLine>
+
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.7" VPOS="874.00" WIDTH="1825.95">
+            <String CONTENT="suspension" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.7.1" VPOS="874.00" WIDTH="234.10"/>
+            <SP HPOS="607.73" ID="SP_2.2.7.2" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="631.14" ID="ST_2.2.7.3" VPOS="874.00" WIDTH="46.82"/>
+            <SP HPOS="677.96" ID="SP_2.2.7.4" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="5" HEIGHT="35.67" HPOS="701.37" ID="ST_2.2.7.5" VPOS="874.00" WIDTH="23.41"/>
+            <SP HPOS="724.78" ID="SP_2.2.7.6" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="months" HEIGHT="35.67" HPOS="748.19" ID="ST_2.2.7.7" VPOS="874.00" WIDTH="140.46"/>
+            <SP HPOS="888.65" ID="SP_2.2.7.8" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="for" HEIGHT="35.67" HPOS="912.06" ID="ST_2.2.7.9" VPOS="874.00" WIDTH="70.23"/>
+            <SP HPOS="982.29" ID="SP_2.2.7.10" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="unvaibility" HEIGHT="35.67" HPOS="1005.70" ID="ST_2.2.7.11" VPOS="874.00" WIDTH="257.51"/>
+            <SP HPOS="1263.20" ID="SP_2.2.7.12" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="1286.61" ID="ST_2.2.7.13" VPOS="874.00" WIDTH="46.82"/>
+            <SP HPOS="1333.43" ID="SP_2.2.7.14" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="judges," HEIGHT="35.67" HPOS="1356.84" ID="ST_2.2.7.15" VPOS="874.00" WIDTH="163.87"/>
+            <SP HPOS="1520.71" ID="SP_2.2.7.16" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="and" HEIGHT="35.67" HPOS="1544.12" ID="ST_2.2.7.17" VPOS="874.00" WIDTH="70.23"/>
+            <SP HPOS="1614.35" ID="SP_2.2.7.18" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="concluded" HEIGHT="35.67" HPOS="1637.76" ID="ST_2.2.7.19" VPOS="874.00" WIDTH="210.69"/>
+            <SP HPOS="1848.45" ID="SP_2.2.7.20" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="today," HEIGHT="35.67" HPOS="1871.86" ID="ST_2.2.7.21" VPOS="874.00" WIDTH="140.46"/>
+            <SP HPOS="2012.31" ID="SP_2.2.7.22" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="2035.72" ID="ST_2.2.7.23" VPOS="874.00" WIDTH="70.23"/>
+            <SP HPOS="2105.95" ID="SP_2.2.7.24" VPOS="874.00" WIDTH="23.41"/>
+            <String CONTENT="7th" HEIGHT="35.67" HPOS="2129.36" ID="ST_2.2.7.25" VPOS="874.00" WIDTH="70.23"/>
+          </TextLine>
+          <TextLine HEIGHT="35.67" HPOS="373.64" ID="TL_2.2.8" VPOS="945.33" WIDTH="1147.07">
+            <String CONTENT="December" HEIGHT="35.67" HPOS="373.64" ID="ST_2.2.8.1" VPOS="945.33" WIDTH="187.28"/>
+            <SP HPOS="560.92" ID="SP_2.2.8.2" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="2002" HEIGHT="35.67" HPOS="584.33" ID="ST_2.2.8.3" VPOS="945.33" WIDTH="93.64"/>
+            <SP HPOS="677.96" ID="SP_2.2.8.4" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="with" HEIGHT="35.67" HPOS="701.37" ID="ST_2.2.8.5" VPOS="945.33" WIDTH="93.64"/>
+            <SP HPOS="795.01" ID="SP_2.2.8.6" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="818.42" ID="ST_2.2.8.7" VPOS="945.33" WIDTH="70.23"/>
+            <SP HPOS="888.65" ID="SP_2.2.8.8" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="rendering" HEIGHT="35.67" HPOS="912.06" ID="ST_2.2.8.9" VPOS="945.33" WIDTH="210.69"/>
+            <SP HPOS="1122.75" ID="SP_2.2.8.10" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="of" HEIGHT="35.67" HPOS="1146.16" ID="ST_2.2.8.11" VPOS="945.33" WIDTH="46.82"/>
+            <SP HPOS="1192.98" ID="SP_2.2.8.12" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="the" HEIGHT="35.67" HPOS="1216.39" ID="ST_2.2.8.13" VPOS="945.33" WIDTH="70.23"/>
+            <SP HPOS="1286.61" ID="SP_2.2.8.14" VPOS="945.33" WIDTH="23.41"/>
+            <String CONTENT="decision." HEIGHT="35.67" HPOS="1310.02" ID="ST_2.2.8.15" VPOS="945.33" WIDTH="210.69"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>

--- a/spec/fixtures/kh392jb5994.mods
+++ b/spec/fixtures/kh392jb5994.mods
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+  <titleInfo>
+    <title>Virtual Tribunals: East Timor</title>
+  </titleInfo>
+  <abstract>
+    Information to be added in consultation with the team.
+  </abstract>
+  <accessCondition type="useAndReproduction">TBD</accessCondition>
+</mods>

--- a/spec/fixtures/kh392jb5994.xml
+++ b/spec/fixtures/kh392jb5994.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:kh392jb5994" published="2017-10-06T20:45:59Z" publishVersion="dor-services/5.23.1">
+  <identityMetadata>
+    <objectId>druid:kh392jb5994</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>Virtual Tribunals: East Timor</objectLabel>
+    <objectType>collection</objectType>
+    <otherId name="uuid">083abc68-aad7-11e7-a524-0050569b2d90</otherId>
+  </identityMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <copyright>
+      <human>TBD</human>
+    </copyright>
+    <use>
+      <human type="useAndReproduction">TBD</human>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:kh392jb5994"></rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:srw_dc="info:srw/schema/1/dc-schema"
+    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Virtual Tribunals: East Timor</dc:title>
+    <dc:description>
+      Information to be added in consultation with the team.
+    </dc:description>
+  </oai_dc:dc>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+    <titleInfo>
+      <title>Virtual Tribunals: East Timor</title>
+    </titleInfo>
+    <abstract>
+      Information to be added in consultation with the team.
+    </abstract>
+    <accessCondition type="useAndReproduction">TBD</accessCondition>
+  </mods>
+</publicObject>

--- a/spec/models/full_text_parser_spec.rb
+++ b/spec/models/full_text_parser_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FullTextParser do
+  subject(:parser) { described_class.new(purl_object) }
+
+  let(:purl_object) { instance_double('PurlObject', bare_druid: 'cc842mn9348', public_xml: public_xml) }
+  let(:public_xml) { Nokogiri::XML.parse(File.read(File.join(FIXTURES_PATH, 'cc842mn9348.xml'))) }
+
+  describe '#ocr_files' do
+    it 'is an array of nokogiri elements for the appropriate files' do
+      ocr_files = parser.ocr_files
+      expect(ocr_files.length).to eq 1
+      expect(ocr_files.first['mimetype']).to eq 'application/xml'
+    end
+  end
+
+  describe '#to_text' do
+    before do
+      fixture_file = File.read(File.join(FIXTURES_PATH, 'cc842mn9348_ocr_1.xml'))
+      file_name = 'EastTimor_CE-SPSC_Final_Decisions_2001_04b-2001_Sabino_Gouveia_Leite_Judgment_0001.xml'
+      stub_request(
+        :get,
+        "https://stacks.stanford.edu/file/cc842mn9348/#{file_name}"
+      ).to_return(status: 200, body: fixture_file)
+    end
+
+    it 'is an array of text parsed of the OCR files' do
+      ocr_text = parser.to_text
+      expect(ocr_text.length).to eq 1
+      expect(ocr_text.first).to start_with 'INTRODUCTION 1 The trial of'
+      expect(ocr_text.first).to end_with 'with the rendering of the decision.'
+    end
+  end
+end


### PR DESCRIPTION
Closes #1039 

#### TODO:
- [x] Ensure XML we're processing has an ALTO namespace
- [x] Determine if checking the content-type of the response is acceptable (or should we refactor a bit to be able to use the mime-type described in the contentMetadata)
- [x] ~~Validate we're handling restricted content~~ (We're not going to worry about this at the moment.  We'll come up w/ a longer term strategy in sul-dlss/content_search#29)
- [x] Handle spaces/characters in file paths.

---

**Example:** _cc842mn9348_
<img width="906" alt="cc842mn9348-highlight" src="https://user-images.githubusercontent.com/96776/34315026-dfc1d22c-e72f-11e7-818d-c0dfc56a83c4.png">
