### PR TITLE
Adds configurable async javascript to improve time to first paint

### DIFF
--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -24,7 +24,7 @@
       <%= stylesheet_link_tag "application" %>
     <% end %>
     <%= stylesheet_link_tag "https://www.stanford.edu/su-identity/css/su-identity.css" %>
-    <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "application", async: Settings.async_javascript %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
     <%= description %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,3 +57,4 @@ mirador_options:
   windowSettings:
     sidePanel: true
     sidePanelVisible: false
+async_javascript: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -9,3 +9,4 @@ purl:
     prefix: "http://purl.stanford.edu/"
 sidekiq:
   logger_level: 'Logger::WARN'
+async_javascript: true


### PR DESCRIPTION
Since we include all of the JavaScript into a large bundle, lets load it
async so that we increase the page time to first paint for users.

https://developers.google.com/web/tools/lighthouse/audits/blocking-resources

## Before this pull request
<img width="763" alt="screen shot 2018-04-20 at 4 36 18 pm" src="https://user-images.githubusercontent.com/1656824/39077764-1e2b8c9c-44b9-11e8-8e77-6e79531dcfab.png">

## Using async
<img width="723" alt="screen shot 2018-04-20 at 4 36 27 pm" src="https://user-images.githubusercontent.com/1656824/39077763-1e19269c-44b9-11e8-8198-e5e8c843be23.png">
