### PR TITLE
Re-add the border to blockquotes

### DIFF
--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -66,3 +66,8 @@ th {
 .btn-outline-secondary {
   @include button-variant($sul-btn-secondary-color, $sul-btn-secondary-border);
 }
+
+.blockquote {
+  border-left: 5px solid $border-color;
+  padding-left: 1rem;
+}


### PR DESCRIPTION
Fixes #1658 

<img width="425" alt="Screen Shot 2020-02-13 at 08 10 13" src="https://user-images.githubusercontent.com/111218/74454123-44586400-4e38-11ea-9d35-7d4f8c8904a8.png">

Requires https://github.com/projectblacklight/spotlight/pull/2455