### PR TITLE
Separate exhibits by a line break fixes #1765

### DIFF
--- a/app/helpers/search_across_helper.rb
+++ b/app/helpers/search_across_helper.rb
@@ -73,8 +73,7 @@ module SearchAcrossHelper
     exhibit_links = exhibit_metadata.slice(*value).values.map do |x|
       link_to x['title'] || x['slug'], spotlight.exhibit_solr_document_path(x['slug'], document.id)
     end
-
-    safe_join exhibit_links, ', '
+    safe_join exhibit_links, '<br/>'.html_safe
   end
 
   def render_exhibit_title_facet(value)

--- a/spec/helpers/search_across_helper_spec.rb
+++ b/spec/helpers/search_across_helper_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe SearchAcrossHelper, type: :helper do
       actual = Capybara.string(helper.render_exhibit_title(document: doc, value: %w(abc 123 private)))
       expect(actual).to have_link text: 'Alphabet', href: spotlight.exhibit_solr_document_path(exhibit_id: 'abc', id: 1)
       expect(actual).to have_link text: 'Numbers', href: spotlight.exhibit_solr_document_path(exhibit_id: '123', id: 1)
+      expect(actual).to have_css 'br'
       expect(actual).not_to have_link text: 'Secret'
     end
   end


### PR DESCRIPTION
<img width="805" alt="Screen Shot 2020-02-26 at 12 57 02 PM" src="https://user-images.githubusercontent.com/1656824/75382537-e3994480-5897-11ea-8167-8950722a12b9.png">
