### PR TITLE
Updates per_page options to be multiples of 12

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,6 +73,11 @@ class CatalogController < ApplicationController
       'hl.mergeContiguous' => true
     }
 
+    # Maximum number of results to show per page
+    config.max_per_page = 96
+    # Options for the user for number of results to show per page
+    config.per_page = [12, 24, 48, 96]
+
     config.default_autocomplete_solr_params = Spotlight::Engine.config.default_autocomplete_params
 
     config.add_results_collection_tool(:sort_widget)

--- a/db/migrate/20210112001713_change_per_page.rb
+++ b/db/migrate/20210112001713_change_per_page.rb
@@ -1,0 +1,20 @@
+class ChangePerPage < ActiveRecord::Migration[5.2]
+  def change
+    Spotlight::Exhibit.find_each do |exhibit|
+      config = exhibit.blacklight_configuration
+      case config.default_per_page
+      when 10
+        config.default_per_page = 12
+      when 20
+        config.default_per_page = 24
+      when 50
+        config.default_per_page = 48
+      when 100
+        config.default_per_page = 96
+      else
+        config.default_per_page = 12
+      end
+      config.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_15_034031) do
+ActiveRecord::Schema.define(version: 2021_01_12_001713) do
 
   create_table "bibliography_services", force: :cascade do |t|
     t.string "header"

--- a/spec/features/exhibit_spec.rb
+++ b/spec/features/exhibit_spec.rb
@@ -26,7 +26,7 @@ describe 'an exhibit', type: :feature do
       visit spotlight.url_for(exhibit)
       fill_in 'q', with: 'Africa'
       click_button 'search'
-      expect(page).to have_content '1 - 10 of 16'
+      expect(page).to have_content '1 - 12 of 16'
       expect(page).to have_content 'Title: Africa'
     end
 

--- a/spec/features/sanity_check_spec.rb
+++ b/spec/features/sanity_check_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Sanity checking upstream dependencies', type: :feature do
     it 'has renders linkable titles (and other controller behavior is not leaking in)' do
       visit spotlight.search_exhibit_catalog_path(exhibit, params: { q: 'map' })
 
-      expect(page).to have_css('.document h3 a', count: 10)
+      expect(page).to have_css('.document h3 a', count: 12)
     end
   end
 end

--- a/spec/features/search_across_spec.rb
+++ b/spec/features/search_across_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Searching Across Exhibits', type: :feature do
         click_button 'Search'
       end
 
-      expect(page).to have_css('#sortAndPerPage .page-entries', text: /1 - 10 of \d{2,} items/)
+      expect(page).to have_css('#sortAndPerPage .page-entries', text: /1 - 12 of \d{2,} items/)
 
       within '#facets .facet-limit.blacklight-spotlight_exhibit_slugs_ssim', visible: false do
         expect(page).to have_css('.facet-label', text: unpublished_exhibit_with_documents.title, visible: :hidden)
@@ -119,7 +119,7 @@ RSpec.describe 'Searching Across Exhibits', type: :feature do
       expect(page).to have_content '13 results'
 
       click_link '13 results'
-      expect(page).to have_content '1 - 10 of 13'
+      expect(page).to have_content '1 - 12 of 13'
     end
   end
 end

--- a/spec/features/search_by_exhibit_title_spec.rb
+++ b/spec/features/search_by_exhibit_title_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Searching Exhibits By Title', type: :feature, js: true do
       fill_in 'q', with: 'Map'
       click_button 'Search'
 
-      expect(page).to have_css('.sort-pagination .page-links .page-entries', text: /1 - 10 of \d+/)
+      expect(page).to have_css('.sort-pagination .page-links .page-entries', text: /1 - 12 of \d+/)
     end
   end
 end


### PR DESCRIPTION
Fixes #1942 

**NOTE** this will change all existing default per page options in existing Exhibits

## After
![Screen Shot 2021-01-11 at 5 27 12 PM](https://user-images.githubusercontent.com/1656824/104253703-5ff63100-5432-11eb-9d56-6dd3cc50f5f7.png)

## Before
![Screen Shot 2021-01-11 at 5 26 26 PM](https://user-images.githubusercontent.com/1656824/104253707-61275e00-5432-11eb-8c8e-dada506fb0eb.png)


@caaster @ggeisler just want to mention the note above. Can you sign off on this before we ship?