### PR TITLE
Remove the "sm" breakpoint from the container-max-widths configuration.

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -54,3 +54,6 @@ $breadcrumb-padding-vertical: $spacer;
 $nav-link-padding: $spacer;
 
 $modal-header-footer-height-guess: 212px;
+
+// Only set max-width of containers at breakpoints above "sm"
+$container-max-widths: map-remove($container-max-widths, "sm");


### PR DESCRIPTION
Closes #1579 

## Before (767px wide)
<img width="761" alt="767-px-before" src="https://user-images.githubusercontent.com/96776/73568500-5b04c100-441d-11ea-946d-163eae7da236.png">

## After (767px wide)
<img width="765" alt="767-px-after" src="https://user-images.githubusercontent.com/96776/73568502-5b04c100-441d-11ea-8cab-a68a69abba21.png">
