### PR TITLE
Bump factory_bot_rails and rubocop-rspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,10 +281,10 @@ GEM
       activesupport (>= 3.0, < 6.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    factory_bot (4.10.0)
+    factory_bot (4.11.0)
       activesupport (>= 3.0.0)
-    factory_bot_rails (4.10.0)
-      factory_bot (~> 4.10.0)
+    factory_bot_rails (4.11.0)
+      factory_bot (~> 4.11.0)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -542,8 +542,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.27.0)
-      rubocop (>= 0.56.0)
+    rubocop-rspec (1.28.0)
+      rubocop (>= 0.58.0)
     ruby-oembed (0.12.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
@@ -790,4 +790,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,15 +4,15 @@
 FactoryBot.define do
   factory :curator, class: User do
     sequence(:email) { |n| "curator#{n}@example.com" }
-    password 'password'
-    password_confirmation 'password'
+    password { 'password' }
+    password_confirmation { 'password' }
     after(:build) { |user| user.webauth_groups = 'dlss:exhibits-creators' }
   end
 
   factory :admin, class: User do
     sequence(:email) { |n| "admin#{n}@example.com" }
-    password 'password'
-    password_confirmation 'password'
+    password { 'password' }
+    password_confirmation { 'password' }
     after(:build) { |user| user.webauth_groups = 'dlss:exhibits-admin' }
   end
 end


### PR DESCRIPTION
Noticed the tests failing on #1233 so thought I'd clean them up. This just updates the gems that were causing that (FactoryBot just deprecated using non-block declarations, and `rubocop-rspec` added a cop for it).