### PR TITLE
Update modal header markup for bootstrap 4; fixes #1491

### DIFF
--- a/app/views/metadata/show.html.erb
+++ b/app/views/metadata/show.html.erb
@@ -4,8 +4,10 @@
 
 <div class='view-metadata'>
   <div class='modal-header'>
-    <button type='button' class='blacklight-modal-close close' data-dismiss='modal' aria-hidden='true'>×</button>
     <h3 class='modal-title'><%= presenter(@document).heading %></h3>
+    <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+      <span aria-hidden="true">&times;</span>
+    </button>
   </div>
   <div class='modal-body'>
     <%= render partial: 'metadata' %>


### PR DESCRIPTION
<img width="791" alt="Screen Shot 2020-01-15 at 07 31 34" src="https://user-images.githubusercontent.com/111218/72446872-2e884e00-3769-11ea-8988-f84543150e28.png">
