### PR TITLE
Stop storing all_search fields

### DIFF
--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -12,10 +12,10 @@
     <field name="last_updated" type="date" indexed="true" stored="true" default="NOW/SECOND" />
     <!-- entire marc bib record -->
     <field name="marcxml" type="string" indexed="false" stored="true" />
-    <!-- all_search: catch-all field for metadata text; stored for hit highlighting -->
-    <field name="all_search" type="text" indexed="true" stored="true" termVectors="true" termPositions="true" termOffsets="true" multiValued="true" />
-    <field name="all_unstem_search" type="textNoStem" indexed="true" stored="true" multiValued="true" />
-    <field name="vern_all_search" type="text" indexed="true" stored="true" multiValued="true" />
+    <!-- all_search: catch-all field for metadata text -->
+    <field name="all_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="all_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+    <field name="vern_all_search" type="text" indexed="true" stored="false" multiValued="true" />
 
     <!-- Format Field: facet and display -->
     <field name="format" type="string" indexed="true" stored="true" multiValued="true" />

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -812,7 +812,7 @@
       <str name="facet.field">collection_with_title</str>
 
       <!-- Highlighting defaults -->
-      <str name="hl.fl">all_search full_text_search full_text_search_en full_text_search_pt full_text_search_id</str>
+      <str name="hl.fl">full_text_search full_text_search_en full_text_search_pt full_text_search_id</str>
 
       <str name="fl">
         score,


### PR DESCRIPTION
AFAICT, the comment about highlighting came from upstream in searchworks. We've never used that field for highlighting in exhibits (and, in fact, override `hl.fl` to just those full tet fields)