### PR TITLE
[WIP] Change default height for viewers in item embed

### DIFF
--- a/app/assets/stylesheets/viewers.scss
+++ b/app/assets/stylesheets/viewers.scss
@@ -10,10 +10,12 @@
   font-size: 0.9em;
 }
 
-.custom-oembed {
+.pull-right .custom-oembed,
+.pull-left .custom-oembed {
   height: 400px;
 }
 
+.custom-oembed,
 .show-document .custom-oembed {
   height: 600px;
 }

--- a/app/assets/stylesheets/viewers.scss
+++ b/app/assets/stylesheets/viewers.scss
@@ -9,3 +9,11 @@
 .purl-link {
   font-size: 0.9em;
 }
+
+.custom-oembed {
+  height: 400px;
+}
+
+.show-document .custom-oembed {
+  height: 600px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,7 @@ module ApplicationHelper
   def custom_render_oembed_tag_async(document, canvas_id)
     url = context_specific_oembed_url(document)
 
-    content_tag :div, '', data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
+    content_tag :div, '', style: 'height: 400px;',data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
   end
 
   ##

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,7 @@ module ApplicationHelper
   def custom_render_oembed_tag_async(document, canvas_id)
     url = context_specific_oembed_url(document)
 
-    content_tag :div, '', style: 'height: 400px;',data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
+    content_tag :div, '', class: 'custom-oembed', data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
   end
 
   ##

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,9 @@ module ApplicationHelper
   def custom_render_oembed_tag_async(document, canvas_id)
     url = context_specific_oembed_url(document)
 
-    content_tag :div, '', class: 'custom-oembed', data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
+    content_tag :div, '',
+                class: 'custom-oembed',
+                data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
   end
 
   ##

--- a/config/initializers/oembed_providers.rb
+++ b/config/initializers/oembed_providers.rb
@@ -2,7 +2,7 @@ require 'oembed'
 
 OEmbed::Providers.register_all
 
-purl_provider = OEmbed::Provider.new('http://purl.stanford.edu/embed.{format}?&hide_title=true&maxheight=600')
+purl_provider = OEmbed::Provider.new('http://purl.stanford.edu/embed.{format}?&hide_title=true&fullheight=true')
 purl_provider << 'http://purl.stanford.edu/*'
 purl_provider << 'https://purl.stanford.edu/*'
 purl_provider << 'http://searchworks.stanford.edu/*'


### PR DESCRIPTION
Fixes #1196 
We'll want to deploy this to stage to UAT + probably pair with Gary. 

Approach:
- use `fullheight` property in Oembed so that it takes up 100% of available height
- set height for embed widget div

UAT:
- How does this affect viewers on the show page? 
- Does this affect Mirador vs. UV viewers differently? --> Seem to be unaffected. See Lanciani and Parker.

Sample PURLs:


## ✅ Item embed widget w/ text
### Before (600px)
<img width="881" alt="screen shot 2018-12-21 at 4 28 08 pm" src="https://user-images.githubusercontent.com/5402927/50368433-7bd1c600-053d-11e9-846c-d102b2d5f465.png">

<img width="853" alt="screen shot 2018-12-21 at 4 34 43 pm" src="https://user-images.githubusercontent.com/5402927/50368522-6f9a3880-053e-11e9-97b1-c3fed34302f2.png">


### After (400px)
<img width="872" alt="screen shot 2018-12-21 at 4 31 04 pm" src="https://user-images.githubusercontent.com/5402927/50368464-de2ac680-053d-11e9-9fe1-bcf12b40b210.png">

<img width="873" alt="screen shot 2018-12-21 at 4 32 27 pm" src="https://user-images.githubusercontent.com/5402927/50368526-7759dd00-053e-11e9-9866-03b6ddf5dc5c.png">


## ✅ Item embed widget w/out text (600px, unchanged)
<img width="877" alt="screen shot 2018-12-21 at 4 31 31 pm" src="https://user-images.githubusercontent.com/5402927/50368473-f4d11d80-053d-11e9-844b-f6ef1568b9f9.png">

## ✅ Show page, Mirador (642px❓, unchanged)
<img width="1210" alt="screen shot 2018-12-21 at 4 42 54 pm" src="https://user-images.githubusercontent.com/5402927/50368610-81301000-053f-11e9-948d-cbbd475c39b1.png">

## ✅ Show page, UV (600px, unchanged)
<img width="1223" alt="screen shot 2018-12-21 at 4 36 43 pm" src="https://user-images.githubusercontent.com/5402927/50368542-b720c480-053e-11e9-8afa-dea19ca9b192.png">

## 🛑 Show page, sul-embed video
## Before (602px)
<img width="1211" alt="screen shot 2018-12-21 at 4 45 21 pm" src="https://user-images.githubusercontent.com/5402927/50368685-5a260e00-0540-11e9-8c25-d8e19524f46e.png">

## After 😢
600px div with a 400px viewer
<img width="1206" alt="screen shot 2018-12-21 at 4 52 30 pm" src="https://user-images.githubusercontent.com/5402927/50368746-f51ee800-0540-11e9-912d-44cb238eb6ca.png">

