### PR TITLE
Fall back to the original thumbnail for the list view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -119,7 +119,7 @@ class CatalogController < ApplicationController
     config.show.partials << :cited_documents
     config.show.partials << :page_details
 
-    config.view.list.thumbnail_field = :thumbnail_square_url_ssm
+    config.view.list.thumbnail_field = [:thumbnail_square_url_ssm, :thumbnail_url_ssm]
     config.view.list.partials = [:exhibits_document_header, :index]
     config.view.gallery.title_only_by_default = true
     config.view.gallery.partials = [:index_header, :index]


### PR DESCRIPTION
In #1884 we added support for square thumbnails for IIIF resources, but not all IIIF manifests will have a IIIF service for their thumbnails, so we should support falling back to the original aspect ratio if the square thumbnail is not available.