### PR TITLE
Update sidebar styling

### DIFF
--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -16,15 +16,12 @@ body {
   padding-left: 0;
 }
 
-.nav {
-  a {
-    color: $nav-link-color;
-  }
+.nav a {
+  color: $nav-link-color;
+}
 
-  > li > a:hover,
-  > li > a:focus {
-    background-color: $sidebar-link-background-color;
-  }
+.nav-link:hover {
+  text-decoration: underline;
 }
 
 .nav-tabs > li.active > a {

--- a/app/assets/stylesheets/modules/mixins.scss
+++ b/app/assets/stylesheets/modules/mixins.scss
@@ -9,6 +9,8 @@
 
 @mixin sidebar-link-active() {
   color: $sidebar-link-active-color;
+  cursor: default;
+  text-decoration: none;
 }
 
 @mixin thumbnail-image-border() {

--- a/app/assets/stylesheets/modules/mixins.scss
+++ b/app/assets/stylesheets/modules/mixins.scss
@@ -8,8 +8,7 @@
 }
 
 @mixin sidebar-link-active() {
-  color: $sidebar-link-color;
-  font-weight: 600;
+  color: $sidebar-link-active-color;
 }
 
 @mixin thumbnail-image-border() {

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -88,7 +88,7 @@ h5,
 }
 
 #sidebar ul.nav > li a {
-  padding: 0.25rem 0.5rem 0.25rem 0.25rem;
+  padding: 0.25rem;
 
   .blacklight-about_pages-show & { // accommodate likely occurrence of multi-line items
     padding-bottom: 4px;

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -96,17 +96,10 @@ h5,
   }
 }
 
-.page-sidebar .nav-link.active {
+.page-sidebar .nav-link.active,
+#sidebar ol.sidenav li.active,
+#sidebar ul.sidenav li.active a {
   @include sidebar-link-active();
-}
-
-#sidebar ol.sidenav li.active {
-  @include sidebar-link-active();
-}
-
-#sidebar ol.sidenav li a:hover,
-#sidebar ol.sidenav li a:focus {
-  background-color: $sidebar-link-background-color;
 }
 
 .blacklight-about_pages-show #sidebar {

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -100,49 +100,8 @@ h5,
   @include sidebar-link-active();
 }
 
-// Sidebar adjustments for feature pages.
-// Links here are constructed using h4s and nested ol items so styling
-// needs to be different than other sidebar links.
-#sidebar ol.sidenav {
-  > li > h4 { // parent pages
-    border-bottom: 0;
-    color: $sidebar-link-color;
-    font-size: 15px;
-    font-weight: 600;
-    line-height: 1.2;
-    margin-bottom: 3px;
-    margin-top: $padding-base-vertical * 4;
-
-    > a {
-      color: $color-dark-red;
-
-      &:hover,
-      &:focus {
-        background-color: $sidebar-link-background-color;
-      }
-    }
-  }
-
-  li:first-child > h4 {
-    margin-top: $padding-large-vertical * 3;
-  }
-
-  ol.subsection li { // child pages
-    list-style-type: none;
-    margin-left: 0;
-    padding-bottom: 3px;
-    padding-left: 3px;
-    padding-top: 3px;
-
-    &.active {
-      @include sidebar-link-active();
-    }
-
-    > a:hover,
-    > a:focus {
-      background-color: $sidebar-link-background-color;
-    }
-  }
+#sidebar ol.sidenav li.active {
+  @include sidebar-link-active();
 }
 
 #sidebar ol.sidenav li a:hover,

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -88,7 +88,7 @@ h5,
 }
 
 #sidebar ul.nav > li a {
-  padding: 3px $padding-base-horizontal 3px 3px;
+  padding: 0.25rem 0.5rem 0.25rem 0.25rem;
 
   .blacklight-about_pages-show & { // accommodate likely occurrence of multi-line items
     padding-bottom: 4px;
@@ -96,7 +96,7 @@ h5,
   }
 }
 
-.sidenav .active > a {
+.page-sidebar .nav-link.active {
   @include sidebar-link-active();
 }
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -36,6 +36,7 @@ $sul-link-color-border: $color-pantone-401;
 $nav-link-color: $black;
 
 $sidebar-link-color: $color-black-80;
+$sidebar-link-active-color: $color-cardinal-red;
 $sidebar-link-background-color: $color-beige-10;
 
 @import "bootstrap-reboot";

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -37,7 +37,6 @@ $nav-link-color: $black;
 
 $sidebar-link-color: $color-black-80;
 $sidebar-link-active-color: $color-cardinal-red;
-$sidebar-link-background-color: $color-beige-10;
 
 @import "bootstrap-reboot";
 @import "bootstrap/variables";


### PR DESCRIPTION
We have four places where we show a sidebar with links:

- Site pages
- Exhibit feature pages
- Exhibit about pages
- Exhibit admin pages

Our styling is currently (on -prod) inconsistent (in most places we don't indicate which menu item is currently active), and with the BL7 upgrade became a little worse, with the feature page styling in particular losing all previous styling and making child pages difficult to distinguish from parent pages:

<img width="441" alt="Screen Shot 2020-02-06 at 4 27 45 PM" src="https://user-images.githubusercontent.com/101482/73988493-1cc93f00-4900-11ea-89e9-0529294eebf8.png">

This PR removes a bunch of the current custom styling and makes all sidebars consistently show the active menu item in a different color. It also removes the previous background color hover styling in favor of link underline styling. So overall it is simpler, and if we want to update the styling it'll be easier to do it in a consistent way.

Some examples with the updates from this PR:

<img width="561" alt="Screen Shot 2020-02-06 at 4 24 26 PM" src="https://user-images.githubusercontent.com/101482/73988682-a711a300-4900-11ea-9e16-5429d3fd9959.png">

---

<img width="495" alt="Screen Shot 2020-02-06 at 4 24 40 PM" src="https://user-images.githubusercontent.com/101482/73988693-aed14780-4900-11ea-99b1-7f88896b536a.png">

---

<img width="460" alt="Screen Shot 2020-02-06 at 4 24 59 PM" src="https://user-images.githubusercontent.com/101482/73988704-b4c72880-4900-11ea-8882-8752ffab691b.png">

---

<img width="424" alt="Screen Shot 2020-02-06 at 4 25 17 PM" src="https://user-images.githubusercontent.com/101482/73988716-bbee3680-4900-11ea-969d-1ecb80c738f4.png">
