### PR TITLE
Add the thumb field for IIIF imported items

### DIFF
--- a/app/models/spotlight/resources/iiif_manifest.rb
+++ b/app/models/spotlight/resources/iiif_manifest.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This unpleasantness allows us to include the upstream class before overriding it
+# rubocop:disable Rails/DynamicFindBy
+spotlight_path = Gem::Specification.find_by_name('blacklight-spotlight').full_gem_path
+require_dependency File.join(spotlight_path, 'app/models/spotlight/resources/iiif_manifest.rb')
+# rubocop:enable Rails/DynamicFindBy
+
+module Spotlight
+  module Resources
+    ##
+    # A PORO to construct a solr hash for a given IiifManifest
+    class IiifManifest
+      def add_thumbnail_url
+        return unless thumbnail_field && manifest['thumbnail'].present?
+
+        if manifest&.[]('thumbnail')&.[]('service')&.[]('profile')&.match? 'api/image'
+          solr_hash[:thumbnail_square_url_ssm] =
+            "#{manifest&.[]('thumbnail')&.[]('service')&.[]('@id')}/square/100,100/0/default.jpg"
+        end
+        solr_hash[thumbnail_field] = manifest['thumbnail']['@id']
+      end
+    end
+  end
+end

--- a/app/models/spotlight/resources/iiif_manifest.rb
+++ b/app/models/spotlight/resources/iiif_manifest.rb
@@ -12,13 +12,22 @@ module Spotlight
     # A PORO to construct a solr hash for a given IiifManifest
     class IiifManifest
       def add_thumbnail_url
-        return unless thumbnail_field && manifest['thumbnail'].present?
+        return unless thumbnail_field
 
-        if manifest&.[]('thumbnail')&.[]('service')&.[]('profile')&.match? 'api/image'
-          solr_hash[:thumbnail_square_url_ssm] =
-            "#{manifest&.[]('thumbnail')&.[]('service')&.[]('@id')}/square/100,100/0/default.jpg"
+        if manifest['thumbnail'].present?
+          if manifest&.[]('thumbnail')&.[]('service')&.[]('profile')&.match? 'api/image'
+            solr_hash[:thumbnail_square_url_ssm] =
+              "#{manifest&.[]('thumbnail')&.[]('service')&.[]('@id')}/square/100,100/0/default.jpg"
+          end
+          solr_hash[thumbnail_field] = manifest['thumbnail']['@id']
+        else
+          first_image_id = manifest&.[]('sequences')&.[](0)&.[]('canvases')&.[](0)
+            &.[]('images')&.[](0)&.[]('resource')&.[]('service')&.[]('@id')
+          if first_image_id
+            solr_hash[:thumbnail_square_url_ssm] = "#{first_image_id}/square/100,100/0/default.jpg"
+            solr_hash[thumbnail_field] = "#{first_image_id}/full/!400,400/0/default.jpg"
+          end
         end
-        solr_hash[thumbnail_field] = manifest['thumbnail']['@id']
       end
     end
   end

--- a/app/models/spotlight/resources/iiif_manifest.rb
+++ b/app/models/spotlight/resources/iiif_manifest.rb
@@ -17,14 +17,14 @@ module Spotlight
         if manifest['thumbnail'].present?
           if manifest&.[]('thumbnail')&.[]('service')&.[]('profile')&.match? 'api/image'
             solr_hash[:thumbnail_square_url_ssm] =
-              "#{manifest&.[]('thumbnail')&.[]('service')&.[]('@id')}/square/100,100/0/default.jpg"
+              "#{manifest&.[]('thumbnail')&.[]('service')&.[]('@id')}/full/100,100/0/default.jpg"
           end
           solr_hash[thumbnail_field] = manifest['thumbnail']['@id']
         else
           first_image_id = manifest&.[]('sequences')&.[](0)&.[]('canvases')&.[](0)
             &.[]('images')&.[](0)&.[]('resource')&.[]('service')&.[]('@id')
           if first_image_id
-            solr_hash[:thumbnail_square_url_ssm] = "#{first_image_id}/square/100,100/0/default.jpg"
+            solr_hash[:thumbnail_square_url_ssm] = "#{first_image_id}/full/100,100/0/default.jpg"
             solr_hash[thumbnail_field] = "#{first_image_id}/full/!400,400/0/default.jpg"
           end
         end

--- a/spec/models/spotlight/resources/iiif_manifest_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Spotlight::Resources::IiifManifest do
+  let(:manifest) do
+    {
+      'thumbnail' => {
+        '@id' => 'www.example.com/iiif/full/!400,400/0/default.jpg',
+        'service' => {
+          'profile' => 'http://iiif.io/api/image/2/level2.json',
+          '@id' => 'www.example.com/iiif'
+        }
+      }
+    }
+  end
+
+  let(:iiif_manifest_resource) { described_class.new }
+
+  describe '#add_thumbnail_url' do
+    it 'adds in the exhibits custom field thumbnail_square_url_ssm' do
+      expect(iiif_manifest_resource).to receive_messages(
+        thumbnail_field: 'thumbnail_field',
+        manifest: manifest
+      )
+
+      iiif_manifest_resource.add_thumbnail_url
+      expect(iiif_manifest_resource.send(:solr_hash)).to include(
+        'thumbnail_field' => 'www.example.com/iiif/full/!400,400/0/default.jpg',
+        thumbnail_square_url_ssm: 'www.example.com/iiif/square/100,100/0/default.jpg'
+      )
+    end
+  end
+end

--- a/spec/models/spotlight/resources/iiif_manifest_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_spec.rb
@@ -23,12 +23,50 @@ describe Spotlight::Resources::IiifManifest do
         thumbnail_field: 'thumbnail_field',
         manifest: manifest
       )
-
       iiif_manifest_resource.add_thumbnail_url
+
       expect(iiif_manifest_resource.send(:solr_hash)).to include(
         'thumbnail_field' => 'www.example.com/iiif/full/!400,400/0/default.jpg',
         thumbnail_square_url_ssm: 'www.example.com/iiif/square/100,100/0/default.jpg'
       )
+    end
+
+    context 'no thumbnail manifest' do
+      let(:manifest) do
+        {
+          'sequences' => [
+            {
+              'canvases' => [
+                {
+                  'images' => [
+                    {
+                      'resource' => {
+                        'service' => {
+                          'profile' => 'http://iiif.io/api/image/2/level2.json',
+                          '@id' => 'www.example.com/iiif/1v'
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'uses the first canvas as a thumbnail' do
+        expect(iiif_manifest_resource).to receive_messages(
+          thumbnail_field: 'thumbnail_field',
+          manifest: manifest
+        )
+        iiif_manifest_resource.add_thumbnail_url
+
+        expect(iiif_manifest_resource.send(:solr_hash)).to include(
+          'thumbnail_field' => 'www.example.com/iiif/1v/full/!400,400/0/default.jpg',
+          thumbnail_square_url_ssm: 'www.example.com/iiif/1v/square/100,100/0/default.jpg'
+        )
+      end
     end
   end
 end

--- a/spec/models/spotlight/resources/iiif_manifest_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_spec.rb
@@ -27,7 +27,7 @@ describe Spotlight::Resources::IiifManifest do
 
       expect(iiif_manifest_resource.send(:solr_hash)).to include(
         'thumbnail_field' => 'www.example.com/iiif/full/!400,400/0/default.jpg',
-        thumbnail_square_url_ssm: 'www.example.com/iiif/square/100,100/0/default.jpg'
+        thumbnail_square_url_ssm: 'www.example.com/iiif/full/100,100/0/default.jpg'
       )
     end
 
@@ -64,7 +64,7 @@ describe Spotlight::Resources::IiifManifest do
 
         expect(iiif_manifest_resource.send(:solr_hash)).to include(
           'thumbnail_field' => 'www.example.com/iiif/1v/full/!400,400/0/default.jpg',
-          thumbnail_square_url_ssm: 'www.example.com/iiif/1v/square/100,100/0/default.jpg'
+          thumbnail_square_url_ssm: 'www.example.com/iiif/1v/full/100,100/0/default.jpg'
         )
       end
     end


### PR DESCRIPTION
Adds support for a few cases so the results views look consistent:

 1. No thumbnail is provided (falls back to first canvas) https://cdm17229.contentdm.oclc.org/iiif/info/p17229coll19/192/manifest.json
 2. Thumbnail is provided https://purl.stanford.edu/bb389yg4719/iiif/manifest
<img width="883" alt="Screen Shot 2020-03-12 at 5 04 26 PM" src="https://user-images.githubusercontent.com/1656824/76577810-a5994480-6483-11ea-9e43-388bb3faae9a.png">

## Update

Adds a commit that removes the `square` region parameter. This is not supported by existing Exhibits content that @camillevilla pointed out. So while this is suboptimal, its better than broken images.

<img width="450" alt="Screen Shot 2020-03-13 at 4 08 05 PM" src="https://user-images.githubusercontent.com/1656824/76663370-57994500-6546-11ea-890d-0f2be5a4bacb.png">

