### PR TITLE
Update Spotlight Upload Field configurations.

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -1,6 +1,6 @@
 Spotlight::Engine.config.upload_title_field = Spotlight::UploadFieldConfig.new(
-  field_name: %w(title title_full_display title_display title_245_search title_sort),
-  label: -> { I18n.t(:'spotlight.search.fields.title') }
+  field_name: :spotlight_upload_title_tesim,
+  label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_title_tesim') }
 )
 Spotlight::Engine.config.upload_fields = [
   Spotlight::UploadFieldConfig.new(
@@ -13,7 +13,7 @@ Spotlight::Engine.config.upload_fields = [
     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_attribution_tesim') }
   ),
   Spotlight::UploadFieldConfig.new(
-    field_name: %w(date spotlight_upload_date_tesim date_sort),
+    field_name: :spotlight_upload_date_tesim,
     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
   )
 ]

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -31,4 +31,4 @@ en:
         help: Enter a valid SUNet email address. Do not enter an email alias or an email address that isn't in the stanford.edu domain.
     search:
       fields:
-        title: Title
+        spotlight_upload_title_tesim: Title

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -339,6 +339,11 @@
   <!-- exhibits fields -->
   <copyField source="id" dest="id_ng" maxChars="3000"/>
   <copyField source="title_full_display" dest="full_title_ng" maxChars="3000"/>
+  <copyField source="spotlight_upload_title_tesim" dest="title_display" />
+  <copyField source="spotlight_upload_title_tesim" dest="title_full_display" />
+  <copyField source="spotlight_upload_title_tesim" dest="title_245_search" />
+  <copyField source="spotlight_upload_title_tesim" dest="title_sort" />
+  <copyField source="spotlight_upload_date_tesim" dest="date_sort" />
   <!-- NOTE:  all_search is meant for metadata -->
   <copyField source="*_tesim" dest="all_search" />
   <copyField source="*_tesim" dest="all_unstem_search" />


### PR DESCRIPTION
Currently, adding/editing titles/dates do not work for uploaded documents.

This approach adds a new field (following the naming convention for other upload fields) and uses solr's copyFields instead.

This approach will also require that we run a pre deploy data migration that populates this new field from existing data (for the 836 existing documents).

https://solr-host/solr/exhibits_prod/select?fq=spotlight_resource_type_ssim:spotlight/resources/uploads&wt=json&fl=id,title*,date*