### PR TITLE
Use title_display instead of title_full_display for titles on the …

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,7 +111,7 @@ class CatalogController < ApplicationController
     config.index.square_image_field = :thumbnail_square_url_ssm
     config.index.slideshow_field = :large_image_url_ssm
 
-    config.show.title_field = 'title_full_display'
+    config.show.title_field = 'title_display'
     config.show.oembed_field = :url_fulltext
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
 

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -15,19 +15,17 @@ RSpec.feature 'Metadata display' do
 
     it 'view metadata link links through to page', js: false do
       click_link 'More details »'
-      expect(page).to have_link 'Afrique Physique.', href: document_url
-      expect(page).to have_css 'h3', text: 'Afrique Physique.'
+      expect(page).to have_link 'Afrique Physique', href: document_url
+      expect(page).to have_css 'h3', text: 'Afrique Physique'
       expect(page).not_to have_css 'dt', text: 'Title:'
-      expect(page).not_to have_css 'dd', text: 'Afrique Physique.'
       expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
     end
 
     it 'opens view metadata in modal', js: true do
       click_link 'More details »'
       within '#blacklight-modal' do
-        expect(page).to have_css 'h3', text: 'Afrique Physique.'
+        expect(page).to have_css 'h3', text: 'Afrique Physique'
         expect(page).not_to have_css 'dt', text: 'Title:'
-        expect(page).not_to have_css 'dd', text: 'Afrique Physique.'
         expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
       end
     end


### PR DESCRIPTION
…record/show view

Closes #1959 

According to the stanford-mods code:

https://github.com/sul-dlss/stanford-mods/blob/3ffbfb58a8357de3ba4595206d0bd54c83dd5993/lib/stanford-mods/searchworks.rb#L189-L193

The title_display is just like title_full_display but w/o the additional punctuation (and is what is being used in SW)

## Before
<img width="661" alt="mk267cj8576-before" src="https://user-images.githubusercontent.com/96776/109041668-2432c600-7684-11eb-93ed-aa6dc69f3d72.png">

## After
<img width="721" alt="mk267cj8576-after" src="https://user-images.githubusercontent.com/96776/109041674-26952000-7684-11eb-88de-69874d2fd101.png">
