### PR TITLE
Set a rows parameter when searching by exhibit titles to return all …

### DIFF
--- a/app/models/exhibit_finder.rb
+++ b/app/models/exhibit_finder.rb
@@ -39,7 +39,7 @@ class ExhibitFinder
         params: {
           q: query,
           qt: 'exhibit-titles',
-          rows: 5,
+          rows: 10_000,
           fl: 'exhibit_slug_ssi'
         }
       ).dig('response', 'docs') || {}


### PR DESCRIPTION
…possible.

We already limit the number to 5 in the typeahead, this will allow other consumers of this API to show more results (e.g. bento)