### PR TITLE
Update translation progress badge styling to match SUL style

### DIFF
--- a/app/assets/stylesheets/modules/admin.scss
+++ b/app/assets/stylesheets/modules/admin.scss
@@ -38,3 +38,10 @@ h3 + .table.analytics {
     margin-top: $padding-large-vertical * 4;
   }
 }
+
+[data-behavior="translation-progress"] .badge {
+  background-color: $color-beige-10;
+  border-radius: 3px;
+  color: $black;
+  font-weight: normal;
+}


### PR DESCRIPTION
### Before

<img width="433" alt="before" src="https://user-images.githubusercontent.com/101482/39438454-0b4914b2-4c59-11e8-979a-7fe306d1b537.png">

### After

<img width="440" alt="after" src="https://user-images.githubusercontent.com/101482/39438456-10c50680-4c59-11e8-9c26-3427c16633e6.png">
