### PR TITLE
Ensure that map does not break the metadata layout fixes #1787

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_heatmaps_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_heatmaps_overrides.scss
@@ -1,9 +1,3 @@
-.blacklight-heatmaps-show-map-wrapper {
-  @media (min-width: breakpoint-min("sm")) {
-    padding-left: 50px;
-  }
-}
-
 .blacklight-heatmaps-show-map {
   margin-bottom: $spacer;
   width: 100%;

--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -108,11 +108,3 @@
     }
   }
 }
-
-dt.blacklight-geographic_srpt {
-  display: none;
-}
-
-dd.blacklight-geographic_srpt {
-  margin-left: 0;
-}


### PR DESCRIPTION
Some Gifs of configurations that we use in production (top and bottom)

## Configured at the top
![Kapture 2020-03-04 at 11 40 30](https://user-images.githubusercontent.com/1656824/75911558-f8805580-5e0c-11ea-9150-f166a26022e0.gif)

## Configured at the bottom
![Kapture 2020-03-04 at 11 38 54](https://user-images.githubusercontent.com/1656824/75911563-fae2af80-5e0c-11ea-824f-eb1ba9e82a9b.gif)