### PR TITLE
Fix responsive font sizing on browse category tiles

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -68,15 +68,20 @@
   letter-spacing: 1.1px;
 }
 
-.browse-landing .text-overlay .browse-category-title {
-  font-size: 26px;
-
-  @media screen and (min-width: 992px) and (max-width: 1199px) {
-    font-size: 22px;
+#content .browse-landing .text-overlay .browse-category-title {
+  @media (min-width: breakpoint-min("md")) and (max-width: breakpoint-min("lg")) {
+    font-size: 1.4rem;
+    line-height: 1.1;
   }
 
-  @media screen and (min-width: 768px) and (max-width: 991px) {
-    font-size: 19px;
+  @media (min-width: breakpoint-min("lg")) and (max-width: breakpoint-min("xl")) {
+    font-size: $h4-font-size;
+  }
+
+  small {
+    @media (min-width: breakpoint-min("md")) and (max-width: breakpoint-min("lg")) {
+      font-size: 1.125rem;
+    }
   }
 }
 


### PR DESCRIPTION
At some point the responsive font sizing that we have for the text on the browse category tiles was overridden by a more powerful selector. This results in the display of `28px` font size for the browse category title titles at all viewports. This isn't ideal, however, since the tiles vary in size depending on the viewport width. This is a bit of an extreme case (because the titles are unusually long) but at the `md` viewport in particular the 28px font doesn't work well with the smaller tile size:

<img width="773" alt="Screen Shot 2020-09-22 at 3 04 05 PM" src="https://user-images.githubusercontent.com/101482/94042639-b440ac80-fd80-11ea-93e4-f448aad3e50d.png">

---

This PR fixes the responsive font-sizing for the text on the browse category tiles. There are a couple of other minor tweaks, but the biggest fix is for the `md` viewport so that the example above should now look more like this:

<img width="762" alt="Screen Shot 2020-09-23 at 9 34 08 AM" src="https://user-images.githubusercontent.com/101482/94042876-f1a53a00-fd80-11ea-89a5-3ffe30502f39.png">
