### PR TITLE
[WIP] Render Mirador for IIIF external resources

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
   end
 
   def render_external_iiif_viewer(document, block)
-    if current_exhibit.viewer.viewer_type != 'mirador'
+    if current_exhibit.viewer.nil? || current_exhibit.viewer.viewer_type != 'mirador'
       mirador_instance = Viewer.create(viewer_type: 'mirador')
       render mirador_instance, document: document, block: block
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,4 +65,13 @@ module ApplicationHelper
       document.first(blacklight_config.show.oembed_field)
     end
   end
+
+  def render_external_iiif_viewer(document, block)
+    if current_exhibit.viewer.viewer_type != 'mirador'
+      mirador_instance = Viewer.create(viewer_type: 'mirador')
+      render mirador_instance, document: document, block: block
+    else
+      render current_exhibit.required_viewer, document: document, block: block
+    end
+  end
 end

--- a/app/views/catalog/_viewer_default.html.erb
+++ b/app/views/catalog/_viewer_default.html.erb
@@ -1,5 +1,7 @@
-<% if document.uploaded_resource? || document.external_iiif? %>
+<% if document.uploaded_resource? %>
   <%= render partial: "openseadragon_default", locals: {document: document} %>
+<% elsif document.external_iiif? %>
+  <%= render_external_iiif_viewer(document, choose_canvas_id(local_assigns[:block])) %>
 <% else %>
   <% # block comes from a local passed in from Spotlight %>
   <% # https://github.com/projectblacklight/spotlight/blob/37f6a4c266db9aa9d2a59529340a634d1796fefc/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb#L10 %>

--- a/app/views/viewers/_mirador.html.erb
+++ b/app/views/viewers/_mirador.html.erb
@@ -1,4 +1,10 @@
-<% exhibit_specific_manifest = document.exhibit_specific_manifest(current_exhibit.required_viewer.custom_manifest_pattern) %>
+<% exhibit_specific_manifest = if document.external_iiif?
+                                document["iiif_manifest_url_ssi"]
+                              else
+                                document.exhibit_specific_manifest(
+                                  current_exhibit.required_viewer.custom_manifest_pattern
+                                )
+                              end %>
 
 <% if exhibit_specific_manifest %>
   <iframe


### PR DESCRIPTION
Fixes #1216 

Exhibits now...
- renders OSD for uploaded resources
- renders Mirador for **valid** external IIIF

**TODO:** 
- [ ] additional specs
- [x] fall back to OSD for invalid manifests? <-- unfortunately, we need to make some policy decision re: what support (if any) we'll offer for invalid manifests, as well as where validation can / should happen in this process (per view, on the fly? at import?). 
- [x]  fix bug where Mirador viewer is unavailable the first time you access it (e.g. implement something similar to `required_viewer`. 

### Regular PURL 🐱 (SUL-Embed default viewer)
![item rendered in UnviersalViewer](https://user-images.githubusercontent.com/5402927/43865972-0a2a74ea-9b19-11e8-9c77-ffe07ecdf7fd.png)

### Uploaded resource (OSD with semi-working controls)
![item rendered in Openseadragon](https://user-images.githubusercontent.com/5402927/43865980-0f6740d2-9b19-11e8-8ac4-8ccdaff439a8.png)

### Valid External IIIF resource (Mirador)
![item rendered in Mirador](https://user-images.githubusercontent.com/5402927/43866017-29bc1bc4-9b19-11e8-9237-26e39a5e0dbd.png)

### TODO: Invalid External IIIF resource (OSD with non-working zoom) 
😢
![empty Mirador instance](https://user-images.githubusercontent.com/5402927/43916237-dcac163c-9bc1-11e8-9996-8d8188fee9d5.png)

