### PR TITLE
Add message to not remove druids in SDR item list

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ en:
     items:
       item-status: "Item status"
       item-submission: "Item submission"
-      item-submission-help_html: "To add SDR items to the exhibit, enter collection or item druids below, one per line (e.g. qb438pg7646)."
+      item-submission-help_html: "To add SDR items to the exhibit, enter collection or item druids below, one per line (e.g. qb438pg7646).<p>When adding new items to an exhibit with existing items, do not remove the existing druids from the list.</p>"
       object-druids: "Object druids"
       object-druids-help_html: "Items below with the status of <em>published</em> were added to the exhibit. Items must be published (i.e., have a valid PURL) before they can be added to the exhibit."
       many-object-druids-help_html: "<p>There are %{count} object druids indexed in this exhibit. To determine whether a particular item is indexed in this exhibit, or to check the indexing status of an item, begin typing the object druid below.</p><p>Items displayed with a status of published were added to the exhibit. Items must be published (i.e. have a valid PURL) before they can be added to the exhibit.</p>"


### PR DESCRIPTION
@caaster This adds an additional sentence to the Add items > SDR items panel to remind curators to not remove existing druids from the list. The hope is this will reduce the chances a curator removes existing items when adding new items.

A longer-term solution is to [redesign this form](https://github.com/sul-dlss/exhibits/issues/1151), but this is an easy, short-term mitigation strategy.

<img width="765" alt="Screen Shot 2020-08-05 at 1 41 32 PM" src="https://user-images.githubusercontent.com/101482/89462332-15091c80-d722-11ea-8307-2458e95e0955.png">
