### PR TITLE
Update i18n fallbacks config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,6 +58,10 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  # config.i18n.fallbacks = [I18n.default_locale]
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,10 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  # config.i18n.fallbacks = [I18n.default_locale]
+
   # Have long-running requests timeout after 60 seconds
   config.slowpoke.timeout = 60
 end


### PR DESCRIPTION
Update i18n fallbacks setting per `i18n` [v1.1.0](https://github.com/ruby-i18n/i18n/releases/tag/v1.1.0). 
Also see: https://github.com/ruby-i18n/i18n/wiki/Fallbacks