### PR TITLE
Add a sul-embed based m3 viewer that is opt-in by exhibit curators

### DIFF
--- a/app/views/viewers/_mirador3.html.erb
+++ b/app/views/viewers/_mirador3.html.erb
@@ -1,0 +1,15 @@
+<% exhibit_specific_manifest = document.exhibit_specific_manifest(current_exhibit.required_viewer.custom_manifest_pattern) %>
+
+<% if exhibit_specific_manifest.present? %>
+  <%= content_tag :iframe, '',
+        src: "#{Settings.iiif_embed.url}?#{{ url: exhibit_specific_manifest, image_tools: true, canvas_id: document.canvas.iiif_id }.to_query}",
+        allowfullscreen: true,
+        class: 'mirador-embed-wrapper',
+        frameborder: 0,
+        marginwidth: 0,
+        marginheight: 0,
+        scrolling: 'no',
+        width: '100%'
+        %>
+  <%= iiif_drag_n_drop(exhibit_specific_manifest) %>
+<% end %>

--- a/app/views/viewers/edit.html.erb
+++ b/app/views/viewers/edit.html.erb
@@ -24,7 +24,8 @@
 
           <div class="col-md-9">
             <%= f.radio_button :viewer_type, 'sul-embed', label: 'SUL-Embed', checked: true %>
-            <%= f.radio_button :viewer_type, 'mirador', label: 'Mirador' %>
+            <%= f.radio_button :viewer_type, 'mirador', label: 'Mirador 2' %>
+            <%= f.radio_button :viewer_type, 'mirador3', label: 'Mirador 3' %>
           </div>
         </div>
 

--- a/spec/features/viewers_spec.rb
+++ b/spec/features/viewers_spec.rb
@@ -32,11 +32,11 @@ describe 'Viewers', type: :feature do
       end
 
       within '#item-detail-page' do
-        choose 'Mirador'
+        choose 'Mirador 2'
         click_button 'Save changes'
       end
 
-      expect(find_field('Mirador')[:checked]).to eq 'checked'
+      expect(find_field('Mirador 2')[:checked]).to eq 'checked'
     end
 
     it 'includes breadcrumbs on the edit page' do


### PR DESCRIPTION
![Kapture 2020-06-22 at 15 28 36](https://user-images.githubusercontent.com/1656824/85337124-257c7500-b49d-11ea-82fb-de5a659c44ed.gif)
