### PR TITLE
Fix color of browse widget item count text

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -87,6 +87,10 @@
   font-size: 1.25rem;
 }
 
+.category-caption .item-count {
+  color: inherit;
+}
+
 small.form-text {
   font-size: 0.875rem;
 }


### PR DESCRIPTION
We're using `item-count` for two different things, which need to be different font colors.

### Before
<img width="442" alt="Screen Shot 2020-02-14 at 6 00 37 PM" src="https://user-images.githubusercontent.com/101482/74578914-8aa2e580-4f54-11ea-995c-7ab69bfcdd65.png">


### After
<img width="442" alt="Screen Shot 2020-02-14 at 6 01 13 PM" src="https://user-images.githubusercontent.com/101482/74578916-90003000-4f54-11ea-89ac-7b3837241d22.png">
