### PR TITLE
Update thumbnail border styling to always show border

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -38,7 +38,8 @@
 }
 
 .img-thumbnail {
-  border: 0;
+  border-radius: 0;
+  padding: 0;
 }
 
 #document {


### PR DESCRIPTION
We currently display a border on thumbnail images in some places where images are shown but not all places. I think the reason why we had `border: 0;` was to avoid the look we get from Spotlight (or Bootstrap, probably?) by default that adds a bit of padding and then shows a light border with a border radius. That doesn't really fit the visual style of Exhibits. However, in instances where the thumbnail image is particularly light, such as an image of a PDF, the lack of border makes the image sort of amorphous, because the image blends into the page background.

This PR makes sure we do show a thumbnail border, but hides the border-radius and padding. The result is that there is really no visual difference for non-light images, and for light images, the outline of the image is more clear.

## Before example (Virtual Tribunals)
<img width="880" alt="Screen Shot 2020-10-02 at 12 18 38 PM" src="https://user-images.githubusercontent.com/101482/94961931-79d6be00-04aa-11eb-85d2-893ce81ae48c.png">

## After example (Virtual Tribunals)
<img width="880" alt="Screen Shot 2020-10-02 at 12 18 51 PM" src="https://user-images.githubusercontent.com/101482/94961954-84915300-04aa-11eb-958e-1e0afd986bc5.png">

## Before example (unpublished PDF-only exhibit)
<img width="1153" alt="Screen Shot 2020-10-02 at 11 47 01 AM" src="https://user-images.githubusercontent.com/101482/94961982-93780580-04aa-11eb-82c7-e8cea6ba729d.png">

## After example (unpublished PDF-only exhibit)
<img width="1153" alt="Screen Shot 2020-10-02 at 11 50 29 AM" src="https://user-images.githubusercontent.com/101482/94962016-9ecb3100-04aa-11eb-9820-d7738e3810a2.png">

## Before example (Item row widget)
<img width="880" alt="Screen Shot 2020-10-02 at 12 07 07 PM" src="https://user-images.githubusercontent.com/101482/94962046-ac80b680-04aa-11eb-82b1-57bf23d25916.png">

## After example (Item row widget)
<img width="880" alt="Screen Shot 2020-10-02 at 12 07 20 PM" src="https://user-images.githubusercontent.com/101482/94962070-b5718800-04aa-11eb-918e-9b740966c783.png">
