### PR TITLE
Use edismax instead of regular dismax

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,7 +18,7 @@ class CatalogController < ApplicationController
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
     # config.advanced_search[:qt] ||= 'advanced'
     config.advanced_search[:url_key] ||= 'advanced'
-    config.advanced_search[:query_parser] ||= 'dismax'
+    config.advanced_search[:query_parser] ||= 'edismax'
     config.advanced_search[:form_solr_parameters] ||= {}
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params


### PR DESCRIPTION
blacklight_advanced_search inflicts the advanced search configuration's query_parser on any query that it can parse (to pre-parse boolean queries in a more understandable way). We intend to use edismax everywhere, though.

This will allow us to change some browse categories to target specific fields (and then update some solr analyzer steps without changing the current browse category results)