### PR TITLE
Add a link inside the full-text highlight section to initialize the...

### DIFF
--- a/app/assets/javascripts/full_text_collapse.js
+++ b/app/assets/javascripts/full_text_collapse.js
@@ -14,10 +14,23 @@ Blacklight.onLoad(function(){
   });
 
   $('dt.blacklight-full_text_tesimv').each(function() {
-    $(this).text($(this).text().replace(/:$/, ''));
-    $(this).append('<span class="caret caret-right"></span>');
-    $(this).attr('data-toggle', 'collapse');
-    $(this).attr('data-target', '#' + $(this).next('dd').attr('id'));
+    var $dt = $(this);
+    var $dd = $dt.next('dd');
+    var $link = $dd.find('a.prepared-search-link');
+
+    $dt.text($dt.text().replace(/:$/, ''));
+    $dt.append('<span class="caret caret-right"></span>');
+    $dt.attr('data-toggle', 'collapse');
+    $dt.attr('data-target', '#' + $dd.attr('id'));
+
+    if ($link.length > 0) {
+      $dt.before(
+        $('<dt class="prepared-search-container"></dt>')
+          .html($link.clone())
+      );
+      $dt.before($('<dd></dd>'));
+      $link.remove();
+    }
   });
 
   $('dd.blacklight-full_text_tesimv').collapse({ toggle: false });

--- a/app/assets/stylesheets/modules/full_text_highlight.scss
+++ b/app/assets/stylesheets/modules/full_text_highlight.scss
@@ -1,4 +1,5 @@
-dt.blacklight-full_text_tesimv {
+dt.blacklight-full_text_tesimv,
+dt.prepared-search-container {
   color: $gray-dark;
   cursor: pointer;
   display: inline-block;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,14 @@ module ApplicationHelper
   def custom_render_oembed_tag_async(document, canvas_id)
     url = context_specific_oembed_url(document)
 
-    content_tag :div, '', data: { embed_url: blacklight_oembed_engine.embed_url(url: url, canvas_id: canvas_id) }
+    content_tag :div, '', data: {
+      embed_url: blacklight_oembed_engine.embed_url(
+        url: url,
+        canvas_id: canvas_id,
+        search: params[:search],
+        suggested_search: params[:suggested_search]
+      )
+    }
   end
 
   ##

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -76,7 +76,8 @@ module CatalogHelper
     content_tag('p') do
       link_to(
         "Search for \"#{params[:q]}\" in document text",
-        spotlight.exhibit_solr_document_path(current_exhibit, document[:druid], search: params[:q])
+        spotlight.exhibit_solr_document_path(current_exhibit, document[:druid], search: params[:q]),
+        class: 'prepared-search-link'
       )
     end
   end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -70,16 +70,29 @@ module CatalogHelper
     link_to link_title, spotlight.exhibit_solr_document_path(current_exhibit, druid)
   end
 
+  def search_for_doc_text_link(document)
+    return '' unless params[:q]
+
+    content_tag('p') do
+      link_to(
+        "Search for \"#{params[:q]}\" in document text",
+        spotlight.exhibit_solr_document_path(current_exhibit, document[:druid], search: params[:q])
+      )
+    end
+  end
+
   # rubocop:disable Rails/OutputSafety
   def render_fulltext_highlight(document:, **_args)
     highlights = document.full_text_highlights
     return if highlights.none?
 
+    link = search_for_doc_text_link(document)
+
     safe_join(highlights.take(Settings.full_text_highlight.snippet_count).map do |val|
       content_tag('p') do
         val.html_safe # val is highlighted field from solr which is html safe
       end
-    end, '')
+    end.prepend(link), '')
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/config/initializers/blacklight_oembed.rb
+++ b/config/initializers/blacklight_oembed.rb
@@ -1,1 +1,1 @@
-Blacklight::Oembed::Engine.config.additional_params = [:canvas_id]
+Blacklight::Oembed::Engine.config.additional_params = [:canvas_id, :search, :suggested_search]

--- a/spec/features/full_text_highlight_spec.rb
+++ b/spec/features/full_text_highlight_spec.rb
@@ -18,8 +18,8 @@ RSpec.feature 'Full text highlighting' do
     sign_out user
   end
 
-  context 'when a document has a full text highlight hit' do
-    it 'shows the full-text hightlight field and provides a toggle', js: true do
+  context 'when a document has a full text highlight hit', js: true do
+    it 'shows the full-text hightlight field and provides a toggle' do
       visit spotlight.search_exhibit_catalog_path(exhibit, q: 'structure')
 
       expect(page).to have_css('dt', text: 'Sample matches in document text')
@@ -27,6 +27,15 @@ RSpec.feature 'Full text highlighting' do
       expect(page).not_to have_css('dd p', text: 'about need for data structures capable of storing', visible: true)
       page.find('dt', text: 'Sample matches in document text').click
       expect(page).to have_css('dd p', text: 'about need for data structures capable of storing', visible: true)
+    end
+
+    it 'pulls the prepared-search-link link from the full text snippet section to a new dt' do
+      visit spotlight.search_exhibit_catalog_path(exhibit, q: 'structure')
+
+      expect(page).to have_css('dt a', text: 'Search for "structure" in document text', visible: true)
+      expect(page).not_to have_css('dd a', text: 'Search for "structure" in document text') # Original link location
+      page.find('dt', text: 'Sample matches in document text').click
+      expect(page).not_to have_css('dd a', text: 'Search for "structure" in document text') # Original link location
     end
   end
 


### PR DESCRIPTION
...viewer on the record view with a prepared search.

Potentially closes sul-dlss/sul-embed#1022

![forced-search](https://user-images.githubusercontent.com/96776/60234964-0a136580-985b-11e9-978a-17009a979484.gif)
