### PR TITLE
Remove Callnumber and Full text from default exhibit Search config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 ### Changed
+- Remove "Call number" and "Full text" from default search fields for new exhibits #1293
 ### Deprecated
 ### Removed
 ### Fixed

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -294,6 +294,7 @@ class CatalogController < ApplicationController
       field.solr_parameters = {
         df: 'callnum_search'
       }
+      field.enabled = false
     end
 
     config.add_search_field('full_text') do |field|
@@ -305,6 +306,7 @@ class CatalogController < ApplicationController
         pf3: '${pf3_full_text}',
         pf2: '${pf2_full_text}'
       }
+      field.enabled = false
     end
 
     config.add_search_field('table_of_contents') do |field|

--- a/spec/features/exhibit_spec.rb
+++ b/spec/features/exhibit_spec.rb
@@ -9,7 +9,9 @@ describe 'an exhibit', type: :feature do
     visit '/'
   end
 
-  it 'has working full text fielded search' do
+  it 'can enable full text fielded search' do
+    exhibit.blacklight_configuration.search_fields['full_text'] = { enabled: true }
+    exhibit.blacklight_configuration.save
     visit spotlight.url_for(exhibit)
     fill_in 'q', with: 'cobbler'
     select 'Full text', from: 'search_field'


### PR DESCRIPTION
Fixes #1244 

This PR ensure that the following search fields are UNselected by default for new exhibits:
- Call number
- Full text

## Before
![most options selected](https://user-images.githubusercontent.com/5402927/49320642-a0df9580-f4b7-11e8-9361-d57bfca5e9a6.png)

## After
![more options deslected](https://user-images.githubusercontent.com/5402927/49320643-a0df9580-f4b7-11e8-8da4-bb847ced0e68.png)



## After