### PR TITLE
Remove padding and border radius from masonry thumbnails.

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -86,6 +86,14 @@
     }
   }
 
+  .masonry {
+    .img-thumbnail {
+      border-radius: 0;
+      padding: 0;
+    }
+  }
+
+
   &.gallery {
     .thumbnail {
       border: 0;


### PR DESCRIPTION
Closes #1606 

## Before
<img width="698" alt="masonry-before" src="https://user-images.githubusercontent.com/96776/74053798-7e85b980-4991-11ea-86c8-807a928ef057.png">

## After
<img width="700" alt="masonry-after" src="https://user-images.githubusercontent.com/96776/74053800-7f1e5000-4991-11ea-9e95-cc9625047722.png">
