### PR TITLE
Remove link and rename other link in site 'See Also' sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 ### Changed
+- Change sidebar links to newer documentation #1255, #1260
 ### Deprecated
 ### Removed
 ### Fixed
@@ -20,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Long versioned pages cannot be saved now fixed #1225
 ### Security
-- Updates dependencies #1232 
+- Updates dependencies #1232
 
 ## [v1.20.0] - 2018-08-09
 

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -2,11 +2,7 @@
   <h2 class="nav-heading">See also</h2>
   <ul class="nav sidenav">
     <li>
-      <%= link_to "Digital collections in SearchWorks",
-      "http://searchworks.stanford.edu/catalog?f%5Bcollection_type%5D%5B%5D=Digital+Collection" %>
-    </li>
-    <li>
-      <%= link_to "Older collection exhibits",
+      <%= link_to "Other library collections at Stanford",
       "http://library.stanford.edu/collections" %>
     </li>
     <li>


### PR DESCRIPTION
Fixes #1259 

Before:

<img width="350" alt="stanford_university_libraries" src="https://user-images.githubusercontent.com/101482/47667165-876ac700-db62-11e8-8c50-0d23c8caafd7.png">

After removing first link and renaming second link:

<img width="317" alt="stanford_university_libraries-2" src="https://user-images.githubusercontent.com/101482/47667186-95b8e300-db62-11e8-9a66-e3696d354954.png">
