### PR TITLE
Always render the full text helper for documents that have full text …

### DIFF
--- a/app/assets/javascripts/full_text_collapse.js
+++ b/app/assets/javascripts/full_text_collapse.js
@@ -30,6 +30,10 @@ Blacklight.onLoad(function(){
       );
       $dt.before($('<dd></dd>'));
       $link.remove();
+      if ($dd.find('p').length === 0) { // There is no highlight
+        $dt.remove();
+        $dd.remove();
+      }
     }
   });
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -226,7 +226,7 @@ class CatalogController < ApplicationController
         # This is required for the metadata configuration admin page to return the field properly.
         return true if args.length < 3
 
-        full_text_highlight_exists_in_response?(*args)
+        document_has_full_text_and_search_is_query?(*args)
       end,
       label: 'Sample matches in document text',
       highlight: true,
@@ -393,18 +393,8 @@ class CatalogController < ApplicationController
   end
 
   class << self
-    # Blacklight's highlighting feature assumes that the metadata exists in the page
-    # and replaces the rendered version from the dopcument with that of the highlighting
-    # section. In the case of our full text field, we do not render it in the normal results
-    # so we need to not display the field at all unless it was returned in the highlighting.
-    def full_text_highlight_exists_in_response?(context, _config, document)
-      response = context.instance_variable_get(:@response) || {}
-      document_highlight = response.dig('highlighting', document['id'])
-      return true if document_highlight.present? && document_highlight.any? do |field, values|
-        Settings.full_text_highlight.fields.include?(field) && values.present?
-      end
-
-      false
+    def document_has_full_text_and_search_is_query?(context, _config, document)
+      context.params[:q].present? && document['full_text_tesimv'].present?
     end
   end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -73,19 +73,16 @@ module CatalogHelper
   def search_for_doc_text_link(document)
     return '' unless params[:q]
 
-    content_tag('p') do
-      link_to(
-        "Search for \"#{params[:q]}\" in document text",
-        spotlight.exhibit_solr_document_path(current_exhibit, document[:druid], search: params[:q]),
-        class: 'prepared-search-link'
-      )
-    end
+    link_to(
+      "Search for \"#{params[:q]}\" in document text",
+      spotlight.exhibit_solr_document_path(current_exhibit, document[:druid], search: params[:q]),
+      class: 'prepared-search-link'
+    )
   end
 
   # rubocop:disable Rails/OutputSafety
   def render_fulltext_highlight(document:, **_args)
     highlights = document.full_text_highlights
-    return if highlights.none?
 
     link = search_for_doc_text_link(document)
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -3,17 +3,35 @@
 require 'rails_helper'
 
 describe CatalogController do
-  describe '#full_text_highlight_exists_in_response?' do
-    context 'when there is no solr response' do
-      it 'does not throw an error (returns false)' do
-        expect(
-          described_class.full_text_highlight_exists_in_response?(
-            instance_double('Context'),
-            instance_double('Config'),
-            SolrDocument.new(id: 'abc123')
-          )
-        ).to be false
-      end
+  describe '#document_has_full_text_and_search_is_query?' do
+    it 'is true when a query term is passed and the document has full text' do
+      expect(
+        described_class.document_has_full_text_and_search_is_query?(
+          instance_double('Context', params: { q: 'Search Term' }),
+          instance_double('Config'),
+          SolrDocument.new(full_text_tesimv: ['Some text'])
+        )
+      ).to be true
+    end
+
+    it 'is false if no query was passed' do
+      expect(
+        described_class.document_has_full_text_and_search_is_query?(
+          instance_double('Context', params: { f: { format_facet: ['Book'] } }),
+          instance_double('Config'),
+          SolrDocument.new(full_text_tesimv: ['Some text'])
+        )
+      ).to be false
+    end
+
+    it 'is false when a query term is passed but the document has no full text' do
+      expect(
+        described_class.document_has_full_text_and_search_is_query?(
+          instance_double('Context', params: { q: 'Search Term' }),
+          instance_double('Config'),
+          SolrDocument.new(id: 'abc123')
+        )
+      ).to be false
     end
   end
 end

--- a/spec/features/full_text_highlight_spec.rb
+++ b/spec/features/full_text_highlight_spec.rb
@@ -39,6 +39,15 @@ RSpec.feature 'Full text highlighting' do
     end
   end
 
+  context 'when a document has full text but there is no highlight', js: true do
+    it 'still offers a link to open up the document with a search prepared (and does not have a highlight section)' do
+      visit spotlight.search_exhibit_catalog_path(exhibit, q: 'zy575vf8599')
+
+      expect(page).to have_css('dt a', text: 'Search for "zy575vf8599" in document text', visible: true)
+      expect(page).not_to have_css('dt', text: 'Sample matches in document text')
+    end
+  end
+
   context 'when a document has non-english full text' do
     it 'stems Portuguese properly', js: true do
       visit spotlight.search_exhibit_catalog_path(exhibit, q: 'homens')


### PR DESCRIPTION
…where there is a query passed in the search context.

This also changes the JS to remove the highlight section if it didn't contain any actual highlights (keeping the prepared search link intact)

Closes #1398 