### PR TITLE
The width HTML attribute should not have units

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
 
   ##
   # @param [String] manifest
-  def iiif_drag_n_drop(manifest, width: '40px')
+  def iiif_drag_n_drop(manifest, width: '40')
     link_url = format Settings.iiif_dnd_base_url, query: { manifest: manifest }.to_query
     link_to link_url, class: 'iiif-dnd pull-right', data: { turbolinks: false } do
       image_tag 'iiif-drag-n-drop.svg', width: width, alt: 'IIIF Drag-n-drop'

--- a/app/views/catalog/_exhibits_document_header_default.html.erb
+++ b/app/views/catalog/_exhibits_document_header_default.html.erb
@@ -8,6 +8,6 @@
   <div class='col-xs-1'>
     <% exhibit_specific_manifest = document.exhibit_specific_manifest(current_exhibit.required_viewer.custom_manifest_pattern) %>
 
-    <%= iiif_drag_n_drop(exhibit_specific_manifest, width: '30px') if exhibit_specific_manifest %>
+    <%= iiif_drag_n_drop(exhibit_specific_manifest, width: '30') if exhibit_specific_manifest %>
   </div>
 </div>


### PR DESCRIPTION
You can see this error if you run the W3c validator:
https://validator.w3.org/nu/?doc=https%3A%2F%2Fexhibits.stanford.edu%2Fparker%2Fcatalog%3Futf8%3D%E2%9C%93%26sort%3Dpub_year_isi%2Basc%2C%2Btitle_sort%2Basc%26exhibit_id%3Dparker%26search_field%3Dsearch%26q%3Dastrology