### PR TITLE
Allow the ExhibitIndexer to commit immediately after adds/deletes so …

### DIFF
--- a/app/models/exhibit_indexer.rb
+++ b/app/models/exhibit_indexer.rb
@@ -6,10 +6,16 @@
 # ExhibitIndexer.new(exhibit)
 # There is an #add method that will add/update the document in the index for that exhibit.
 # There is also a #delete method that will delete the document for that exhibit (by id).
+# The indexer will commit by default (since it runs in a background job), but if you're indexing
+# in batches you you may want to commit after, in that case you can initialize the indexer with commit: false
+# ExhibitIndexer.new(exhibit, commit: false).add
 class ExhibitIndexer
   attr_accessor :exhibit
-  def initialize(exhibit)
+  attr_reader :commit
+
+  def initialize(exhibit, commit: true)
     @exhibit = exhibit
+    @commit = commit
   end
 
   def to_solr
@@ -18,10 +24,12 @@ class ExhibitIndexer
 
   def delete
     self.class.solr_connection.delete_by_id(document_id)
+    self.class.solr_connection.commit if commit
   end
 
   def add
     self.class.solr_connection.add(to_solr)
+    self.class.solr_connection.commit if commit
   end
 
   def self.solr_connection

--- a/spec/models/exhibit_indexer_spec.rb
+++ b/spec/models/exhibit_indexer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ExhibitIndexer do
           exhibit_title_tesim: exhibit.title
         )
       )
+      expect(solr_connection).to have_received(:commit)
     end
   end
 
@@ -30,6 +31,7 @@ RSpec.describe ExhibitIndexer do
       indexer.delete
 
       expect(solr_connection).to have_received(:delete_by_id).with("exhibit-#{exhibit.slug}")
+      expect(solr_connection).to have_received(:commit)
     end
   end
 


### PR DESCRIPTION
…that the autocomplete is as up-to-date as possible