### PR TITLE
Add an initial exhibit search implementation 

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,12 +33,14 @@
 //= require blacklight_oembed
 //= require full_text_collapse
 //= require index_status_typeahead
+//= require exhibit_search_typeahead
 //= require nested_related_items
 //= require openseadragon
 //= require spotlight
 //= require sul-exhibits-template
 //= require table_of_contents
 //= require custom-file-input
+//= require site_search_type_toggle
 
 
 // For blacklight_range_limit built-in JS, if you don't want it you don't need

--- a/app/assets/javascripts/exhibit_search_typeahead.js
+++ b/app/assets/javascripts/exhibit_search_typeahead.js
@@ -1,0 +1,105 @@
+/* global Blacklight */
+/* global Bloodhound */
+/* global Handlebars */
+/* global ExhibitSearchTypeahead */
+
+(function (global) {
+  var ExhibitSearchTypeahead;
+
+  ExhibitSearchTypeahead = {
+    form: null,
+    typeaheadElement: null,
+    typeaheadRemoteUrl: null,
+    typeaheadOptions: { hint: true, highlight: true, minLength: 1 },
+
+    init: function (el) {
+      var _this = this;
+      var container = el.parents('.exhibit-search-typeahead');
+      _this.typeaheadElement = el;
+      _this.form = el.parents('form');
+      _this.typeaheadRemoteUrl = el.data().typeaheadRemoteUrl + '?q=%QUERY';
+      _this.preventFormSubmitOnTypeahead();
+
+      // Cleanup typeahead if it alread exists (e.g. back-button cache)
+      if (el.parent().hasClass('twitter-typeahead')) {
+        el.typeahead('destroy');
+
+        el.attr('disabled', false);
+        el.attr('style', '');
+        el.removeClass('tt-hint');
+
+        container.html(el);
+      }
+
+      el.typeahead(_this.typeaheadOptions, _this.typeaheadSources());
+
+      container.find('.tt-dropdown-menu').attr('aria-live', 'assertive');
+
+      el.bind('typeahead:selected', function(e, suggestion) {
+        window.location = '/' + suggestion.slug;
+      });
+    },
+
+    preventFormSubmitOnTypeahead: function() {
+      var _this = this;
+
+      _this.form.on('submit', function(e) {
+        if(_this.typeaheadElement.is(':focus')) {
+          e.preventDefault();
+        }
+      });
+    },
+
+    typeaheadSources: function() {
+      var bloodhound = this.bloodhoundEngine();
+      bloodhound.initialize();
+      return {
+        name: 'exhibit',
+        displayKey: 'title',
+        source: bloodhound.ttAdapter(),
+        templates: {
+          empty: [
+            '<div class="no-items">',
+            'No matches found',
+            '</div>'
+          ].join('\n'),
+          suggestion: Handlebars.compile(
+            '<div class="exhibit-result">{{title}} <span class="subtitle">{{subtitle}}</span></div>'
+          )
+        }
+      };
+    },
+
+    bloodhoundEngine: function() {
+      return new Bloodhound({
+        limit: 5,
+        remote: {
+          url: this.typeaheadRemoteUrl,
+          filter: function (documents) {
+            return $.map(documents, function (document) {
+              return {
+                title: document.title,
+                subtitle: document.subtitle,
+                slug: document.slug
+              };
+            });
+          }
+        },
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        datumTokenizer: function(d) {
+          return Bloodhound.tokenizers.whitespace(d);
+        }
+      });
+    }
+  };
+
+  global.ExhibitSearchTypeahead = ExhibitSearchTypeahead;
+}(this));
+
+Blacklight.onLoad(function () {
+  'use strict';
+
+  $('[data-behavior="exhibit-search-typeahead"]').each(function (i, element) {
+    ExhibitSearchTypeahead.init($(element)); // eslint-disable-line no-undef
+  });
+});

--- a/app/assets/javascripts/site_search_type_toggle.js
+++ b/app/assets/javascripts/site_search_type_toggle.js
@@ -1,0 +1,47 @@
+/* global Blacklight */
+/* global SiteSearchTypeToggle */
+
+(function (global) {
+  var SiteSearchTypeToggle;
+
+  SiteSearchTypeToggle = {
+    menuOptions: [],
+    init: function (el) {
+      var _this = this;
+      var button = el.find('button.dropdown-toggle');
+      var menuItems = el.find('.dropdown-menu .dropdown-item');
+      _this.menuOptions = $('[data-behavior="site-search-type"]');
+      _this.hideAllMenuOptions();
+      el.show();
+
+      $(el.data('enabled')).show();
+
+      menuItems.each(function() {
+        $(this).on('click', function(e) {
+          e.preventDefault();
+
+          _this.hideAllMenuOptions();
+          $($(this).data('target')).show();
+
+          button.text($(this).data('buttonText'));
+        });
+      });
+    },
+
+    hideAllMenuOptions: function() {
+      this.menuOptions.each(function() {
+        $(this).hide();
+      });
+    }
+  };
+
+  global.SiteSearchTypeToggle = SiteSearchTypeToggle;
+}(this));
+
+Blacklight.onLoad(function () {
+  'use strict';
+
+  $('[data-behavior="site-search-type-toggle"]').each(function (i, element) {
+    SiteSearchTypeToggle.init($(element)); // eslint-disable-line no-undef
+  });
+});

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -18,3 +18,4 @@
 @import "modules/full_text_highlight";
 @import "modules/caret";
 @import "modules/search_across";
+@import "modules/exhibit_search_typeahead";

--- a/app/assets/stylesheets/modules/exhibit_search_typeahead.scss
+++ b/app/assets/stylesheets/modules/exhibit_search_typeahead.scss
@@ -1,0 +1,24 @@
+.exhibit-search-typeahead {
+  .tt-dropdown-menu {
+    width: 100%;
+  }
+
+  .tt-suggestion {
+    border-bottom: 1px solid $exhibit-title-typeahead-border;
+
+    .subtitle {
+      display: block;
+      font-size: 13px;
+      margin-top: 0.25em;
+    }
+  }
+
+  .tt-suggestion,
+  .no-items {
+    font-size: 15px;
+    line-height: 1.5em;
+    margin-bottom: 8px;
+    padding: 0 15px 8px;
+    text-transform: none;
+  }
+}

--- a/app/assets/stylesheets/modules/layout.scss
+++ b/app/assets/stylesheets/modules/layout.scss
@@ -34,6 +34,18 @@
   .search-query-form {
     min-width: 17em;
   }
+
+  @media (min-width: breakpoint-min("lg")) {
+    .site-search-nav {
+      max-width: 30em;
+    }
+  }
+
+  @media (min-width: breakpoint-min("xl")) {
+    .site-search-nav {
+      max-width: 32em;
+    }
+  }
 }
 
 .exhibit-navbar,

--- a/app/assets/stylesheets/modules/search_across.scss
+++ b/app/assets/stylesheets/modules/search_across.scss
@@ -20,6 +20,7 @@
   .search-group {
     margin-left: 0;
     margin-right: auto;
+    z-index: 0;
   }
 }
 
@@ -127,5 +128,26 @@
 
   .exhibit-card {
     padding-bottom: 0;
+  }
+}
+
+.search-across-form {
+  input {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+  }
+
+  // dropdown-men is position: static on small
+  // viewports but we want it to remain absolute
+  .dropdown-menu {
+    position: absolute;
+  }
+
+  .input-group {
+    flex-wrap: nowrap;
+  }
+
+  .site-search-type {
+    flex-grow: 3;
   }
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -22,6 +22,7 @@ $secondary: $color-beige-10;
 
 $exhibit-card-bg: $color-beige-20;
 $exhibit-card-border: $color-gray-80;
+$exhibit-title-typeahead-border: $color-beige-20;
 
 $navbar-dark-color: lighten($gray-base, 86%);
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,6 +41,7 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: 'search',
+      fq: '-document_type_ssi:exhibit',
       # Wipe out the values of the `all_search*` and `full_text*` fields using clever solr tricks to deal with
       # cases (like rarebooks) that have abundant full text data (to the tune of 1MB per object.. times 8) that
       # cause search results to slow to a crawl. We don't actually use these fields for displaying results,

--- a/app/controllers/exhibit_finder_controller.rb
+++ b/app/controllers/exhibit_finder_controller.rb
@@ -9,6 +9,11 @@ class ExhibitFinderController < ApplicationController
 
   # /exhibit_finder/:id
   def show
-    render json: ExhibitFinder.new(params[:id])
+    render json: ExhibitFinder.find(params[:id])
+  end
+
+  # /exhibit_finder
+  def index
+    render json: ExhibitFinder.search(params[:q])
   end
 end

--- a/app/helpers/search_across_helper.rb
+++ b/app/helpers/search_across_helper.rb
@@ -14,6 +14,10 @@ module SearchAcrossHelper
     search_state.params_for_search.merge(group: true)
   end
 
+  def in_search_across?
+    controller.controller_name == 'search_across'
+  end
+
   # Strip out parameters (particularly facets) that don't make sense to pass
   # along to the exhibit-specific search endpoint
   def exhibit_search_state_params(my_search_state = search_state)

--- a/app/jobs/index_exhibit_metadata_job.rb
+++ b/app/jobs/index_exhibit_metadata_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+##
+# A job to add or delete exhibit index documents
+class IndexExhibitMetadataJob < ApplicationJob
+  def perform(exhibit:, action:)
+    case action
+    when 'add'
+      ExhibitIndexer.new(exhibit).add
+    when 'delete'
+      ExhibitIndexer.new(exhibit).delete
+    end
+  end
+end

--- a/app/models/exhibit_indexer.rb
+++ b/app/models/exhibit_indexer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+##
+# A claass to index exhibit metadata (and related)
+# You must pass an instance of an exhibit in the initializer
+# ExhibitIndexer.new(exhibit)
+# There is an #add method that will add/update the document in the index for that exhibit.
+# There is also a #delete method that will delete the document for that exhibit (by id).
+class ExhibitIndexer
+  attr_accessor :exhibit
+  def initialize(exhibit)
+    @exhibit = exhibit
+  end
+
+  def to_solr
+    fields.merge(type_field).merge(id_field).reject { |_, v| v.blank? }
+  end
+
+  def delete
+    self.class.solr_connection.delete_by_id(document_id)
+  end
+
+  def add
+    self.class.solr_connection.add(to_solr)
+  end
+
+  def self.solr_connection
+    @solr_connection ||= Blacklight.default_index.connection
+  end
+
+  private
+
+  def fields
+    {
+      exhibit_title_tesim: exhibit.title,
+      exhibit_subtitle_tesim: exhibit.subtitle,
+      exhibit_description_tesim: exhibit.description,
+      exhibit_slug_ssi: exhibit.slug
+    }
+  end
+
+  def document_id
+    "exhibit-#{exhibit.slug}"
+  end
+
+  def id_field
+    { id: document_id }
+  end
+
+  def type_field
+    { document_type_ssi: 'exhibit' }
+  end
+end

--- a/app/views/shared/_old_site_search_form.html.erb
+++ b/app/views/shared/_old_site_search_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <% if search_fields.length > 1 %>
+    <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+  <% end %>
+  <div class="input-group">
+    <%= hidden_field_tag :search_field, search_fields.first.last %>
+
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('.placeholder'), class: "search-q q form-control rounded-left", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+
+    <span class="input-group-append">
+      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+        <%= blacklight_icon :search, aria_hidden: true %>
+      </button>
+    </span>
+  </div>
+<% end %>

--- a/app/views/shared/_site_navbar.html.erb
+++ b/app/views/shared/_site_navbar.html.erb
@@ -1,13 +1,23 @@
 <% if Settings.feature_flags.home_page_navbar %>
   <div id="site-navbar" class="site-navbar navbar navbar-light navbar-expand-md" role="navigation" aria-label="<%= t('spotlight.exhibitnavbar.label') %>">
     <div class="container flex-column flex-md-row">
-      <ul class="navbar-nav mr-auto w-100 order-1 order-md-0 mt-3 mt-md-0">
-        <li class="navbar-item">
-          <% if Settings.feature_flags.search_across || controller.controller_name == 'search_across' %>
-            <%= render 'shared/site_search_form', presenter: Blacklight::SearchBarPresenter.new(controller, SearchAcrossController.blacklight_config) %>
-          <% end  %>
-        </li>
-      </ul>
+      <% if FeatureFlags.new.exhibits_index? %>
+        <ul class="site-search-nav navbar-nav mr-auto mr-md-3 mr-lg-auto w-100 order-1 order-md-0 mt-3 mt-md-0">
+          <li class="navbar-item d-flex flex-grow-1">
+            <% if Settings.feature_flags.search_across || in_search_across? %>
+              <%= render 'shared/site_search_form', presenter: Blacklight::SearchBarPresenter.new(controller, SearchAcrossController.blacklight_config) %>
+            <% end  %>
+          </li>
+        </ul>
+      <% else %>
+        <ul class="navbar-nav mr-auto w-100 order-1 order-md-0 mt-3 mt-md-0">
+          <li class="navbar-item">
+            <% if Settings.feature_flags.search_across || in_search_across? %>
+              <%= render 'shared/old_site_search_form', presenter: Blacklight::SearchBarPresenter.new(controller, SearchAcrossController.blacklight_config) %>
+            <% end  %>
+          </li>
+        </ul>
+      <% end %>
 
       <ul class="navbar-nav align-self-start order-0 order-md-1">
         <li class="nav-item dropdown">

--- a/app/views/shared/_site_navbar.html.erb
+++ b/app/views/shared/_site_navbar.html.erb
@@ -36,7 +36,7 @@
         </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            More at Stanford
+            <span class="d-md-none d-lg-inline">More</span> at Stanford
           </a>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
             <%= link_to "Other library collections at Stanford",

--- a/app/views/shared/_site_search_form.html.erb
+++ b/app/views/shared/_site_search_form.html.erb
@@ -1,19 +1,48 @@
-<%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+<%= form_tag search_action_url, method: :get, class: 'd-flex flex-grow-1 search-across-form search-query-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
+
   <div class="input-group">
-    <%= hidden_field_tag :search_field, search_fields.first.last %>
-
-    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, params[:q], placeholder: t('.placeholder'), class: "search-q q form-control rounded-left", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
-
-    <span class="input-group-append">
-      <button type="submit" class="btn btn-primary search-btn" id="search">
-        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
-        <%= blacklight_icon :search, aria_hidden: true %>
+    <div class="dropdown input-group-prepend" data-behavior="site-search-type-toggle" data-enabled="<%= in_search_across? ? '#item-search' : '#exhibit-search' %>" style="display: none">
+      <button type="button" class="btn btn-outline-secondary dropdown-toggle" id="site-search-type" data-toggle="dropdown" aria-expanded="false">
+        <% if in_search_across? %>
+          <%= t('.find_all_items') %>
+        <% else %>
+          <%= t('.find_exhibits_by_title') %>
+        <% end %>
       </button>
-    </span>
+
+      <div class="dropdown-menu">
+        <a class="dropdown-item" href="#" data-target="#exhibit-search" data-button-text="<%= t('.find_exhibits_by_title') %>">
+          <%= t('.exhibits_by_title') %>
+        </a>
+        <a class="dropdown-item" href="#" data-target="#item-search" data-button-text="<%= t('.find_all_items') %>">
+          <%= t('.all_items') %>
+        </a>
+      </div>
+    </div>
+
+    <div class="exhibit-search-typeahead site-search-type" data-behavior="site-search-type" id="exhibit-search" style="display: none;">
+      <input type="text" class="form-control" role="combobox" aria-labelledby="site-search-type" data-behavior="exhibit-search-typeahead" data-typeahead-remote-url="<%= exhibit_finder_index_path %>" />
+    </div>
+
+    <div id="item-search" class="site-search-type" data-behavior="site-search-type">
+      <div class="input-group">
+        <%= hidden_field_tag :search_field, search_fields.first.last %>
+        <noscript>
+          <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+        </noscript>
+        <%= text_field_tag :q, params[:q], class: "search-q q form-control", id: "q", 'aria-labelledby': "site-search-type", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+
+        <span class="input-group-append">
+          <button type="submit" class="btn btn-primary search-btn" id="search">
+            <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+            <%= blacklight_icon :search, aria_hidden: true %>
+          </button>
+        </span>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% unless Settings.feature_flags.home_page_navbar %>
-  <% if Settings.feature_flags.search_across || controller.controller_name == 'search_across' %>
+  <% if Settings.feature_flags.search_across || in_search_across? %>
     <div class="mb-4">
       <%= render 'shared/site_search_form', presenter: Blacklight::SearchBarPresenter.new(controller, SearchAcrossController.blacklight_config) %>
       <% if defined? @response %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,8 +113,13 @@ en:
     results:
       heading: Search all exhibits
   shared:
-    site_search_form:
+    old_site_search_form:
       placeholder: 'Find items in all exhibits'
+    site_search_form:
+      all_items: items in all exhibits
+      exhibits_by_title: exhibits by title
+      find_all_items: Find items in all exhibits
+      find_exhibits_by_title: Find exhibits by title
   viewers:
     menu_link: Viewers
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Exhibits::Application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  resources :exhibit_finder, only: :show
+  resources :exhibit_finder, only: %i[show index]
 
   scope '(:locale)', locale: Regexp.union(Spotlight::Engine.config.i18n_locales.keys.map(&:to_s)), defaults: { locale: nil } do
     mount Blacklight::Oembed::Engine, at: 'oembed'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@ feature_flags:
   uat_embed: false
   search_across: false
   home_page_navbar: false
+  exhibits_index: false
 traject:
   processing_thread_pool: 1
 iiif_embed:

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -884,6 +884,48 @@
     </lst>
   </requestHandler>
 
+  <!-- for searching exhibit documents (e.g. by title) -->
+  <requestHandler name="exhibit-titles" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <str name="sort">score desc, title_sort asc</str>
+      <int name="rows">20</int>
+      <str name="q.alt">*:*</str>
+      <float name="tie">0.01</float>
+      <bool name="lowercaseOperators">false</bool>
+      <!-- in case lucene query parser -->
+      <str name="df">all_search</str>
+      <str name="q.op">AND</str>
+      <bool name="facet">false</bool>
+      <str name="fq">document_type_ssi:exhibit</str>
+
+      <str name="fl">
+        id
+        exhibit_title_tesim
+        exhibit_subtitle_tesim
+        exhibit_slug_ssi
+        document_type_ssi
+      </str>
+
+      <str name="qf">
+        exhibit_title_tesim^100
+        exhibit_subtitle_tesim^10
+      </str>
+      <str name="pf">
+        exhibit_title_tesim^100
+        exhibit_subtitle_tesim^10
+      </str>
+      <str name="pf3">
+        exhibit_title_tesim^100
+        exhibit_subtitle_tesim^10
+      </str>
+      <str name="pf2">
+        exhibit_title_tesim^100
+        exhibit_subtitle_tesim^10
+      </str>
+    </lst>
+  </requestHandler>
 
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
     <str name="queryAnalyzerFieldType">textSpell</str>

--- a/spec/features/search_by_exhibit_title_spec.rb
+++ b/spec/features/search_by_exhibit_title_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Searching Exhibits By Title', type: :feature, js: true do
+  let(:exhibit1) do
+    FactoryBot.create(:exhibit, published: true, slug: 'test-exhibit')
+  end
+  let(:exhibit2) do
+    FactoryBot.create(:exhibit, published: true, slug: 'default-exhibit')
+  end
+
+  before do
+    # "touch" fixtures that need to be created before a user visits the app
+    exhibit1
+    exhibit2
+    allow(Settings.feature_flags).to receive(:exhibits_index).and_return(true)
+    visit root_path
+  end
+
+  it 'provides a dropdown to choose search types' do
+    within '#site-navbar .site-search-nav' do
+      expect(page).to have_css('.dropdown-menu', visible: false)
+      click_button 'Find exhibits by title'
+      expect(page).to have_css('.dropdown-menu', visible: true)
+
+      within '.dropdown-menu' do
+        expect(page).to have_link 'exhibits by title'
+        expect(page).to have_link 'items in all exhibits'
+      end
+    end
+  end
+
+  describe 'the dropdown' do
+    it 'provides a default option to autocomplete by exhibit title' do
+      within '#site-navbar .site-search-nav' do
+        expect(page).to have_css('button', text: 'Find exhibits by title')
+        expect(page).to have_css('[data-behavior="exhibit-search-typeahead"]', visible: true)
+      end
+    end
+
+    it 'provides an option to search items in exhibits' do
+      expect(page).not_to have_css('form input#q', visible: true)
+
+      within '#site-navbar .site-search-nav' do
+        click_button 'Find exhibits by title'
+        click_link 'items in all exhibits'
+
+        expect(page).not_to have_css('button', text: 'Find exhibits by title')
+        expect(page).to have_css('button', text: 'Find items in all exhibits')
+      end
+
+      fill_in 'q', with: 'Map'
+      click_button 'Search'
+
+      expect(page).to have_css('.sort-pagination .page-links .page-entries', text: /1 - 10 of \d+/)
+    end
+  end
+end

--- a/spec/jobs/index_exhibit_metadata_job_spec.rb
+++ b/spec/jobs/index_exhibit_metadata_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IndexExhibitMetadataJob do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:indexer) { instance_spy('ExhibitIndexer') }
+
+  before do
+    allow(ExhibitIndexer).to receive(:new).with(exhibit).and_return(indexer)
+  end
+
+  context 'when the action is add' do
+    it 'sends the add message to the ExhibitIndexer' do
+      subject.perform(exhibit: exhibit, action: 'add')
+
+      expect(indexer).to have_received(:add)
+    end
+  end
+
+  context 'when the action is delete' do
+    it 'sends the delete message to the ExhibitIndexer' do
+      subject.perform(exhibit: exhibit, action: 'delete')
+
+      expect(indexer).to have_received(:delete)
+    end
+  end
+end

--- a/spec/models/exhibit_indexer_spec.rb
+++ b/spec/models/exhibit_indexer_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExhibitIndexer do
+  subject(:indexer) { described_class.new(exhibit) }
+
+  let(:solr_connection) { instance_spy('Blacklight::Solr::Connection') }
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  before do
+    allow(described_class).to receive_messages(solr_connection: solr_connection)
+  end
+
+  describe '#add' do
+    it 'sends the add message to the solr connection with fields containing exhibit metadata' do
+      indexer.add
+
+      expect(solr_connection).to have_received(:add).with(
+        hash_including(
+          exhibit_slug_ssi: exhibit.slug,
+          exhibit_title_tesim: exhibit.title
+        )
+      )
+    end
+  end
+
+  describe '#delete' do
+    it 'sends the delete_by_id message to the solr connection with the generated exhibit document id' do
+      indexer.delete
+
+      expect(solr_connection).to have_received(:delete_by_id).with("exhibit-#{exhibit.slug}")
+    end
+  end
+
+  describe '#to_solr' do
+    let(:to_solr) { indexer.to_solr }
+
+    before do
+      exhibit.subtitle = 'The Subtitle of This Exhibit'
+      exhibit.description = <<-DESC
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+      DESC
+    end
+
+    it 'generates its own document id' do
+      expect(to_solr[:id]).to eq "exhibit-#{exhibit.slug}"
+    end
+
+    it 'includes a document type field to allow us to filter to/out just these documents' do
+      expect(to_solr[:document_type_ssi]).to eq 'exhibit'
+    end
+
+    it 'includes metadata about the exhibit' do
+      expect(to_solr[:exhibit_slug_ssi]).to eq exhibit.slug
+      expect(to_solr[:exhibit_title_tesim]).to eq exhibit.title
+      expect(to_solr[:exhibit_subtitle_tesim]).to eq exhibit.subtitle
+      expect(to_solr[:exhibit_description_tesim]).to eq exhibit.description
+    end
+  end
+end

--- a/spec/requests/exhibit_finder_requests_spec.rb
+++ b/spec/requests/exhibit_finder_requests_spec.rb
@@ -34,4 +34,30 @@ describe 'Exhibit Finder API', type: :request do
       expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
     end
   end
+
+  describe '#index' do
+    let(:solr_connection) { instance_double('Blacklighgt::Solr::Connection') }
+
+    before do
+      allow(Blacklight.default_index).to receive_messages(connection: solr_connection)
+
+      allow(solr_connection).to receive(:select).and_return(
+        'response' => { 'docs' => [{ 'exhibit_slug_ssi' => exhibit.slug }] }
+      )
+    end
+
+    it 'returns JSON exhibit representations' do
+      get '/exhibit_finder?q=Exhib'
+
+      json_response = JSON.parse(response.body)
+      expect(json_response.length).to eq 1
+      expect(json_response.first['slug']).to eq exhibit.slug
+    end
+
+    it 'has the appropriate CORS headers to be available to JS clients' do
+      get '/exhibit_finder?q=Exhib'
+
+      expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+    end
+  end
 end

--- a/spec/services/search_across_search_builder_spec.rb
+++ b/spec/services/search_across_search_builder_spec.rb
@@ -29,7 +29,7 @@ describe SearchAcrossSearchBuilder do
     end
 
     it 'limits documents to public items in published exhibits' do
-      actual = subject[:fq].first.split(Regexp.union(/ OR /, / AND /)).map { |x| x.tr('()', '') }
+      actual = subject[:fq].last.split(Regexp.union(/ OR /, / AND /)).map { |x| x.tr('()', '') }
       expect(actual).to include 'spotlight_exhibit_slugs_ssim:exhibit-title-public'
       expect(actual).to include 'exhibit_exhibit-title-public_public_bsi:true'
       expect(actual).not_to include 'spotlight_exhibit_slugs_ssim:exhibit-title-private'
@@ -51,7 +51,7 @@ describe SearchAcrossSearchBuilder do
     end
 
     it 'allows them to see items in their unpublished exhibits' do
-      actual = subject[:fq].first.split(Regexp.union(/ OR /, / AND /)).map { |x| x.tr('()', '') }
+      actual = subject[:fq].last.split(Regexp.union(/ OR /, / AND /)).map { |x| x.tr('()', '') }
 
       expect(actual).to include 'spotlight_exhibit_slugs_ssim:exhibit-title-public'
       expect(actual).to include 'exhibit_exhibit-title-public_public_bsi:true'

--- a/spec/views/shared/_site_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_site_navbar.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe 'shared/_site_navbar', type: :view do
   before do
     view.extend Spotlight::CrudLinkHelpers
     stub_template 'shared/_site_search_form' => 'search form'
+    stub_template 'shared/_old_site_search_form' => 'old search form'
   end
 
   context 'with a non-admin user' do


### PR DESCRIPTION
## Searching By Exhibit Title
![exhibit-title-search](https://user-images.githubusercontent.com/96776/79813545-d1380600-8330-11ea-9aa8-24d4c82eaaf0.gif)

## Toggling to Searching By Item
![exhibit-search-toggle](https://user-images.githubusercontent.com/96776/79813547-d2693300-8330-11ea-8070-6726bb66382d.gif)

## Responsive Behavior
![exhibit-search-responsive](https://user-images.githubusercontent.com/96776/79813550-d301c980-8330-11ea-8b62-4443666e6775.gif)



## TODO
- [x] Update styling of site search form to accommodate new button
- [x] Improve styling of typeahead dropdown
- [x] ~~Kill subtitle? (was just playing w/ options)~~
- [x] Anything to set ourselves up for this to be used w/ Bento
- [x] Determine what we can/should do WRT associating the search type drop down with the dropdown menu
  * It seems like it would be nice if we could put a `<span>` around the word `Find` give that an ID and say that the dropdown menu is labeled by that span.  However; since we need to manipulate that value via JS and it theoretically needs to be translatable, it begins to get problematic (our current approach is to stash the value that the button should be when the dropdown item is chosen in an attribute on item).  Are there other solutions that we could use to properly associate the dropdown w/ the button?
- [x] Validate if the overall size and responsive/max-width approach for the search input is 👌 