### PR TITLE
Order search across facet values by count

### DIFF
--- a/app/controllers/search_across_controller.rb
+++ b/app/controllers/search_across_controller.rb
@@ -67,7 +67,9 @@ class SearchAcrossController < ::CatalogController
 
   before_action do
     tags_facet = blacklight_config.add_facet_field 'exhibit_tags', query: exhibit_tags_facet_query_config,
-                                                                   label: 'Exhibit category'
+                                                                   label: 'Exhibit category',
+                                                                   sort: :count
+
     blacklight_config.facet_fields.delete(tags_facet.key)
     blacklight_config.facet_fields = { tags_facet.key => tags_facet }.merge(blacklight_config.facet_fields)
 

--- a/app/controllers/search_across_controller.rb
+++ b/app/controllers/search_across_controller.rb
@@ -40,7 +40,9 @@ class SearchAcrossController < ::CatalogController
 
     config.facet_fields.clear
     config.add_facet_field SolrDocument.exhibit_slug_field,
-                           helper_method: :render_exhibit_title_facet
+                           helper_method: :render_exhibit_title_facet,
+                           sort: :count
+
     config.add_facet_field 'pub_year_tisim', label: 'Date range',
                                              range: true,
                                              partial: 'blacklight_range_limit/range_limit_panel'


### PR DESCRIPTION
Closes #1836

Note: The "Exhibit category" facet sorting will require projectblacklight/blacklight#2255 to start sorting, but the config is no-op currently, so this will just begin to be sorted correctly once we've updated (most likely through our automated weekly patching).

## Before
<img width="283" alt="facets-before" src="https://user-images.githubusercontent.com/96776/76036103-0c54b600-5ef8-11ea-8638-68887ea3c359.png">

## After
<img width="303" alt="facets-after" src="https://user-images.githubusercontent.com/96776/76036104-0d85e300-5ef8-11ea-985a-0bde38f7f32b.png">
