### PR TITLE
Copy over uploaded date fields to pub_year_* fields using the Stanfor…

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -17,7 +17,12 @@ Spotlight::Engine.config.upload_fields = [
     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_attribution_tesim') }
   ),
   Spotlight::UploadFieldConfig.new(
-    solr_fields: %w(date_sort spotlight_upload_date_tesim),
+    solr_fields: [
+      'date_sort',
+      'spotlight_upload_date_tesim',
+      pub_year_w_approx_isi: lambda { |value| Stanford::Mods::DateParsing.year_int_from_date_str(value) },
+      pub_year_tisim: lambda { |value| Stanford::Mods::DateParsing.year_int_from_date_str(value) }
+    ],
     field_name: :spotlight_upload_date_tesim,
     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
   )

--- a/spec/services/upload_solr_document_builder_spec.rb
+++ b/spec/services/upload_solr_document_builder_spec.rb
@@ -23,5 +23,13 @@ describe UploadSolrDocumentBuilder do
     it 'adds a square thumbnail field' do
       expect(builder.to_solr).to include thumbnail_square_url_ssm: "/images/#{upload_id}/square/100,100/0/default.jpg"
     end
+
+    it 'copies over the uploaded date field to pub_year fields' do
+      resource.sidecar.update data: {
+        'configured_fields' => { 'spotlight_upload_date_tesim' => 'this is a year: 2014' }
+      }
+
+      expect(builder.to_solr).to include pub_year_tisim: 2014, pub_year_w_approx_isi: 2014
+    end
   end
 end


### PR DESCRIPTION
…d MODS parsing rules.

This allows exhibit-specific items to get e.g. the date range slider. 