### PR TITLE
Revise font sizes

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -87,7 +87,7 @@
   font-size: 1.25rem;
 }
 
-.tab-pane small.form-text {
+small.form-text {
   font-size: 0.875rem;
 }
 

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -67,7 +67,7 @@
   }
 }
 
-// Reduce size of page titles, headings, etc.
+// Adjust size of page titles, headings, etc.
 .page-title,
 .page-header {
   font-size: 2rem;
@@ -85,6 +85,10 @@
 .item-count {
   color: $cool-grey;
   font-size: 1.25rem;
+}
+
+.tab-pane small.form-text {
+  font-size: 0.875rem;
 }
 
 #content h2 {

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -25,12 +25,12 @@
 }
 
 .masthead .site-title-wrapper {
-  padding-bottom: 0.5rem;
   margin-top: 0.5rem;
+  padding-bottom: 0.5rem;
 
   @media screen and (min-width: 992px) {
-    padding-bottom: 1rem;
     margin-top: 1rem;
+    padding-bottom: 1rem;
   }
 }
 
@@ -70,8 +70,8 @@
 // Adjust size of page titles, headings, etc.
 .page-title,
 .page-header {
-  font-size: 2rem;
   color: $heading-font-color;
+  font-size: 2rem;
 
   small {
     font-size: 1.5rem;

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -91,6 +91,11 @@
   font-size: 0.875rem;
 }
 
+.browse-translations-header,
+table#exhibit-specific-fields .field-label {
+  font-size: 1.125rem;
+}
+
 #content h2 {
   font-size: 1.75rem;
 

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -1,10 +1,37 @@
 // scss-lint:disable ImportantRule
 .site-title {
-  font-size: 2.125rem;
+  font-size: 1.625rem;
+
+  @media screen and (min-width: 768px) {
+    font-size: 1.75rem;
+  }
+
+  @media screen and (min-width: 992px) {
+    font-size: 2.125rem;
+  }
 }
 
 .masthead small {
-  font-size: 1.3rem;
+  font-size: 1.125rem;
+  padding-top: 0.25rem !important;
+
+  @media screen and (min-width: 992px) {
+    font-size: 1.5rem;
+  }
+}
+
+.site-title-container {
+  max-height: 8rem;
+}
+
+.masthead .site-title-wrapper {
+  padding-bottom: 0.5rem;
+  margin-top: 0.5rem;
+
+  @media screen and (min-width: 992px) {
+    padding-bottom: 1rem;
+    margin-top: 1rem;
+  }
 }
 
 .dd-list {
@@ -150,11 +177,11 @@ h5,
 }
 
 .search-widgets {
-  
+
   .btn {
     @extend .btn-sm;
   }
-  
+
   .view-type-group {
     height: $input-height-sm;
   }

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -70,7 +70,7 @@
 // Reduce size of page titles, headings, etc.
 .page-title,
 .page-header {
-  font-size: 1.875rem;
+  font-size: 2rem;
   color: $heading-font-color;
 
   small {
@@ -78,9 +78,23 @@
   }
 }
 
+.blacklight-browse h1 {
+  font-size: 2rem;
+}
+
 .item-count {
   color: $cool-grey;
   font-size: 1.25rem;
+}
+
+#content h2 {
+  font-size: 1.75rem;
+
+  // Landing page cards use H2 but we don't want them to get the
+  // h2 size above.
+  &.card-title {
+    font-size: initial;
+  }
 }
 
 h3,


### PR DESCRIPTION
Nothing too major, but sorts out some inconsistency in sizing between the H1 and H2 sizes, increases the small help text size a bit, and adjusts the masthead title and subtitle sizes. I also did a little responsive sizing to the masthead titles, just because below `lg` the title feels bigger than it should be given the reduced width of the viewport.

Will double-check everything again when it gets to -stage.

<img width="969" alt="Screen Shot 2020-02-14 at 11 33 11 AM" src="https://user-images.githubusercontent.com/101482/74561670-dbe3b280-4f1d-11ea-8332-9f16e4d191a3.png">


