### PR TITLE
Update max-width of the metadata's DDs to be 45 em (instead of ch)

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -28,7 +28,7 @@
     margin-top: 2 * $padding-large-vertical;
 
     dd {
-      max-width: 45ch;
+      max-width: 45em;
     }
   }
 


### PR DESCRIPTION
Fixes #1676 

## Before
<img width="1185" alt="before" src="https://user-images.githubusercontent.com/96776/74562048-c7ec8080-4f1e-11ea-8507-2acdc2c04f23.png">

## After
<img width="876" alt="after" src="https://user-images.githubusercontent.com/96776/74562053-c9b64400-4f1e-11ea-8eb2-9eed07a562f6.png">
