### PR TITLE
Change content justification in search results

### DIFF
--- a/app/assets/stylesheets/modules/search_across.scss
+++ b/app/assets/stylesheets/modules/search_across.scss
@@ -10,7 +10,7 @@
   .search-widgets {
     @extend .w-100;
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
   }
 
   .btn-group {


### PR DESCRIPTION
Use `flex-end` instead of `end` (which has mixed browser support)