### PR TITLE
Remove redundant block length ignore in rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,10 +17,6 @@ AllCops:
 Rails:
   Enabled: true
 
-Metrics/BlockLength:
-  Exclude:
-  - 'spec/models/spotlight/dor/indexer_spec.rb'
-
 Metrics/LineLength:
   Max: 120
   Exclude:


### PR DESCRIPTION
This is covered below by the `spec/**/*` on (now) line 66 below