### PR TITLE
Override bootstrap hover/focus styling for top navbar

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -1,3 +1,13 @@
+#header-navbar {
+  a {
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline;
+    }
+  }
+}
+
 .dd-list {
   .panel-default {
     > .panel-heading {
@@ -36,6 +46,7 @@
 }
 
 .page-title,
+
 .page-header {
   @extend .h2;
   color: $heading-font-color;


### PR DESCRIPTION
Fixes #1647

Clarified the intent of this ticket w/ Gary after looking at the difference between stage and master. The main addition here is underlining hover / focus links in the top navbar. 

![underlined hover link](https://user-images.githubusercontent.com/5402927/74387213-cc912780-4dac-11ea-9a3f-2d6f351c047b.png)


