### PR TITLE
Update tag styling fixes #1573

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -196,4 +196,10 @@ h5,
 .img-thumbnail > a > img {
   @include thumbnail-image-border;
 }
+
+.tags .nav-link {
+  margin-bottom: 0.5rem;
+  padding: 0.33rem 0.66rem;
+}
+
 // scss-lint:enable ImportantRule


### PR DESCRIPTION
<img width="798" alt="Screen Shot 2020-01-30 at 3 23 15 PM" src="https://user-images.githubusercontent.com/1656824/73495853-98614400-4374-11ea-9e1d-449d2e7b4f78.png">
