### PR TITLE
Update vertical spacing of Bibliography section and button icon

### DIFF
--- a/app/assets/stylesheets/modules/bibliography.scss
+++ b/app/assets/stylesheets/modules/bibliography.scss
@@ -3,6 +3,7 @@
   padding-left: 0;
 
   h3 {
+    @extend .mt-4;
     color: $brand-primary;
     margin-left: 0;
     padding-left: 0;
@@ -37,6 +38,7 @@
       display: inline-block;
       font-size: 1.2em;
       font-weight: bold;
+      line-height: 1;
       margin-left: 5px;
       transform: rotate(90deg);
     }


### PR DESCRIPTION
A couple of very minor updates, only relevant to Parker.

<img width="1002" alt="Screen Shot 2020-02-24 at 12 31 37 PM" src="https://user-images.githubusercontent.com/101482/75186719-c3d21700-5705-11ea-95fe-1f60cb3e9638.png">

- A: "Bibliography" heading too close to preceeding content.
- B: Formatting issues with reference. Thought I might be able to fix this but decided it'll be safer if I file a ticket for it: #1736 
- C: Button feels slightly too tall, and the alignment of the button text and icon seems off. In the PR I adjusted the line-height of the icon to bring it down slightly, which fixes the unnecessary extra height of the button.

### After

<img width="733" alt="Screen Shot 2020-02-24 at 12 56 24 PM" src="https://user-images.githubusercontent.com/101482/75186916-29260800-5706-11ea-9675-187b5f451ceb.png">
