### PR TITLE
Update styling of search across grouped by views

### DIFF
--- a/app/assets/stylesheets/modules/search_across.scss
+++ b/app/assets/stylesheets/modules/search_across.scss
@@ -35,6 +35,12 @@
   }
 
   .card-body {
+    @media (max-width: breakpoint-max(sm)) {
+      padding-top: 0;
+    }
+
+    padding-bottom: $spacer * 0.5;
+    padding-top: $spacer * 0.5;
     flex-direction: column;
   }
 
@@ -69,13 +75,16 @@
   .exhibit-description,
   &:hover .exhibit-description,
   &:focus-within .exhibit-description {
-    margin-bottom: 0;
+    @extend .my-1;
     max-height: inherit;
   }
 
   .subtitle {
-    @extend .h5;
-    font-size: 0.875rem;
+    @media (max-width: breakpoint-max(sm)) {
+      margin-bottom: $spacer * 0.25;
+    }
+
+    font-size: 1rem;
     line-height: $headings-line-height;
     text-align: left;
   }
@@ -95,6 +104,7 @@
 
 .exhibit-gallery {
   .card-body {
+    @extend .p-3;
     text-align: center;
   }
 
@@ -110,6 +120,7 @@
   .exhibit-description,
   &:hover .exhibit-description,
   &:focus-within .exhibit-description {
+    @extend .mt-2;
     margin-bottom: 0;
     max-height: inherit;
   }


### PR DESCRIPTION
A handful of fairly minor styling updates intended to space the text elements of the Grouped by views a bit better.

### List view
Moved text elements toward the top a bit, space between title and subtitle, increase font size of subtitle, space between description and result count text.

![Screen Shot 2020-03-03 at 11 28 00 AM](https://user-images.githubusercontent.com/101482/75812194-a3780d00-5d42-11ea-80c4-8616097ebdbb.png)

### List view, mobile
Adjust the spacing above the title so it is closer to the top, given the reduced height of the result item rows on mobile.

![Screen Shot 2020-03-03 at 11 29 51 AM](https://user-images.githubusercontent.com/101482/75812269-c4406280-5d42-11ea-890e-e40cf725eb3f.png)

### Gallery view
Reduce card padding to allow text to go a bit wider (to mitigate text wrapping a bit), add space between title and subtitle.

![Screen Shot 2020-03-03 at 11 26 36 AM](https://user-images.githubusercontent.com/101482/75812378-fbaf0f00-5d42-11ea-9368-fbf80da336ce.png)
