### PR TITLE
Add border to thumbnail images that are inside a link tag

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -181,6 +181,7 @@
   }
 }
 
-.thumbnail > img {
+.thumbnail > img,
+.thumbnail > a > img {
   @include thumbnail-image-border;
 }


### PR DESCRIPTION
Just extends our current styling of thumbnail images to include those thumbnails that are contained by a link tag.

### Before
<img width="464" alt="before" src="https://user-images.githubusercontent.com/101482/39379188-610621f2-4a0f-11e8-89a1-7afc2829db74.png">

### After
<img width="443" alt="after" src="https://user-images.githubusercontent.com/101482/39379196-67d1a8e4-4a0f-11e8-830d-9b4f0103ebab.png">
