### PR TITLE
Make the metadata in the gallery view block so the dt/dd are on …

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -90,6 +90,10 @@
     .thumbnail {
       border: 0;
     }
+
+    dl {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
…different lines.

Closes sul-dlss/exhibits#1605

Note, the "after" screenshot below is in concert with projectblacklight/blacklight-gallery#77

## Before
<img width="857" alt="gallery-before" src="https://user-images.githubusercontent.com/96776/74060845-aaa83700-499f-11ea-897d-c446ba06d525.png">

## After
<img width="839" alt="gallery-after" src="https://user-images.githubusercontent.com/96776/74060852-af6ceb00-499f-11ea-8462-578d58fc43e4.png">

