### PR TITLE
Update styling of user metrics on Analytics page

### DIFF
--- a/app/assets/stylesheets/modules/admin.scss
+++ b/app/assets/stylesheets/modules/admin.scss
@@ -19,3 +19,22 @@ a[aria-expanded=false] .glyphicon-chevron-down {
 .text-as-label {
   font-weight: bold;
 }
+
+h3 + .table.analytics {
+  margin-top: $padding-large-vertical * 2;
+}
+
+.table.analytics {
+  background-color: $table-bg-accent;
+
+  .value {
+    color: $color-gray-90;
+    font-size: $font-size-h2;
+    font-weight: 700;
+    padding-bottom: 0;
+  }
+
+  + h4 {
+    margin-top: $padding-large-vertical * 4;
+  }
+}


### PR DESCRIPTION
The display of the user metrics on the current Analytics page is a bit anemic:

<img width="443" alt="analytics-before" src="https://user-images.githubusercontent.com/101482/39141311-4fe3edf4-46dc-11e8-9e51-76507cf48632.png">

This is a CSS-only PR to make the user metrics a bit more prominent and easier to see at a glance:

<img width="440" alt="analytics-after" src="https://user-images.githubusercontent.com/101482/39141343-659a3838-46dc-11e8-8410-e72e668ed91d.png">
