### PR TITLE
Wrap exhibit finder title search queries with parens so the boolean +…

### DIFF
--- a/app/models/exhibit_finder.rb
+++ b/app/models/exhibit_finder.rb
@@ -33,7 +33,7 @@ class ExhibitFinder
     private
 
     def exhibit_slugs_for_search(query)
-      query = "#{query} OR #{query}*"
+      query = "(#{query}) OR (#{query}*)"
 
       documents = Blacklight.default_index.connection.select(
         params: {

--- a/spec/models/exhibit_finder_spec.rb
+++ b/spec/models/exhibit_finder_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ExhibitFinder do
     it 'sends in a query that ORs itself and a wildcarded version of itself' do
       allow(solr_connection).to receive(:select).with(
         params: hash_including(
-          q: 'Exhib OR Exhib*'
+          q: '(Exhib) OR (Exhib*)'
         )
       ).and_return({})
 


### PR DESCRIPTION
… wildcard works better.

This seems to only affect titles that end in stemmed words (e.g. Names as in the example below)

## Before
![title-search-before](https://user-images.githubusercontent.com/96776/93516236-9be31480-f8de-11ea-862d-b69bfb4ec973.gif)

## After
![title-search-after](https://user-images.githubusercontent.com/96776/93516251-a00f3200-f8de-11ea-9e60-6bb361ade36d.gif)
