### PR TITLE
Only render the first search field (all/default) as a hidden input …

### DIFF
--- a/app/views/shared/_site_search_form.html.erb
+++ b/app/views/shared/_site_search_form.html.erb
@@ -4,18 +4,10 @@
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
   <div class="input-group">
-    <% if search_fields.length > 1 %>
-        <%= select_tag(:search_field,
-                       options_for_select(search_fields, h(params[:search_field])),
-                       title: t('blacklight.search.form.search_field.title'),
-                       id: "search_field",
-                       class: "custom-select search-field") %>
-    <% elsif search_fields.length == 1 %>
-      <%= hidden_field_tag :search_field, search_fields.first.last %>
-    <% end %>
+    <%= hidden_field_tag :search_field, search_fields.first.last %>
 
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, params[:q], placeholder: t('.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+    <%= text_field_tag :q, params[:q], placeholder: t('.placeholder'), class: "search-q q form-control rounded-left", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
 
     <span class="input-group-append">
       <button type="submit" class="btn btn-primary search-btn" id="search">


### PR DESCRIPTION
… in the Search Across form.

Closes #1825 

## Site Users Admin (before)
<img width="529" alt="admin-users-before" src="https://user-images.githubusercontent.com/96776/75829421-fa8dda00-5d62-11ea-925c-19502fde702e.png">

## Site Users Admin (after)
<img width="480" alt="admin-users-after" src="https://user-images.githubusercontent.com/96776/75829556-5f493480-5d63-11ea-8e36-e2c9a07b2f3f.png">


This also affects a few other pages as well.