### PR TITLE
Use M3 instead of OSD for external IIIF items

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,6 +9,10 @@ class CatalogController < ApplicationController
 
   include Blacklight::Catalog
 
+  before_action only: :manifest do
+    response.headers['Access-Control-Allow-Origin'] = '*'
+  end
+
   before_action only: :admin do
     blacklight_config.view.admin_table.thumbnail_field = :thumbnail_square_url_ssm
   end

--- a/app/models/concerns/manifest_concern.rb
+++ b/app/models/concerns/manifest_concern.rb
@@ -5,10 +5,13 @@
 # convenient accessors for IIIF manifests embeded in a SolrDocument
 module ManifestConcern
   def manifest
-    manifest_url = fetch('iiif_manifest_url_ssi', nil)
     return if manifest_url.blank? || !manifest_available?
 
     manifest_url
+  end
+
+  def manifest_url
+    fetch('iiif_manifest_url_ssi', nil)
   end
 
   def exhibit_specific_manifest(custom_manifest_pattern)

--- a/app/views/catalog/_embedded_mirador3.html.erb
+++ b/app/views/catalog/_embedded_mirador3.html.erb
@@ -1,0 +1,14 @@
+<% if document.manifest_url.present? %>
+  <% manifest_url = document.manifest_url.starts_with?('/') ? root_url + document.manifest_url.slice(1..-1) : document.manifest_url %>
+  <%= content_tag :iframe, '',
+        src: "#{Settings.iiif_embed.url}?#{{ url: manifest_url }.to_query}",
+        allowfullscreen: true,
+        class: 'mirador-embed-wrapper',
+        frameborder: 0,
+        marginwidth: 0,
+        marginheight: 0,
+        scrolling: 'no',
+        width: '100%'
+        %>
+  <%= iiif_drag_n_drop(manifest_url) %>
+<% end %>

--- a/app/views/catalog/_viewer_default.html.erb
+++ b/app/views/catalog/_viewer_default.html.erb
@@ -1,4 +1,6 @@
-<% if document.uploaded_resource? || document.external_iiif? %>
+<% if document.external_iiif? %>
+  <%= render partial: "embedded_mirador3", locals: {document: document} %>
+<% elsif document.uploaded_resource? %>
   <%= render partial: "openseadragon_default", locals: {document: document} %>
 <% else %>
   <% # block comes from a local passed in from Spotlight %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,8 @@ feature_flags:
   uat_embed: false
 traject:
   processing_thread_pool: 1
+iiif_embed:
+  url: https://embed.stanford.edu/iiif
 iiif_dnd_base_url: https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?%{query}
 action_mailer:
   default_options:

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Spotlight::CatalogController do
+  routes { Spotlight::Engine.routes }
+
+  let(:exhibit) { create(:exhibit) }
+  let(:user) { create(:exhibit_admin, exhibit: exhibit) }
+
+  before do
+    sign_in user
+  end
+
+  describe '#manifest' do
+    it 'sets appropriate CORS headers' do
+      get :manifest, params: { id: 1, exhibit_id: exhibit.id, locale: 'en' }
+
+      expect(response.headers.to_h).to include 'Access-Control-Allow-Origin' => '*'
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -19,6 +19,19 @@ describe SolrDocument do
     end
   end
 
+  describe '#manifest_url' do
+    subject do
+      described_class.new(
+        id: 'abc123',
+        'iiif_manifest_url_ssi' => 'http://www.example.com/default/'
+      )
+    end
+
+    it 'pulls data from the solr document' do
+      expect(subject.manifest_url).to eq 'http://www.example.com/default/'
+    end
+  end
+
   describe '#exhibit_specific_manifest' do
     subject do
       described_class.new(

--- a/spec/views/catalog/_embedded_mirador3.html.erb_spec.rb
+++ b/spec/views/catalog/_embedded_mirador3.html.erb_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'catalog/_embedded_mirador3', type: :view do
+  let(:document) { SolrDocument.new(id: 'abc', iiif_manifest_url_ssi: manifest_url) }
+  let(:manifest_url) { 'http://example.com/iiif/manifest' }
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive_messages(
+        document: document
+      )
+    end
+  end
+
+  it 'renders an iframe' do
+    render
+
+    expect(rendered).to have_css "iframe[src='https://embed.stanford.edu/iiif?#{{ url: manifest_url }.to_query}']"
+  end
+
+  context 'with a local IIIF manifest' do
+    let(:manifest_url) { '/iiif/manifest' }
+
+    it 'uses the full url to the manifest' do
+      expected_url = 'http://test.host/iiif/manifest'
+
+      render
+
+      expect(rendered).to have_css "iframe[src='https://embed.stanford.edu/iiif?#{{ url: expected_url }.to_query}']"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1216 
Fixes #1413 
Fixes #1336 (or, rather, makes it obsolete)
Perhaps related to #476 too? 