### PR TITLE
Hide border on uploaded item widget images

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -42,6 +42,12 @@
   padding: 0;
 }
 
+// Hide image border for this widget only because curators use it with images
+// they want to blend into the page background.
+.uploaded-items-block .img-thumbnail {
+  border: 0;
+}
+
 #document {
   h1 {
     font-size: 1.5rem;


### PR DESCRIPTION
I recently did a PR to add a light image border on images, to improve the display of images with a light or white background, such as PDFs shown in search results or an item row widget. But in at least one of our exhibits the curators use a lot of uploaded images with a white background. Which produces unwanted image borders (B and C in this example):

<img width="906" alt="Screen Shot 2020-10-21 at 4 46 53 PM" src="https://user-images.githubusercontent.com/101482/96803429-2aa4ee80-13c1-11eb-8681-55227344a3b2.png">

This PR turns the image border off, but only for the uploaded item row widget. That way we can retain the image border for search results or an item row widget, where it is unlikely an image border is unwanted, but remove it for images that are uploaded (and the curator could manually add an image border to the image before uploading if for some reason they needed one). So with this PR the example above now has image borders for the item row widget (A) but not the upload items (B and C):

<img width="906" alt="Screen Shot 2020-10-21 at 4 48 16 PM" src="https://user-images.githubusercontent.com/101482/96803573-90917600-13c1-11eb-93ee-1ad716be39dc.png">



