### PR TITLE
Don't send invited users through Devise's password confirmation...

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,9 @@ class User < ApplicationRecord
   include Blacklight::User
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :confirmable, :lockable, :registerable, :recoverable, :timeoutable and :omniauthable
   devise :invitable, :remote_user_authenticatable, :database_authenticatable,
-         :registerable, :recoverable, :rememberable, :trackable, :validatable
+         :rememberable, :trackable, :validatable
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -9,7 +9,8 @@
 
 <p><%= t("spotlight.#{key}.invitation_instructions.someone_invited_you", role: @resource.roles.first.role, exhibit_name: @resource.roles.first.resource.title, url: spotlight.exhibit_home_page_url(@resource.roles.first.resource)) %></p>
 
-<p><%= link_to t("spotlight.#{key}.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token, referrer: spotlight.exhibit_path(@resource.roles.first.resource)) %></p>
+<% # We pass the user to the new_user_session_url so that they are kicked through our authentication service. Devise's default behavior is to send a user to a password confirmation page, which we do not want. %>
+<p><%= link_to t("spotlight.#{key}.invitation_instructions.accept"), new_user_session_url(invitation_token: @token, referrer: spotlight.exhibit_path(@resource.roles.first.resource)) %></p>
 
 <p><%= t("spotlight.#{key}.invitation_instructions.ignore_html", exhibit_name: @resource.roles.first.resource.title) %></p>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,6 +166,10 @@ Devise.setup do |config|
   # Default: false
   # config.allow_insecure_sign_in_after_accept = true
 
+  # We don't maintain user passwords, so we should not
+  # require a password when a user accepts an invitation
+  config.require_password_on_accepting = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be


### PR DESCRIPTION
... and pass them through our authentication service instead.

Closes #1243 