### PR TITLE
Prepend the app host to thumbnail URLs when they are relative…

### DIFF
--- a/app/models/exhibit_finder.rb
+++ b/app/models/exhibit_finder.rb
@@ -91,8 +91,12 @@ class ExhibitFinder
 
     def as_json(*)
       @exhibits.map do |exhibit|
+        thumbnail_url = exhibit&.thumbnail&.iiif_url
+        if thumbnail_url&.start_with?('/')
+          thumbnail_url = "#{Settings.action_mailer.default_url_options.host}#{thumbnail_url}"
+        end
         exhibit.as_json.merge(
-          'thumbnail_url' => exhibit&.thumbnail&.iiif_url
+          'thumbnail_url' => thumbnail_url
         )
       end
     end

--- a/spec/models/exhibit_finder_spec.rb
+++ b/spec/models/exhibit_finder_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe ExhibitFinder do
         %r{stanford\.edu/images/\d+/full/400,400/0/default.jpg}
       )
     end
+
+    context 'when the thubmnail comes from an uploaded document' do
+      before do
+        thumb = exhibit.thumbnail
+        thumb.iiif_tilesource = exhibit.thumbnail
+                                       .iiif_tilesource
+                                       .sub(%r{^https?://exhibits(-.*)?\.stanford.edu}, '')
+        thumb.save
+      end
+
+      it 'appends the host of the app to the URL in the case it is a relative URL' do
+        expect(json_response.as_json.first['thumbnail_url']).to match(
+          %r{example\.com/images/\d+/full/400,400/0/default.jpg}
+        )
+      end
+    end
   end
 
   describe '#documents (private)' do


### PR DESCRIPTION
…(i.e. images from uploaded documents)

This was noticed once #1928 would be implemented the "Say Their Names" thumb would not display because it's using an uploaded thumbnail (and not getting the exhibit's host in the url to the thumb)

<img width="592" alt="Screen Shot 2020-09-21 at 3 20 35 PM" src="https://user-images.githubusercontent.com/96776/93827581-614ee400-fc1e-11ea-87ea-e7561448c717.png">
