### PR TITLE
Move SearchAcross link_to_document override to the controller context…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Style/SymbolArray:
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+    - 'app/controllers/search_across_controller.rb'
 
 Capybara/FeatureMethods:
   Enabled: false

--- a/app/helpers/search_across_helper.rb
+++ b/app/helpers/search_across_helper.rb
@@ -42,28 +42,6 @@ module SearchAcrossHelper
     spotlight.opensearch_search_across_url(*args)
   end
 
-  def link_to_document(doc, field_or_opts, opts = { counter: nil })
-    label = case field_or_opts
-            when NilClass
-              index_presenter(doc).heading
-            when Hash
-              opts = field_or_opts
-              index_presenter(doc).heading
-            when Proc, Symbol
-              Deprecation.silence(Blacklight::IndexPresenter) do
-                index_presenter(doc).label field_or_opts, opts
-              end
-            else # String
-              field_or_opts
-            end
-
-    if doc[SolrDocument.exhibit_slug_field]&.many?
-      label
-    else
-      link_to label, url_for_document(doc), send(:document_link_params, doc, opts)
-    end
-  end
-
   def exhibit_metadata
     @exhibit_metadata ||= accessible_exhibits_from_search_results.as_json(only: %i(slug title description id))
                                                                  .index_by { |x| x['slug'] }

--- a/spec/controllers/search_across_controller_spec.rb
+++ b/spec/controllers/search_across_controller_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe SearchAcrossController, type: :controller do
     end
   end
 
+  describe '#link_to_document' do
+    let(:exhibit_document) do
+      SolrDocument.new(id: 'SomeId1', "#{SolrDocument.exhibit_slug_field}": ['abc'])
+    end
+    let(:multi_exhibit_document) do
+      SolrDocument.new(id: 'SomeId2', "#{SolrDocument.exhibit_slug_field}": %w(abc xyz))
+    end
+
+    it 'links to exhibit documents' do
+      expect(controller.link_to_document(exhibit_document, nil)).to eq '<a href="/abc/catalog/SomeId1">SomeId1</a>'
+    end
+
+    it 'suppresses links for multi-exhibit documents' do
+      expect(controller.link_to_document(multi_exhibit_document, nil)).to eq 'SomeId2'
+    end
+  end
+
   describe '#exhibit_tags_facet_query_config' do
     subject(:config) { controller.exhibit_tags_facet_query_config }
 

--- a/spec/helpers/search_across_helper_spec.rb
+++ b/spec/helpers/search_across_helper_spec.rb
@@ -182,34 +182,5 @@ RSpec.describe SearchAcrossHelper, type: :helper do
         expect(helper).to have_received(:render_document_index).with(exhibits)
       end
     end
-
-    describe '#link_to_document' do
-      let(:exhibit_document) do
-        SolrDocument.new(id: 'Some title', "#{SolrDocument.exhibit_slug_field}": ['abc'])
-      end
-      let(:multi_exhibit_document) do
-        SolrDocument.new(id: 'Some title', "#{SolrDocument.exhibit_slug_field}": %w(abc xyz))
-      end
-      let(:blacklight_config) { SearchAcrossController.new.blacklight_config }
-
-      it 'links to exhibit documents' do
-        expect(helper).to receive_messages(
-          blacklight_config: blacklight_config,
-          blacklight_configuration_context: Blacklight::Configuration::Context.new(SearchAcrossController.new),
-          search_state: Blacklight::SearchState.new({}, blacklight_config),
-          search_session: {},
-          current_search_session: {}
-        )
-        expect(helper.link_to_document(exhibit_document, nil)).to eq '<a href="/catalog/Some%20title">Some title</a>'
-      end
-
-      it 'suppresses links for multi-exhibit documents' do
-        expect(helper).to receive_messages(
-          blacklight_config: blacklight_config,
-          blacklight_configuration_context: Blacklight::Configuration::Context.new(SearchAcrossController.new)
-        )
-        expect(helper.link_to_document(multi_exhibit_document, nil)).to eq 'Some title'
-      end
-    end
   end
 end


### PR DESCRIPTION
… so it doesn't override behavior across the app.

Fixes #1788 

I plan on backfilling this with some sanity check tests, as well as investigate some of the other helper methods and their potential impact, but wanted to get this fix out ASAP.