### PR TITLE
Add !important to a few of our css overrides to 🥊 the !important now …

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -1,3 +1,4 @@
+// scss-lint:disable ImportantRule
 .site-title {
   font-size: 2.125rem;
 }
@@ -166,7 +167,7 @@ h5,
   }
 
   &.facet-limit-active {
-    border-color: $color-beige-40;
+    border-color: $color-beige-40 !important;
 
     > .card-header {
       background-color: $color-beige-40 !important;
@@ -175,7 +176,7 @@ h5,
   }
 
   .facet-values li .selected {
-    color: $color-blackish;
+    color: $color-blackish !important;
   }
 }
 
@@ -195,3 +196,4 @@ h5,
 .img-thumbnail > a > img {
   @include thumbnail-image-border;
 }
+// scss-lint:enable ImportantRule


### PR DESCRIPTION
…upstream.

Fixes #1568 

## Before
<img width="300" alt="selected-facet-before" src="https://user-images.githubusercontent.com/96776/73494287-1881ac80-4369-11ea-9ffa-0b16b43921c4.png">

## After
<img width="297" alt="selected-facet-after" src="https://user-images.githubusercontent.com/96776/73494288-191a4300-4369-11ea-8a83-b332a88e5120.png">
