### PR TITLE
Remove deprecated PaperTrail config

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,0 @@
-PaperTrail.config.track_associations = false


### PR DESCRIPTION
```
Association Tracking for PaperTrail has been extracted to a separate gem. To use it, 
please add `paper_trail-association_tracking` to your Gemfile. If you don't use it (most 
people don't, that's the default) and you set `track_associations = false` somewhere 
(probably a rails initializer) you can remove that line now.
```