### PR TITLE
Map IIIF title fields to our solr fields

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -3,6 +3,9 @@ Spotlight::Engine.config.upload_title_field = Spotlight::UploadFieldConfig.new(
   field_name: :spotlight_upload_title_tesim,
   label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_title_tesim') }
 )
+
+Spotlight::Engine.config.iiif_title_fields = %w(title_full_display title_display title_245_search title_sort spotlight_upload_title_tesim)
+
 Spotlight::Engine.config.upload_fields = [
   Spotlight::UploadFieldConfig.new(
     field_name: Spotlight::Engine.config.upload_description_field,


### PR DESCRIPTION
## Before
![resource ID rendered above image](https://user-images.githubusercontent.com/5402927/62906855-65bf8280-bd25-11e9-8f1e-e25fc1205fe5.png)
External IIIF resources were rendering their ID instead of their manifest label. 

## After
![resource title rendered above image](https://user-images.githubusercontent.com/5402927/62906856-65bf8280-bd25-11e9-947e-c7114a7b6a7e.png)