### PR TITLE
Remove Stanford 'S' and link to documentation exhibit

### DIFF
--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -18,9 +18,8 @@
       "http://library.stanford.edu/department/library-communications-and-development" %>
     </li>
     <li>
-      <%= link_to "https://consul.stanford.edu/x/2ok1CQ" do %>
-        Exhibit documentation &amp; marketing <%= image_tag("stanford_s.png", class: "stanford-only", alt: "Stanford only") %>
-      <% end %>
+      <%= link_to "Exhibit documentation & marketing",
+      "https://exhibits.stanford.edu/exhibits-documentation" %>
     </li>
     <li>
       <%= link_to "https://consul.stanford.edu/x/g4A-CQ" do %>


### PR DESCRIPTION
Fixes #1254 

<img width="338" alt="stanford_university_libraries" src="https://user-images.githubusercontent.com/101482/47054703-358c6f00-d168-11e8-86b6-8db173f36cd4.png">
