### PR TITLE
Update bootstrap carousel styling to more closely match previous stylle

### DIFF
--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -81,6 +81,15 @@ th {
   }
 }
 
+.carousel-control-prev,
+.carousel-control-next {
+  svg {
+    fill: $white;
+    height: 36px;
+    width: 36px;
+  }
+}
+
 .carousel-control-prev {
   @include gradient-x($start-color: rgba(0 , 0 , 0, .5) , $end-color: rgba(0 ,0 , 0, .0001));
 }

--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -64,3 +64,19 @@ th {
   border-left: 5px solid $border-color;
   padding-left: 1rem;
 }
+
+.carousel-indicators li {
+  background-color: transparent;
+  border: 1px solid $white;
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline-block;
+  height: 10px;
+  margin: 1px 3px;
+  text-indent: -999px;
+  width: 10px;
+
+  &.active {
+    background-color: $white;
+  }
+}

--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -80,3 +80,11 @@ th {
     background-color: $white;
   }
 }
+
+.carousel-control-prev {
+  @include gradient-x($start-color: rgba(0 , 0 , 0, .5) , $end-color: rgba(0 ,0 , 0, .0001));
+}
+
+.carousel-control-next {
+  @include gradient-x($start-color: rgba(0 ,0 , 0, .0001), $end-color: rgba(0 , 0 , 0, .5));
+}


### PR DESCRIPTION
Closes #1682 

## Before Upgrade
<img width="785" alt="carousel-b4-upgrade" src="https://user-images.githubusercontent.com/96776/74790630-03fc4a00-526d-11ea-8b36-eaef42b9505b.png">

## After Upgrade
<img width="778" alt="carousel-before" src="https://user-images.githubusercontent.com/96776/74790549-be3f8180-526c-11ea-8989-2d394a292fa0.png">

## After This PR
<img width="772" alt="carousel-after" src="https://user-images.githubusercontent.com/96776/74790556-c1d30880-526c-11ea-84ba-ab0407bfb0f9.png">
