### PR TITLE
Adds a min-width to search field so it contains "everything"

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -177,4 +177,9 @@ h5,
   padding: 0.33rem 0.66rem;
 }
 
+// A hackety McHack so that the search fields contain "Everything" in all the browsers
+#exhibit-navbar #search_field {
+  min-width: 114px;
+}
+
 // scss-lint:enable ImportantRule


### PR DESCRIPTION
Fixes #1583 

The problem is this sizing is different between the browsers. This "solution" makes sure the default label "Everything" works in the browsers (Chrome was the problem).

## Chrome
![Screen Shot 2020-02-11 at 8 19 05 AM](https://user-images.githubusercontent.com/1656824/74250235-8900c580-4ca7-11ea-921a-7fea728276fd.png)

## Firefox
![Screen Shot 2020-02-11 at 8 19 13 AM](https://user-images.githubusercontent.com/1656824/74250230-87cf9880-4ca7-11ea-95bf-373422b9d469.png)

## Safari
![Screen Shot 2020-02-11 at 8 19 09 AM](https://user-images.githubusercontent.com/1656824/74250232-88682f00-4ca7-11ea-84ba-7865f3216359.png)

