### PR TITLE
Allow the dt/dd in gallery view to take up 100% width of the page …

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -99,6 +99,12 @@
 
     dl {
       display: block;
+
+      // Override the max-width's (set by bootstrap's columns)
+      dt,
+      dd {
+        max-width: 100%;
+      }
     }
   }
 }


### PR DESCRIPTION
…since they are on their own lines.

Closes #1710 

## Before
<img width="766" alt="gallery-label-before" src="https://user-images.githubusercontent.com/96776/74870177-27c39c80-530e-11ea-8b61-c4d65eba38ff.png">

## After
<img width="778" alt="gallery-label-after" src="https://user-images.githubusercontent.com/96776/74870181-28f4c980-530e-11ea-9da9-915db3fbd17c.png">
