### PR TITLE
Set HTML lang to i18n locale

### DIFF
--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="<%= I18n.locale %>" class="no-js">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
There's probably more due diligence to be done here (see [W3C: Authoring HTML: Language declarations](https://www.w3.org/TR/i18n-html-tech-lang/)), but I would expect to discuss some of the hairier issues in upstream Spotlight and DLME work (i.e. how should the markup change when one is doing curation in one language but previewing text that will displayed in a different langauge, etc.)