### PR TITLE
Update UAT oEmbed provider.

### DIFF
--- a/config/initializers/oembed_providers.rb
+++ b/config/initializers/oembed_providers.rb
@@ -7,7 +7,8 @@ purl_provider << 'http://purl.stanford.edu/*'
 purl_provider << 'https://purl.stanford.edu/*'
 purl_provider << 'http://searchworks.stanford.edu/*'
 
-purl_uat_provider = OEmbed::Provider.new('http://sul-purl-uat.stanford.edu/embed.{format}?&hide_title=true')
+purl_uat_provider = OEmbed::Provider.new('https://sul-purl-uat.stanford.edu/embed.{format}?&hide_title=true')
+purl_uat_provider << 'http://sul-purl-uat.stanford.edu/*'
 purl_uat_provider << 'https://sul-purl-uat.stanford.edu/*'
 
 OEmbed::Providers.register(purl_provider)


### PR DESCRIPTION
It appears that it requires https (unlike the production provider)