### PR TITLE
Require a druid when linking to a document w/ full-text.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -69,7 +69,7 @@ module CatalogHelper
   end
 
   def search_for_doc_text_link(document)
-    return '' unless params[:q]
+    return '' unless params[:q] && document[:druid]
 
     link_to(
       "Search for \"#{params[:q]}\" in document text",


### PR DESCRIPTION
This is a stop-gap to adddress the issue described in #1704.  We should take a look at the docs returned in that result-set to see why we're getting to this method in the first place (when we clearly shouldn't).