### PR TITLE
Update the exhibit_metadata method to use pluck instead of as_json fo…

### DIFF
--- a/app/helpers/search_across_helper.rb
+++ b/app/helpers/search_across_helper.rb
@@ -20,9 +20,14 @@ module SearchAcrossHelper
   end
 
   def exhibit_metadata
-    @exhibit_metadata ||= accessible_exhibits_from_search_results.as_json(
-      only: %i(slug title description id published)
-    ).index_by { |x| x['slug'] }
+    @exhibit_metadata ||= begin
+      attrs = %i(slug title description id published)
+      arel_attrs = attrs.collect { |attr| Arel.sql(attr.to_s) } # Needed for rails 6
+      data = accessible_exhibits_from_search_results.pluck(*arel_attrs).map do |exhibit|
+        attrs.zip(exhibit).to_h.stringify_keys
+      end
+      data.index_by { |x| x['slug'] }
+    end
   end
 
   def render_exhibit_title(document:, value:, **)


### PR DESCRIPTION
…as_json for a performance improvement.

I did some benchmarking locally executing each method of accessing data 100 times w/ ~100 `Spotlight::Exhibit` objects w/ the following results:

|        | user  |   system    |  total   |     real |
|---| --- | --- | --- | --- |
| **as_json** |  2.093539 |  0.048699  | 2.142238  | (  2.174745) |
| **pluck**   |  0.105143 |  0.003883 |  0.109026 | (  0.109769) |

<details>
  <summary>Benchmark Code</summary>

```ruby
require 'benchmark'
n = 100

Benchmark.bm do |bm|
  bm.report("as_json") do
    n.times do
      attrs = %i(slug title description id published)
      things = Spotlight::Exhibit.all.as_json(only: attrs)
      things.map { |t| t['slug'] }; 1
    end
  end

  bm.report("pluck") do
    n.times do
      attrs = %i(slug title description id published)
      arel_attrs = attrs.collect { |attr| Arel.sql(attr.to_s) }
      things = Spotlight::Exhibit.all.pluck(*arel_attrs).map do |exhibit|
        attrs.zip(exhibit).to_h.stringify_keys
      end
      things.map { |t| t['slug'] }; 1
    end
  end
end
```

</details>
