### PR TITLE
Update some spacing in the about page sidebar.

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -157,7 +157,11 @@ h5,
 }
 
 .blacklight-about_pages-show #sidebar {
-  margin-top: $spacer * 2;
+  margin-top: $spacer;
+
+  .contacts-header {
+    margin-top: $spacer * 2.5;
+  }
 }
 
 // Use SUL colors for facet sidebar


### PR DESCRIPTION
Closes #1653 

Note, the `After` screenshot is in conjunction with projectblacklight/spotlight#2475

## Before
<img width="665" alt="before" src="https://user-images.githubusercontent.com/96776/74580387-7f51b900-4f58-11ea-9750-77f668a2c31f.png">

## After
<img width="428" alt="Screen Shot 2020-02-18 at 9 49 50 AM" src="https://user-images.githubusercontent.com/96776/74763130-13ab6c80-5234-11ea-8b05-d314014a7989.png">

