### PR TITLE
Add a start_over_html i18n key that includes a "Back" svg.

### DIFF
--- a/app/assets/images/blacklight/start_over.svg
+++ b/app/assets/images/blacklight/start_over.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" role="presentation">
+  <path d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6 1.41-1.41zM6 6h2v12H6V6z"></path>
+</svg>

--- a/app/views/catalog/_start_over.html.erb
+++ b/app/views/catalog/_start_over.html.erb
@@ -1,0 +1,3 @@
+<%= link_to start_over_path, class: "catalog_startOverLink btn btn-primary" do %>
+  <%= blacklight_icon 'start_over' %> <%= t('blacklight.search.start_over') %>
+<% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,5 @@
 en:
   blacklight:
     application_name: 'Stanford University Libraries'
+    search:
+      start_over: Start over


### PR DESCRIPTION
If this seems like an 👌 approach, then this would need a release that includes projectblacklight/blacklight#2238 in order to work.

Closes #1610 

<img width="430" alt="Screen Shot 2020-02-07 at 2 14 44 PM" src="https://user-images.githubusercontent.com/96776/74069891-552a5500-49b4-11ea-8c8a-3573a7249c45.png">
