### PR TITLE
Drop the protocol from the PURL url used in link text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 ### Changed
+- No longer rendering the protocol (e.g. http/https) in the PURL link text. #1094
 ### Deprecated
 ### Removed
 ### Fixed

--- a/app/views/catalog/_viewer_default.html.erb
+++ b/app/views/catalog/_viewer_default.html.erb
@@ -4,5 +4,6 @@
   <% # block comes from a local passed in from Spotlight %>
   <% # https://github.com/projectblacklight/spotlight/blob/37f6a4c266db9aa9d2a59529340a634d1796fefc/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb#L10 %>
   <%= render_viewer_in_context(document, choose_canvas_index(local_assigns[:block]) ) %>
-  <%= link_to context_specific_oembed_url(document), context_specific_oembed_url(document), class: 'purl-link' %>
+  <% oembed_url = context_specific_oembed_url(document) %>
+  <%= link_to(oembed_url.sub(%r{^https?://}, ''), oembed_url, class: 'purl-link') if oembed_url %>
 <% end %>

--- a/spec/features/viewers_spec.rb
+++ b/spec/features/viewers_spec.rb
@@ -109,16 +109,24 @@ describe 'Viewers', type: :feature do
     # rubocop:enable RSpec/ExampleLength
   end
 
-  context 'Parker Theme' do
-    before do
-      exhibit.theme = 'parker'
-      exhibit.save
-    end
-
-    it 'hides the PURL link', js: true do
+  describe 'PURL link' do
+    it 'does not include the protocol' do
       visit spotlight.exhibit_solr_document_path(exhibit, 'hj066rn6500')
 
-      expect(page).not_to have_css('.purl-link', visible: true)
+      expect(page).to have_css('a', text: %r{^purl\.stanford\.edu/hj066rn6500})
+    end
+
+    context 'Parker Theme' do
+      before do
+        exhibit.theme = 'parker'
+        exhibit.save
+      end
+
+      it 'hides the PURL link', js: true do
+        visit spotlight.exhibit_solr_document_path(exhibit, 'hj066rn6500')
+
+        expect(page).not_to have_css('.purl-link', visible: true)
+      end
     end
   end
 end


### PR DESCRIPTION
Connected to #1063
Closes #1081 

<img width="642" alt="sx512yh0203-after" src="https://user-images.githubusercontent.com/96776/36224441-78313e32-117c-11e8-905a-d78769a667b7.png">
