### PR TITLE
Add border to search result thumbnails (list view)

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -51,7 +51,8 @@
     margin-top: 0;
   }
 
-  .thumbnail {
+  .thumbnail,
+  .document-thumbnail {
     img {
       @include thumbnail-image-border;
     }


### PR DESCRIPTION
This just adds a border to thumbnails in result list view (we're already using a border for the thumbnails in the other result views). This will help make thumbnails of PDF documents more distinct, such as in the VT exhibit, where currently the list view looks like this:

<img width="373" alt="before" src="https://user-images.githubusercontent.com/101482/35462310-a42e57a0-02a8-11e8-9560-fad68d30e496.png">

----

With this PR the same page will look like this:

<img width="368" alt="after" src="https://user-images.githubusercontent.com/101482/35462324-aecfe1c4-02a8-11e8-8774-fee5fbe43762.png">

----

I can't think of a reason not to do this; I checked a handful of existing exhibits and can't find a place where adding the border detracts from the appearance (mostly, it's not noticeable since our thumbnails tend to be of images that don't have white/light edges).