### PR TITLE
Use some clever function queries to blank out full text fields in ord…

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -52,6 +52,10 @@ class SolrDocument
     end
   end
 
+  def full_text?
+    self['has_full_text_func_boolean']
+  end
+
   def external_iiif?
     self[self.class.resource_type_field].present? &&
       self[self.class.resource_type_field].include?('spotlight/resources/iiif_harvesters')

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -9,7 +9,7 @@ describe CatalogController do
         described_class.document_has_full_text_and_search_is_query?(
           instance_double('Context', params: { q: 'Search Term' }),
           instance_double('Config'),
-          SolrDocument.new(full_text_tesimv: ['Some text'])
+          instance_double(SolrDocument, full_text?: true)
         )
       ).to be true
     end
@@ -19,7 +19,7 @@ describe CatalogController do
         described_class.document_has_full_text_and_search_is_query?(
           instance_double('Context', params: { f: { format_facet: ['Book'] } }),
           instance_double('Config'),
-          SolrDocument.new(full_text_tesimv: ['Some text'])
+          instance_double(SolrDocument, full_text?: true)
         )
       ).to be false
     end
@@ -29,7 +29,7 @@ describe CatalogController do
         described_class.document_has_full_text_and_search_is_query?(
           instance_double('Context', params: { q: 'Search Term' }),
           instance_double('Config'),
-          SolrDocument.new(id: 'abc123')
+          instance_double(SolrDocument, full_text?: false)
         )
       ).to be false
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -185,4 +185,12 @@ describe SolrDocument do
       end
     end
   end
+
+  describe '#full_text?' do
+    subject(:document) { described_class.new(has_full_text_func_boolean: true) }
+
+    it 'returns true if there was full text data (figured out using solr func queries)' do
+      expect(document).to be_full_text
+    end
+  end
 end


### PR DESCRIPTION
…er to speeed up search result performance for documents that have tons of full text data (that we just end up ignoring for display anyway..); fixes #1419