### PR TITLE
Update MigrateSpotlightUploadFieldConfig to match what was…

### DIFF
--- a/db/migrate/20180511231633_migrate_spotlight_upload_field_config.rb
+++ b/db/migrate/20180511231633_migrate_spotlight_upload_field_config.rb
@@ -2,27 +2,64 @@
 # A revesible data migration to switch the spotlight_upload prefixed
 # field data with the previously generically named title/date data
 class MigrateSpotlightUploadFieldConfig < ActiveRecord::Migration[5.1]
+  NEW_TITLE_FIELD = 'spotlight_upload_title_tesim'.freeze
+  OLD_TITLE_FIELD = 'title'.freeze
+  NEW_DATE_FIELD = 'spotlight_upload_title_tesim'.freeze
+  OLD_DATE_FIELD = 'date'.freeze
+
   def up
     Spotlight::Resources::Upload.find_each do |upload|
-      data = upload.data
-      upload.data = data.merge(
-        'spotlight_upload_title_tesim' => data['title'],
-        'spotlight_upload_date_tesim' => data['date']
-      ).delete_if { |k, _| %w[date title].include?(k) }
+      next unless upload.exhibit
+      next unless upload.sidecar
+      sidecar = upload.sidecar
 
+      upload.data = migrate_data_up(upload.data)
+      sidecar.data['configured_fields'] = migrate_data_up(sidecar.data['configured_fields'])
+
+      sidecar.save
       upload.save_and_index
     end
   end
 
   def down
     Spotlight::Resources::Upload.find_each do |upload|
-      data = upload.data
-      upload.data = data.merge(
-        'title' => data['spotlight_upload_title_tesim'],
-        'date' => data['spotlight_upload_date_tesim']
-      ).delete_if { |k, _| %w[spotlight_upload_date_tesim spotlight_upload_title_tesim].include?(k) }
+      next unless upload.exhibit
+      next unless upload.sidecar
+      sidecar = upload.sidecar
 
+      upload.data = migrate_data_down(upload.data)
+      sidecar.data['configured_fields'] = migrate_data_down(sidecar.data['configured_fields'])
+
+      sidecar.save
       upload.save_and_index
     end
+  end
+
+  def migrate_data_up(data)
+    if data[OLD_TITLE_FIELD].present?
+      data[NEW_TITLE_FIELD] = data[OLD_TITLE_FIELD]
+      data.delete(OLD_TITLE_FIELD)
+    end
+
+    if data[OLD_DATE_FIELD].present?
+      data[NEW_DATE_FIELD] = data[OLD_DATE_FIELD]
+      data.delete(OLD_DATE_FIELD)
+    end
+
+    data
+  end
+
+  def migrate_data_down(data)
+    if data[NEW_TITLE_FIELD].present?
+      data[OLD_TITLE_FIELD] = data[NEW_TITLE_FIELD]
+      data.delete(NEW_TITLE_FIELD)
+    end
+
+    if data[NEW_DATE_FIELD].present?
+      data[OLD_DATE_FIELD] = data[NEW_DATE_FIELD]
+      data.delete(OLD_DATE_FIELD)
+    end
+
+    data
   end
 end


### PR DESCRIPTION
…(subsequently) run on our database.

We can take or leave this, the only thing we're really gaining is ensuring that our down migration is accurate to what we migrated up (although I don't foresee it ever being necessary).

