### PR TITLE
Update site title in locale file

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,6 @@
 en:
   blacklight:
-    application_name: 'Stanford University Libraries'
+    application_name: Spotlight at Stanford
     search:
       start_over: Start over
   views:


### PR DESCRIPTION
Closes #1824 

Search Across result pages use the blacklight application_name for the masthead title. Looking into this revealed that we were using the outdated "Stanford Unviersity Libraries" for the Blacklight application name. Changing this locale key also gets Search Across tab  <title>s in line with the "Spotlight at Stanford" pattern used elsewhere in the application.




### Before
`<title>` is `cat - Stanford University Libraries Search Results`
![Screen Shot 2020-03-03 at 11 59 22 AM](https://user-images.githubusercontent.com/101482/75814625-ee941f00-5d46-11ea-8dfe-b6bbab75ebf8.png)

### After
`<title>` is `cat - Spotlight at Stanford Search Results`
![Screen Shot 2020-03-03 at 11 59 15 AM](https://user-images.githubusercontent.com/101482/75814573-d45a4100-5d46-11ea-9641-46cf23662ca9.png)

