### PR TITLE
Update styling of translation pages

### DIFF
--- a/app/assets/stylesheets/modules/admin.scss
+++ b/app/assets/stylesheets/modules/admin.scss
@@ -45,3 +45,13 @@ h3 + .table.analytics {
   color: $black;
   font-weight: normal;
 }
+
+#new_language {
+  margin-bottom: $padding-large-vertical * 3;
+}
+
+.translation-subheading {
+  font-size: $font-size-h3;
+  margin-top: $padding-large-vertical * 3;
+  padding-bottom: $padding-base-vertical;
+}


### PR DESCRIPTION
Just a couple of spacing and font-size adjustments:

### Before

<img width="478" alt="languages-before" src="https://user-images.githubusercontent.com/101482/39441222-209261d0-4c62-11e8-8c37-b8ad6fb654f5.png">

---

<img width="468" alt="before" src="https://user-images.githubusercontent.com/101482/39441230-257414be-4c62-11e8-888f-afd46c00de11.png">

### After

<img width="447" alt="languages-after" src="https://user-images.githubusercontent.com/101482/39441242-2c466bac-4c62-11e8-82e7-20243d04ddae.png">

---

<img width="452" alt="after" src="https://user-images.githubusercontent.com/101482/39441260-3147f31e-4c62-11e8-9013-275348ef7316.png">
