### PR TITLE
Remove code to prevent item-block images to stretch

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -184,10 +184,3 @@
 .thumbnail > img {
   @include thumbnail-image-border;
 }
-
-.items-block {
-  .thumbnail img {
-    max-width: 400px;
-    width: 100%;
-  }
-}


### PR DESCRIPTION
Fixes #1096 

We added the `.items-block` CSS I'm proposing to delete at some point, presumably for good reason, but removing it prevents the problem noted in #1096 and I tested the fix with the other widgets that I believe are targeted by the `.items-block` CSS and they don't seem to be negatively affected.

It's hard to test locally all combinations of the potentially relevant widgets, however, so ideally I'd like it if we could deploy this fix to -stage, at which point I'll double-check with a wider variety of widget implementations to be sure there aren't negative ramifications I'm missing locally.

Note the image is not as tall in the after version below, and since it's not stretched beyond the natural thumbnail height, the image is sharper.

### Before

<img width="444" alt="before" src="https://user-images.githubusercontent.com/101482/36456318-99f812c2-1661-11e8-8734-4f41e8de98c3.png">


### After

<img width="413" alt="after" src="https://user-images.githubusercontent.com/101482/36456326-9fe397e2-1661-11e8-9ce4-94ec9e93906f.png">

