### PR TITLE
Update upload_title_field solr configuration to remove a non-solr field

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -1,5 +1,5 @@
 Spotlight::Engine.config.upload_title_field = Spotlight::UploadFieldConfig.new(
-  solr_fields: %w(title title_full_display title_display title_245_search title_sort spotlight_upload_title_tesim),
+  solr_fields: %w(title_full_display title_display title_245_search title_sort spotlight_upload_title_tesim),
   field_name: :spotlight_upload_title_tesim,
   label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_title_tesim') }
 )


### PR DESCRIPTION
The conversation in #1177 makes me suspect we intended to remove the `title` field entirely, and it was mistakenly restored in #1258 as copy-pasta from the previous code. In any case, indexing uploaded documents doesn't work with the current configuration, so it should be safe to remove. 