### PR TITLE
Enable resizing for Spotlight::AttachmentUploader to reduce page load time

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,10 +18,14 @@ module Exhibits
 
     config.time_zone = 'Pacific Time (US & Canada)'
 
+    ##
     # Inject our ExhibitExtension concern to add behavior
     # (like relationships) to the Spotlight::Exhibit class
+    # Also enable CarrierWave::MiniMagick for resizing
     config.to_prepare do
       Spotlight::Exhibit.send(:include, ExhibitExtension)
+      Spotlight::AttachmentUploader.send(:include, CarrierWave::MiniMagick)
+      Spotlight::AttachmentUploader.send(:process, resize_to_fit: [1080, 1080])
     end
 
     config.druid_regex = /([a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4})/

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,4 +5,5 @@ CarrierWave.configure do |c|
   end if File.exist? File.join(Rails.root, 'public', '.htaccess')
 
   c.base_path = carrierwave_base_path
+  c.enable_processing = true
 end


### PR DESCRIPTION
I've recently noticed some exhibits with large image files being uploaded and then served out. This proposal would resize image uploads that are not going to be served via IIIF so that the page doesn't need to load the entire large file.

There is likely little to no loss of fidelity between these with the aim to improve performance of pages loading without needing exhibit creators to know how to resize images appropriately for the web.

User impact: User's images will be resized without them having to do anything. The resize likely will not reduce any noticeable fidelity.

Future enhancements: we could optimize the files further for web delivery (beyond just image resizing).

![Screen Shot 2020-09-15 at 12 20 38 PM](https://user-images.githubusercontent.com/1656824/93249323-5abbfa80-f74e-11ea-80ba-ac54b0ac8e18.png)
![Screen Shot 2020-09-15 at 12 20 04 PM](https://user-images.githubusercontent.com/1656824/93249329-5d1e5480-f74e-11ea-9082-efca35b0de0b.png)
