### PR TITLE
Tidy up search across results header area

### DIFF
--- a/app/views/search_across/index.html.erb
+++ b/app/views/search_across/index.html.erb
@@ -2,13 +2,11 @@
   <%= render 'search_sidebar' %>
 <% end %>
 
-<% content_for(:container_header) do %>
-  <% if render_grouped_response? %>
-    <div class="page-links">
-      <div class="page-entries">
-        <%= page_entries_info(Kaminari.paginate_array(@response.aggregations[SolrDocument.exhibit_slug_field].items).page(params[:page] || 1).per(params[:per_page] || current_per_page), entry_name: 'exhibit') %>
-      </div>
+<% if render_grouped_response? %>
+  <div class="page-links">
+    <div class="page-entries">
+      <%= page_entries_info(Kaminari.paginate_array(@response.aggregations[SolrDocument.exhibit_slug_field].items).page(params[:page] || 1).per(params[:per_page] || current_per_page), entry_name: 'exhibit') %>
     </div>
-  <% end %>
+  </div>
 <% end %>
 <%= render 'search_results' %>

--- a/app/views/search_across/index.html.erb
+++ b/app/views/search_across/index.html.erb
@@ -3,11 +3,12 @@
 <% end %>
 
 <% content_for(:container_header) do %>
-  <h1 class="top-content-title"><%= t('.title') %></h1>
-  <div class="page-links">
-    <div class="page-entries">
-      <%= page_entries_info(Kaminari.paginate_array(@response.aggregations[SolrDocument.exhibit_slug_field].items).page(params[:page] || 1).per(params[:per_page] || current_per_page), entry_name: 'exhibit') if render_grouped_response? %>
+  <% if render_grouped_response? %>
+    <div class="page-links">
+      <div class="page-entries">
+        <%= page_entries_info(Kaminari.paginate_array(@response.aggregations[SolrDocument.exhibit_slug_field].items).page(params[:page] || 1).per(params[:per_page] || current_per_page), entry_name: 'exhibit') %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
 <%= render 'search_results' %>


### PR DESCRIPTION
Closes #1806

- Remove Search results header
- Remove empty `page-links` div in "All results" view

## Markup before
![Screen Shot 2020-03-02 at 4 58 00 PM](https://user-images.githubusercontent.com/5402927/75732435-52ffa180-5ca7-11ea-9671-2ef84ffdb2a3.png)

## Markup after
![Screen Shot 2020-03-02 at 4 58 34 PM](https://user-images.githubusercontent.com/5402927/75732434-52ffa180-5ca7-11ea-9ada-2586e6686ad9.png)

---
## Before
### All results 
![cat_-_Stanford_University_Libraries_Search_Results_-_Mozilla_Firefox](https://user-images.githubusercontent.com/5402927/75732076-50e91300-5ca6-11ea-9ddb-204c4e4227b9.png)

### Grouped by exhibit
![cat_-_Stanford_University_Libraries_Search_Results_-_Mozilla_Firefox](https://user-images.githubusercontent.com/5402927/75732057-42026080-5ca6-11ea-8740-24cd2cbcb539.png)

---
## After
### All results 
![cat_-_Stanford_University_Libraries_Search_Results_-_Mozilla_Firefox](https://user-images.githubusercontent.com/5402927/75732020-25662880-5ca6-11ea-9f35-c169824094af.png)

### Grouped by exhibit
![cat_-_Stanford_University_Libraries_Search_Results_-_Mozilla_Firefox](https://user-images.githubusercontent.com/5402927/75732027-2dbe6380-5ca6-11ea-8230-cfb41863362a.png)




