### PR TITLE
Make the oembed viewer the full-width of the item show page; fixes #1062

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -22,6 +22,11 @@
   #sidebar {
     display: none;
   }
+
+  .dl-horizontal {
+    margin-top: 2 * $padding-large-vertical;
+    width: 85ch;
+  }
 }
 
 .thumbnail {
@@ -29,13 +34,6 @@
 }
 
 #document {
-  .oembed-widget {
-    @extend .col-md-6;
-    @extend .col-sm-12;
-
-    padding-left: 0;
-  }
-
   h1 {
     font-size: $font-size-h3;
   }

--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -24,6 +24,7 @@
   }
 
   .dl-horizontal {
+    float: none;
     margin-top: 2 * $padding-large-vertical;
     width: 85ch;
   }

--- a/app/assets/stylesheets/viewers.scss
+++ b/app/assets/stylesheets/viewers.scss
@@ -5,3 +5,7 @@
 .help-text-row {
   padding-top: 12px;
 }
+
+.purl-link {
+  font-size: 0.9em;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,8 +62,6 @@ module ApplicationHelper
     [sir_trevor_block.try(:items).try(:first).try(:[], 'iiif_canvas_id').try(:[], /\d*$/).to_i - 1, 0].max
   end
 
-  private
-
   def context_specific_oembed_url(document)
     if feature_flags.uat_embed? && document['druid'].present?
       format(Settings.purl.uat_url, druid: document['druid'])

--- a/app/views/catalog/_viewer_default.html.erb
+++ b/app/views/catalog/_viewer_default.html.erb
@@ -4,4 +4,5 @@
   <% # block comes from a local passed in from Spotlight %>
   <% # https://github.com/projectblacklight/spotlight/blob/37f6a4c266db9aa9d2a59529340a634d1796fefc/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb#L10 %>
   <%= render_viewer_in_context(document, choose_canvas_index(local_assigns[:block]) ) %>
+  <%= link_to context_specific_oembed_url(document), context_specific_oembed_url(document), class: 'purl-link' %>
 <% end %>

--- a/config/initializers/oembed_providers.rb
+++ b/config/initializers/oembed_providers.rb
@@ -2,12 +2,12 @@ require 'oembed'
 
 OEmbed::Providers.register_all
 
-purl_provider = OEmbed::Provider.new('http://purl.stanford.edu/embed.{format}?&hide_title=true')
+purl_provider = OEmbed::Provider.new('http://purl.stanford.edu/embed.{format}?&hide_title=true&maxheight=600')
 purl_provider << 'http://purl.stanford.edu/*'
 purl_provider << 'https://purl.stanford.edu/*'
 purl_provider << 'http://searchworks.stanford.edu/*'
 
-purl_uat_provider = OEmbed::Provider.new('http://sul-purl-uat.stanford.edu/embed.{format}?&hide_title=true')
+purl_uat_provider = OEmbed::Provider.new('http://sul-purl-uat.stanford.edu/embed.{format}?&hide_title=true&maxheight=600')
 purl_uat_provider << 'https://sul-purl-uat.stanford.edu/*'
 
 OEmbed::Providers.register(purl_provider)


### PR DESCRIPTION
Also, add a purl link below the viewer; fixes #1063.

 ## After
<img width="1263" alt="viewer full width" src="https://user-images.githubusercontent.com/111218/35644269-5aa552a4-067d-11e8-9e8c-5f314f47320a.png">

## Before
![viewer_half_width](https://user-images.githubusercontent.com/5402927/35704934-db172c54-0755-11e8-94ce-d00fc3f42d3e.png)
