### PR TITLE
Override bootstrap variables so input focus borders are blue instead …

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -57,3 +57,7 @@ $modal-header-footer-height-guess: 212px;
 
 // Only set max-width of containers at breakpoints above "sm"
 $container-max-widths: map-remove($container-max-widths, "sm");
+
+$input-focus-width:       0.2rem;
+$input-focus-border-color:       rgba($blue, 0.25);
+$input-focus-box-shadow:  0 0 0 $input-focus-width $input-focus-border-color;


### PR DESCRIPTION
…of the primary color; fixes #1625

<img width="501" alt="Screen Shot 2020-02-07 at 08 49 55" src="https://user-images.githubusercontent.com/111218/74048307-d3700280-4986-11ea-98ec-664c5189423e.png">
