### PR TITLE
Explicitly cast the PurlFetcher config settings to a hash.

### DIFF
--- a/app/models/dor_harvester.rb
+++ b/app/models/dor_harvester.rb
@@ -96,7 +96,7 @@ class DorHarvester < Spotlight::Resource
 
   def harvestdor_indexer
     @harvestdor_indexer ||= Harvestdor::Indexer.new(
-      purl_fetcher: Settings.purl_fetcher,
+      purl_fetcher: Settings.purl_fetcher.to_h,
       harvestdor: Settings.harvestdor
     )
   end


### PR DESCRIPTION
For whatever reason this seems to be required to work correctly on the server (e.g. wasn't necessary for me running the code locally).