### PR TITLE
Add an optional OKComputer check for the background job retry queue size

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -6,4 +6,30 @@ OkComputer::Registry.register "cache", OkComputer::CacheCheck.new
 OkComputer::Registry.register "background_jobs", OkComputer::SidekiqLatencyCheck.new(10, 50)
 OkComputer::Registry.register "solr", OkComputer::SolrCheck.new(Blacklight.default_index.connection.uri.to_s.sub(/\/$/, ''))
 
-OkComputer.make_optional %w(version cache background_jobs)
+class SidekiqRetryQueueCheck < OkComputer::Check
+  def check
+    if sidekiq_retry_size > sidekiq_retry_size_threshold
+      mark_failure
+      mark_message "Sidekiq retry queue size (#{sidekiq_retry_size}) is above the threshold (#{sidekiq_retry_size_threshold})"
+    else
+      mark_message "Sidekiq retry queue size (#{sidekiq_retry_size}) is below the threshold (#{sidekiq_retry_size_threshold})"
+    end
+  rescue => e
+    mark_failure
+    mark_message "Unable to check sidekiq retry queue size with error: #{e}"
+  end
+
+  private
+
+  def sidekiq_retry_size
+    Sidekiq::Stats.new.retry_size.to_i
+  end
+
+  def sidekiq_retry_size_threshold
+    Settings.sidekiq_retry_queue_threshold.to_i
+  end
+end
+
+OkComputer::Registry.register 'sidekiq-retry', SidekiqRetryQueueCheck.new
+
+OkComputer.make_optional %w(version cache background_jobs sidekiq-retry)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,3 +58,4 @@ mirador_options:
     sidePanel: true
     sidePanelVisible: false
 async_javascript: false
+sidekiq_retry_queue_threshold: 100


### PR DESCRIPTION
Potential solution for #769

This isn't necessarily tracking Failed jobs (as is in the description of the issue) but will show us when the retry queue exceeds a particular threshold.  This allows us to not have to track failed jobs overtime and simply rely on a large number of retries queueing up to determine if something is going wrong with the indexing code/pipeline.

This is an optional check, so will only really be useful visually (until/unless we do some sort of more granular monitoring of optional checks).  As-is, this is more or less just adds an additional visual check on the status page.

This is totally up for discussion, I pretty much wrote this as a curiosity as I was looking over the Sidekiq API documentation for something unrelated.