### PR TITLE
Switch back to using the document request handler

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -28,6 +28,9 @@ class CatalogController < ApplicationController
     config.http_method = :post
     config.index.default_thumbnail = :exhibits_default_thumbnail
 
+    config.document_solr_request_handler = 'document'
+    config.document_solr_path = nil
+
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
     # config.advanced_search[:qt] ||= 'advanced'

--- a/spec/features/sanity_check_spec.rb
+++ b/spec/features/sanity_check_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Sanity checking upstream dependencies', type: :feature do
+  let(:exhibit) { create(:exhibit, slug: 'default-exhibit') }
+
+  describe 'the catalog record page' do
+    it 'shows the fields we expect to see' do
+      visit spotlight.exhibit_solr_document_path(exhibit, 'wk210cf6868')
+
+      [
+        'Title', 'Topic', 'Language', 'Physical Description',
+        'Publication Info', 'Imprint', 'Notes', 'Collection', 'Inline Map'
+      ].each do |expected_field|
+        expect(page).to have_selector 'dt', text: expected_field
+      end
+    end
+  end
+end


### PR DESCRIPTION
Blacklight 7's default is to use Solr's Near-Real-Time get, which works
great for everything except copy fields.

The document request handler just executes a regular search (with the added overhead), but doesn't  suffer from that issue.

It turns out a  small number of exhibit's *_display fields are copy  fields:
  <copyField source="topic_search" dest="topic_display" />
  <copyField source="subject_other_search" dest="subject_other_display" />
  <copyField source="title_variant_search" dest="title_variant_display" />
  <copyField source="summary_search" dest="summary_display" />
  <copyField source="pub_search" dest="pub_display" />

Future work should remediate the configuration in the app and database so wee use the real fields.

Fixes #1758 