### PR TITLE
Configure the date range widget so it displays correctly on an exhibit home page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -159,7 +159,9 @@ class CatalogController < ApplicationController
     config.add_facet_field 'pub_year_w_approx_isi', label: 'Date', limit: true
     config.add_facet_field 'pub_year_no_approx_isi', label: 'Date (no approx)', limit: true
     config.add_facet_field 'place_created_ssim', label: 'Place created', limit: true
-    config.add_facet_field 'pub_year_tisim', label: 'Date Range', range: true, limit: true
+    config.add_facet_field 'pub_year_tisim', label: 'Date Range',
+                                             range: true,
+                                             partial: 'blacklight_range_limit/range_limit_panel'
     config.add_facet_field 'language', label: 'Language', limit: true
     config.add_facet_field 'author_person_facet', label: 'Author', limit: true # includes Collectors
     config.add_facet_field 'author_no_collector_ssim', label: 'Author (no Collectors)', limit: true

--- a/app/controllers/spotlight/home_pages_controller.rb
+++ b/app/controllers/spotlight/home_pages_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This unpleasantness allows us to include the upstream controller before overriding it
+# rubocop:disable Rails/DynamicFindBy
+spotlight_path = Gem::Specification.find_by_name('blacklight-spotlight').full_gem_path
+require_dependency File.join(spotlight_path, 'app/controllers/spotlight/home_pages_controller')
+# rubocop:enable Rails/DynamicFindBy
+
+module Spotlight
+  # Override the upstream HomePagesController in order to inject range limit behaviors
+  class HomePagesController
+    include BlacklightRangeLimit::ControllerOverride
+
+    # rubocop:disable Rails/LexicallyScopedActionFilter
+    # Tweak the authorization for the range limit actions
+    before_action :authenticate_user!, except: [:show, :range_limit, :range_limit_panel]
+    skip_authorize_resource only: %i(range_limit range_limit_panel)
+
+    before_action only: %i(range_limit range_limit_panel) do
+      authorize! :read, @page
+    end
+    # rubocop:enable Rails/LexicallyScopedActionFilter
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Exhibits::Application.routes.draw do
     resources :exhibits, path: '/', only: [] do
       get "catalog/range_limit" => "spotlight/catalog#range_limit"
       get "catalog/range_limit_panel/:id" => "spotlight/catalog#range_limit_panel"
+      get "home/range_limit" => "spotlight/home_pages#range_limit"
+      get "home/range_limit_panel/:id" => "spotlight/home_pages#range_limit_panel"
     end
 
     concern :searchable, Blacklight::Routes::Searchable.new


### PR DESCRIPTION

<img width="549" alt="Screen Shot 2020-01-16 at 09 59 03" src="https://user-images.githubusercontent.com/111218/72550088-d4f65100-3846-11ea-8687-63286427309c.png">

Fixes #1356 