### PR TITLE
Hide the facet heading border on smaller viewports

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -175,6 +175,12 @@ h5,
   padding-top: 0;
 }
 
+#sidebar .facets-heading {
+  @media (max-width: breakpoint-max(md)) {
+    border-bottom: 0;
+  }
+}
+
 #sidebar ul.nav > li a {
   padding: 0.25rem;
 


### PR DESCRIPTION
The bottom border on the facet sidebar heading doesn't align well with the expand button that is displayed on `md` or smaller viewports:

![Screen Shot 2020-03-05 at 1 30 37 PM](https://user-images.githubusercontent.com/101482/76027750-048c1600-5ee6-11ea-9a23-956b73d8c077.png)

This PR hides the border on those viewports:

![Screen Shot 2020-03-05 at 1 31 58 PM](https://user-images.githubusercontent.com/101482/76027770-1372c880-5ee6-11ea-91fd-82ec205f19a7.png)
