### PR TITLE
Update font sizes

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -1,5 +1,4 @@
 .facets-heading {
-  @extend .h3;
   @include heading-with-border();
 }
 
@@ -47,7 +46,7 @@
 
 #documents {
   .index_title {
-    font-size: $font-size-lg;
+    font-size: 1rem;
     margin-top: 0;
   }
 

--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -36,7 +36,7 @@
 
 #document {
   h1 {
-    font-size: $h3-font-size;
+    font-size: 1.5rem;
   }
 }
 

--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -1,6 +1,6 @@
 body {
-  font-size: .875rem;
-  line-height:1.428571429;
+  font-size: 0.875rem;
+  line-height: 1.428571429;
 }
 
 .bg-cardinal-red {

--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -1,5 +1,6 @@
 body {
-  font-size: 15px;
+  font-size: 14px;
+  line-height:1.428571429;
 }
 
 .bg-cardinal-red {

--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -1,5 +1,5 @@
 body {
-  font-size: 14px;
+  font-size: .875rem;
   line-height:1.428571429;
 }
 

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -1,3 +1,7 @@
+.site-title {
+  font-size: 2.125rem;
+}
+
 .masthead small {
   font-size: 1.3rem;
 }
@@ -35,19 +39,36 @@
   }
 }
 
-// Reduce size of page titles
-.empty-page-block h2 {
-  @extend .h3;
-}
-
+// Reduce size of page titles, headings, etc.
 .page-title,
 .page-header {
-  @extend .h2;
+  font-size: 1.875rem;
   color: $heading-font-color;
 
   small {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
+}
+
+.item-count {
+  color: $cool-grey;
+  font-size: 1.25rem;
+}
+
+h3,
+.h3,
+.empty-page-block h2 {
+  font-size: 1.5rem;
+}
+
+h4,
+.h4 {
+  font-size: 1.25rem;
+}
+
+h5,
+.h5 {
+  font-size: 1rem;
 }
 
 // Ajustments to sidebars to use SUL color palette, more compact vertical spacing
@@ -55,6 +76,7 @@
   margin-top: 0;
 }
 
+#sidebar .facets-heading,
 #sidebar .nav-heading {
   @include heading-with-border();
   font-size: 20px;

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -14,8 +14,9 @@
 
 // Increase font size because we're using Source Sans in this app
 // and Source Sans is noticeably smaller than the default font.
-.image-masthead .navbar ul.nav.navbar-nav > li a {
+.image-masthead .navbar ul.navbar-nav > li a {
   font-size: 15px;
+  letter-spacing: 1.1px;
 }
 
 .browse-landing .text-overlay .browse-category-title {

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -1,3 +1,7 @@
+.masthead small {
+  font-size: 1.3rem;
+}
+
 .dd-list {
   .panel-default {
     > .panel-heading {


### PR DESCRIPTION
Various updates to get font sizes back to something similar to what we currently have in production.

One change I made is to set all the base font size in rems, so it is back to 14px, but because it's set in rems if a visually-impaired user has their browser font size larger than the default, they'll get a larger base font size.

Also, some of these commits are pretty small, and they are all related, so feel free to squash them if that makes sense.