### PR TITLE
Make (Parker) thumbnail bgcolor same as theme body bgcolor

### DIFF
--- a/app/assets/stylesheets/modules/parker.scss
+++ b/app/assets/stylesheets/modules/parker.scss
@@ -1,4 +1,5 @@
-body {
+body,
+.thumbnail {
   background-color: $color-beige-05;
 }
 


### PR DESCRIPTION
Fixes #1097 

Before:

<img width="502" alt="item_row_widget___parker_library_on_the_web_-_stanford_university_libraries" src="https://user-images.githubusercontent.com/101482/36455515-ac5ed102-165d-11e8-8ef2-46316a7b171d.png">

After:

<img width="478" alt="after" src="https://user-images.githubusercontent.com/101482/36455519-b14b7f80-165d-11e8-9fec-33de8eddbcba.png">
