### PR TITLE
Use OpenSeadragon for viewing external IIIF resources

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -51,4 +51,9 @@ class SolrDocument
       value.gsub(%r{</?em>}, '')
     end
   end
+
+  def external_iiif?
+    self[self.class.resource_type_field].present? &&
+      self[self.class.resource_type_field].include?('spotlight/resources/iiif_harvesters')
+  end
 end

--- a/app/views/catalog/_viewer_default.html.erb
+++ b/app/views/catalog/_viewer_default.html.erb
@@ -1,4 +1,4 @@
-<% if document.uploaded_resource? %>
+<% if document.uploaded_resource? || document.external_iiif? %>
   <%= render partial: "openseadragon_default", locals: {document: document} %>
 <% else %>
   <% # block comes from a local passed in from Spotlight %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -118,6 +118,22 @@ describe SolrDocument do
     end
   end
 
+  describe '#external_iiif?' do
+    context 'when a document is an external IIIF resource' do
+      subject(:document) { described_class.new(spotlight_resource_type_ssim: ['spotlight/resources/iiif_harvesters']) }
+      it 'returns true when the correct fields are present' do
+        expect(document.external_iiif?).to be true
+      end
+    end
+
+    context 'when a document is not an external IIIF resource' do
+      subject(:document) { described_class.new }
+      it 'returns false if the correct fields are not present' do
+        expect(document.external_iiif?).to be false
+      end
+    end
+  end
+
   describe '#full_text_highlights' do
     subject(:document) { described_class.new({ id: 'abc123' }, response) }
     let(:response) { {} }


### PR DESCRIPTION
Fixes a bug reported by @blalbrit where external IIIF resources were not viewable on the show page. External IIIF resources now appear with OpenSeadragon by default.

## Before
<img width="648" alt="no viewer rendered" src="https://user-images.githubusercontent.com/5402927/41236134-36da4abc-6d45-11e8-8c31-9ddc24d23bf7.png">

## After
<img width="634" alt="fallback viewer rendered" src="https://user-images.githubusercontent.com/5402927/41236135-36ef6e6a-6d45-11e8-803a-670916d2f56c.png">

