### PR TITLE
Update search across navbar responsiveness

### DIFF
--- a/app/views/shared/_site_navbar.html.erb
+++ b/app/views/shared/_site_navbar.html.erb
@@ -9,7 +9,7 @@
         </li>
       </ul>
 
-      <ul class="navbar-nav">
+      <ul class="navbar-nav align-self-start">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             About

--- a/app/views/shared/_site_navbar.html.erb
+++ b/app/views/shared/_site_navbar.html.erb
@@ -1,7 +1,7 @@
 <% if Settings.feature_flags.home_page_navbar %>
   <div id="site-navbar" class="site-navbar navbar navbar-light navbar-expand-md" role="navigation" aria-label="<%= t('spotlight.exhibitnavbar.label') %>">
     <div class="container flex-column flex-md-row">
-      <ul class="navbar-nav mr-auto order-1 order-md-0 mt-3 mt-md-0">
+      <ul class="navbar-nav mr-auto w-100 order-1 order-md-0 mt-3 mt-md-0">
         <li class="navbar-item">
           <% if Settings.feature_flags.search_across || controller.controller_name == 'search_across' %>
             <%= render 'shared/site_search_form', presenter: Blacklight::SearchBarPresenter.new(controller, SearchAcrossController.blacklight_config) %>

--- a/app/views/shared/_site_navbar.html.erb
+++ b/app/views/shared/_site_navbar.html.erb
@@ -1,7 +1,7 @@
 <% if Settings.feature_flags.home_page_navbar %>
   <div id="site-navbar" class="site-navbar navbar navbar-light navbar-expand-md" role="navigation" aria-label="<%= t('spotlight.exhibitnavbar.label') %>">
     <div class="container flex-column flex-md-row">
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav mr-auto order-1 order-md-0 mt-3 mt-md-0">
         <li class="navbar-item">
           <% if Settings.feature_flags.search_across || controller.controller_name == 'search_across' %>
             <%= render 'shared/site_search_form', presenter: Blacklight::SearchBarPresenter.new(controller, SearchAcrossController.blacklight_config) %>
@@ -9,7 +9,7 @@
         </li>
       </ul>
 
-      <ul class="navbar-nav align-self-start">
+      <ul class="navbar-nav align-self-start order-0 order-md-1">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             About


### PR DESCRIPTION
Closes #1807

Spoke w/ @ggeisler about this and the mobile element re-order & full-width search bar were desired bonuses.  😺 

## Below Medium (before)
<img width="581" alt="below-md-before" src="https://user-images.githubusercontent.com/96776/75592010-0b261380-5a36-11ea-9e63-dc79f4a57215.png">

## Below Medium (after)
<img width="576" alt="below-md-after" src="https://user-images.githubusercontent.com/96776/75592018-0c574080-5a36-11ea-8bdc-a8159f260b84.png">

No change to the display above medium