### PR TITLE
 Deduplicate highlighting results based on the underlying highlighted phrase

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -66,9 +66,9 @@ module CatalogHelper
   end
 
   # rubocop:disable Rails/OutputSafety
-  def render_fulltext_highlight(args)
-    highlights = full_text_highlights(args[:document]['id'])
-    return if highlights.blank?
+  def render_fulltext_highlight(document:, **_args)
+    highlights = document.full_text_highlights
+    return if highlights.none?
 
     safe_join(highlights.take(Settings.full_text_highlight.snippet_count).map do |val|
       content_tag('p') do
@@ -86,13 +86,5 @@ module CatalogHelper
     elsif document.canvas?
       blacklight_config.view_config(document_index_view_type).default_canvas_thumbnail
     end
-  end
-
-  def full_text_highlights(document_id)
-    highlighting_response = @response.dig('highlighting', document_id) || {}
-
-    highlighting_response.select do |k, _|
-      Settings.full_text_highlight.fields.include?(k)
-    end.values.flatten.compact.uniq
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -43,8 +43,12 @@ class SolrDocument
   def full_text_highlights
     highlighting_response = response.dig('highlighting', id) || {}
 
-    highlighting_response.select do |k, _|
+    all_results = highlighting_response.select do |k, _|
       Settings.full_text_highlight.fields.include?(k)
-    end.values.flatten.compact.uniq
+    end.values.flatten.compact
+
+    all_results.uniq do |value|
+      value.gsub(%r{</?em>}, '')
+    end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -39,4 +39,12 @@ class SolrDocument
   mods_xml_source do |model|
     model.fetch(:modsxml)
   end
+
+  def full_text_highlights
+    highlighting_response = response.dig('highlighting', id) || {}
+
+    highlighting_response.select do |k, _|
+      Settings.full_text_highlight.fields.include?(k)
+    end.values.flatten.compact.uniq
+  end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -129,50 +129,36 @@ describe CatalogHelper, type: :helper do
   end
 
   describe '#render_fulltext_highlight' do
-    let(:document) { { 'id' => 'abc123' } }
-    let(:values) { %w(Value1 Value2) }
+    let(:document) { instance_double(SolrDocument, full_text_highlights: highlights) }
 
     context 'when there is a matching highlight for the given document' do
-      it 'wraps each highlight value in a paragraph tag' do
-        assign(
-          :response,
-          'highlighting' => {
-            'abc123' => { 'full_text_search_en' => ['The first <em>Value1</em>', 'The <em>Value2</em> second'] }
-          }
-        )
+      let(:highlights) do
+        ['The first <em>Value1</em>', 'The <em>Value2</em> second']
+      end
 
-        ps = helper.render_fulltext_highlight(value: values, document: document)
+      it 'wraps each highlight value in a paragraph tag' do
+        ps = helper.render_fulltext_highlight(document: document)
         expect(ps).to eq '<p>The first <em>Value1</em></p><p>The <em>Value2</em> second</p>'
       end
     end
 
     context 'when there are more than the configured amount of highlight snippets returned' do
-      let(:highlight_snippets) do
-        {
-          'full_text_search_en' => %w(Value1 Value2 Value3 Value4),
-          'full_text_search_pt' => %w(Value5 Value6 Value7 Value8)
-        }
+      let(:highlights) do
+        %w(Value1 Value2 Value3 Value4 Value5 Value6 Value7 Value8)
       end
 
       it 'only renders the configured amount of snippets' do
-        assign(
-          :response,
-          'highlighting' => {
-            'abc123' => highlight_snippets
-          }
-        )
-
-        ps = helper.render_fulltext_highlight(value: values, document: document)
+        ps = helper.render_fulltext_highlight(document: document)
         expect(ps.scan('<p>').count).to eq Settings.full_text_highlight.snippet_count
       end
     end
 
     context 'when the response does not include highlighting for the given document' do
-      it 'is nil' do
-        assign(:response, 'highlighting' => { 'xyz987' => { 'full_text_search_en' => values } })
+      let(:highlights) { [] }
 
-        ps = helper.render_fulltext_highlight(value: values, document: document)
-        expect(ps).to be_nil
+      it 'is nil' do
+        ps = helper.render_fulltext_highlight(document: document)
+        expect(ps).to be_blank
       end
     end
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -117,4 +117,33 @@ describe SolrDocument do
       expect(document.mods).to be_an ModsDisplay::HTML
     end
   end
+
+  describe '#full_text_highlights' do
+    subject(:document) { described_class.new({ id: 'abc123' }, response) }
+    let(:response) { {} }
+
+    context 'without any highlighting results returned' do
+      it 'returns an empty array' do
+        expect(document.full_text_highlights).to be_blank
+      end
+    end
+
+    context 'with highlighting for the document' do
+      let(:response) do
+        {
+          'highlighting' => {
+            'abc123' => {
+              'full_text_search_en' => %w(a b),
+              'full_text_search_pt' => ['c'],
+              'some_other_field' => ['not_d']
+            }
+          }
+        }
+      end
+
+      it 'returns the results from only the configured fields' do
+        expect(document.full_text_highlights).to match_array %w(a b c)
+      end
+    end
+  end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -145,5 +145,19 @@ describe SolrDocument do
         expect(document.full_text_highlights).to match_array %w(a b c)
       end
     end
+
+    context 'when there are multiple highlights for the same phrase in a document with varying highlighting' do
+      let(:response) do
+        {
+          'highlighting' => {
+            'abc123' => { 'full_text_search_en' => ['The first <em>Value1</em>', 'The <em>first</em> <em>Value1</em>'] }
+          }
+        }
+      end
+
+      it 'returns only the unique highlighting phrases' do
+        expect(document.full_text_highlights).to match_array ['The first <em>Value1</em>']
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1118, or at least makes it a little better.

The new `uniq` block has an unfortunate property of just picking the first matching result instead of, say, one with the most highlights, meaning we (continue to) prioritize languages that appear earlier in our list of highlighted fields. 