### PR TITLE
Fix metadata alignment in search results; fixes #1480

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -73,6 +73,8 @@
     .document-metadata {
       @extend .col-8;
       @extend .col-md-9;
+      @extend .offset-3;
+      @extend .offset-md-2;
     }
 
     .document-thumbnail {

--- a/app/views/catalog/_exhibits_document_header_default.html.erb
+++ b/app/views/catalog/_exhibits_document_header_default.html.erb
@@ -1,11 +1,11 @@
 <div class='row'>
-  <div class='col-xs-3 col-md-2'>
+  <div class='col-3 col-md-2'>
     <%= render_document_partial(document, 'thumbnail', document_counter: document_counter) %>
   </div>
-  <div class='col-xs-7 col-md-9'>
+  <div class='col-7 col-md-9'>
     <%= render_document_partial(document, 'index_header', document_counter: document_counter) %>
   </div>
-  <div class='col-xs-2 col-md-1'>
+  <div class='col-2 col-md-1'>
     <% exhibit_specific_manifest = document.exhibit_specific_manifest(current_exhibit.required_viewer.custom_manifest_pattern) %>
 
     <%= iiif_drag_n_drop(exhibit_specific_manifest, width: '30') if exhibit_specific_manifest %>


### PR DESCRIPTION
<img width="661" alt="Screen Shot 2020-01-15 at 12 01 15" src="https://user-images.githubusercontent.com/111218/72466936-bdf42800-378e-11ea-9b0f-84695c735c8a.png">
