### PR TITLE
Use the title_display field in place of the title_full_display field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -211,7 +211,7 @@ class CatalogController < ApplicationController
                                                   helper_method: :document_leaflet_map,
                                                   immutable: config.view.keys.map { |k| [k, false] }.to_h
 
-    config.add_index_field 'title_full_display', label: 'Title'
+    config.add_index_field 'title_full_display', label: 'Title', field: 'title_display'
     config.add_index_field 'title_variant_display', label: 'Alternate Title'
     config.add_index_field 'author_person_full_display', label: 'Author' # includes Collectors
     config.add_index_field 'author_no_collector_ssim', label: 'Author (no Collectors)'

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -60,7 +60,7 @@ module CatalogHelper
 
     druid = options[:value][0]
     document = options[:document]
-    title = document['title_full_display']
+    title = document['title_display']
     link_title = if document.canvas? && title.include?(':')
                    title.partition(':')[2]
                  else

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -1,10 +1,10 @@
 Spotlight::Engine.config.upload_title_field = Spotlight::UploadFieldConfig.new(
-  solr_fields: %w(title_full_display title_display title_245_search title_sort spotlight_upload_title_tesim),
+  solr_fields: %w(title_display title_245_search title_sort spotlight_upload_title_tesim),
   field_name: :spotlight_upload_title_tesim,
   label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_title_tesim') }
 )
 
-Spotlight::Engine.config.iiif_title_fields = %w(title_full_display title_display title_245_search title_sort spotlight_upload_title_tesim)
+Spotlight::Engine.config.iiif_title_fields = %w(title_display title_245_search title_sort spotlight_upload_title_tesim)
 
 Spotlight::Engine.config.upload_fields = [
   Spotlight::UploadFieldConfig.new(

--- a/lib/traject/adjust_cardinality.rb
+++ b/lib/traject/adjust_cardinality.rb
@@ -22,7 +22,7 @@ module Traject
       flatten = %w(
         id modsxml druid last_updated url_fulltext display_type collection_type
         author_1xx_search
-        title_245_search title_245a_display title_245a_search title_display title_full_display title_sort
+        title_245_search title_245a_display title_245a_search title_display title_sort
         modsxml_tsi author_sort imprint_display
         pub_year_isi
         pub_year_no_approx_isi

--- a/lib/traject/bibtex_config.rb
+++ b/lib/traject/bibtex_config.rb
@@ -36,7 +36,7 @@ to_field 'ref_type_ssm', extract_bibtex(:type) do |_record, accumulator, _contex
   accumulator.map! { |v| BIBTEX_ZOTERO_MAPPING[v] }.compact!
 end
 
-to_fields %w(title_display title_full_display title_uniform_search title_sort), extract_bibtex_field(:title)
+to_fields %w(title_display title_uniform_search title_sort), extract_bibtex_field(:title)
 to_fields %w(author_person_full_display author_sort), extract_bibtex_field(:author)
 to_fields %w(pub_year_isi pub_year_w_approx_isi), extract_bibtex(:year)
 to_field 'editor_ssim', extract_bibtex_field(:editor)

--- a/lib/traject/canvas_config.rb
+++ b/lib/traject/canvas_config.rb
@@ -19,7 +19,7 @@ to_field 'format_main_ssim', literal('Page details')
 to_field 'manuscript_number_tesim', extract_canvas_parent_manuscript_number
 to_field 'range_labels_tesim', extract_canvas_range_labels
 
-to_fields %w(title_display title_full_display title_uniform_search), extract_canvas_label
+to_fields %w(title_display title_uniform_search), extract_canvas_label
 to_field 'title_sort', extract_canvas_label_sort
 
 to_field 'iiif_annotation_list_url_ssim', extract_canvas_annotation_list_urls

--- a/lib/traject/dor_config.rb
+++ b/lib/traject/dor_config.rb
@@ -43,7 +43,6 @@ end
 to_field 'title_sort', stanford_mods(:sw_sort_title)
 to_field 'title_245a_display', stanford_mods(:sw_short_title)
 to_field 'title_display', stanford_mods(:sw_title_display)
-to_field 'title_full_display', stanford_mods(:sw_full_title)
 
 # author fields
 to_field 'author_1xx_search', stanford_mods(:sw_main_author)

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -60,8 +60,6 @@
     <field name="vern_title_245a_display" type="string" indexed="false" stored="true" />
     <field name="title_245c_display" type="string" indexed="false" stored="true" />
     <field name="vern_title_245c_display" type="string" indexed="false" stored="true" />
-    <field name="title_full_display" type="string" indexed="false" stored="true" />
-    <field name="vern_title_full_display" type="string" indexed="false" stored="true" />
     <field name="title_uniform_display" type="string" indexed="false" stored="true" />
     <field name="vern_title_uniform_display" type="string" indexed="false" stored="true" />
     <field name="title_variant_display" type="string" indexed="false" stored="true" multiValued="true" />
@@ -337,7 +335,7 @@
 
   <!-- exhibits fields -->
   <copyField source="id" dest="id_ng" maxChars="3000"/>
-  <copyField source="title_full_display" dest="full_title_ng" maxChars="3000"/>
+  <copyField source="title_display" dest="full_title_ng" maxChars="3000"/>
   <!-- NOTE:  all_search is meant for metadata -->
   <copyField source="*_tesim" dest="all_search" />
   <copyField source="*_tsi" dest="all_search" />

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -857,7 +857,6 @@
         title_245a_display,           vern_title_245a_display,
         title_245c_display,           vern_title_245c_display,
         title_display,                vern_title_display,
-        title_full_display,           vern_title_full_display,
         title_uniform_display,        vern_title_uniform_display
         url_fulltext,
         url_restricted,

--- a/spec/features/bibliography_resource_integration_spec.rb
+++ b/spec/features/bibliography_resource_integration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
   let(:file) { 'spec/fixtures/bibliography/article.bib' }
   let(:exhibit) { create(:exhibit) }
   let(:title_fields) do
-    %w(title_display title_full_display title_uniform_search title_sort)
+    %w(title_display title_uniform_search title_sort)
   end
   let(:author_fields) do
     %w(author_person_full_display author_sort)

--- a/spec/features/canvas_resource_integration_spec.rb
+++ b/spec/features/canvas_resource_integration_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Canvas resource integration test', type: :feature do
   let(:annolist_file) { 'spec/fixtures/iiif/fh878g0315-text-f254r.json' }
   let(:annolist_url) { 'https://dms-data.stanford.edu/data/manifests/Parker/fh878gz0315/list/text-f254r.json' }
   let(:title_display_search_fields) do
-    %w(title_display title_full_display title_uniform_search)
+    %w(title_display title_uniform_search)
   end
 
   before :all do

--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
                                     title_245a_display: 'Latin glossary : small manuscript fragment on vellum',
                                     title_245a_search: 'Latin glossary : small manuscript fragment on vellum',
                                     title_display: 'Latin glossary : small manuscript fragment on vellum',
-                                    title_full_display: 'Latin glossary : small manuscript fragment on vellum.',
                                     title_sort: 'Latin glossary small manuscript fragment on vellum'
       end
 

--- a/spec/features/manuscript_display_bibliography_spec.rb
+++ b/spec/features/manuscript_display_bibliography_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Cited manuscripts display on the bibliography show page', type: :
     within '.record-metadata-section' do
       within '.cited-documents-list' do
         # can appear in any order
-        expect(page).to have_content('Afrique Physique.')
+        expect(page).to have_content('Afrique Physique')
         expect(page).to have_css('a[href$="gk885tn1705"]')
         expect(page).not_to have_content('The Peterborough Psalter and Bestiary.')
         expect(page).not_to have_css('a[href$="gs233db8425"]')

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -14,7 +14,6 @@
     "title_sort": "Posesiones españolas en Africa Costa Occidental Golfo de Guinea",
     "title_245a_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea",
     "title_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea",
-    "title_full_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea.",
     "author_1xx_search": "Chias, Benito.",
     "author_person_facet": [
       "Chias, Benito."
@@ -157,7 +156,6 @@
     "title_sort": "Gambia",
     "title_245a_display": "Gambia",
     "title_display": "Gambia",
-    "title_full_display": "Gambia.",
     "author_1xx_search": "Great Britain War Office. General Staff. Geographical Section.",
     "author_other_facet": [
       "Great Britain War Office. General Staff. Geographical Section."
@@ -281,7 +279,6 @@
     "title_sort": "Atlas Vidal Lablache",
     "title_245a_display": "Atlas Vidal. Lablache",
     "title_display": "Atlas Vidal. Lablache",
-    "title_full_display": "Atlas Vidal. Lablache.",
     "author_1xx_search": "Vidal de La Blache, Paul, 1845-1918",
     "author_person_facet": [
       "Vidal de La Blache, Paul, 1845-1918"
@@ -427,7 +424,6 @@
     "title_sort": "Africa Industries and Communications",
     "title_245a_display": "Africa: Industries and Communications",
     "title_display": "Africa: Industries and Communications",
-    "title_full_display": "Africa: Industries and Communications.",
     "author_sort": "􏿿 Africa Industries and Communications",
     "topic_search": [
       "Industries and Communications-"
@@ -560,7 +556,6 @@
     "title_sort": "Ruwenzori to illustrate a paper by GF ScottElliot",
     "title_245a_display": "Ruwenzori",
     "title_display": "Ruwenzori : to illustrate a paper by G.F. Scott-Elliot",
-    "title_full_display": "Ruwenzori : to illustrate a paper by G.F. Scott-Elliot.",
     "author_1xx_search": "Ravenstein, Ernst Georg, 1834-1913",
     "author_7xx_search": [
       "Royal Geographical Society (Great Britain)"
@@ -721,7 +716,6 @@
     "title_sort": "Map of South Africa",
     "title_245a_display": "Map of South Africa.",
     "title_display": "Map of South Africa",
-    "title_full_display": "Map of South Africa.",
     "author_sort": "􏿿 Map of South Africa",
     "topic_search": [
       "map",
@@ -844,7 +838,6 @@
     "title_sort": "Afrique Physique",
     "title_245a_display": "Afrique Physique.",
     "title_display": "Afrique Physique",
-    "title_full_display": "Afrique Physique.",
     "author_7xx_search": [
       "Migeon, J.",
       "Lorsignol, G."
@@ -981,7 +974,6 @@
     "title_sort": "Kaart van ZuidAfrika",
     "title_245a_display": "Kaart van Zuid-Afrika.",
     "title_display": "Kaart van Zuid-Afrika",
-    "title_full_display": "Kaart van Zuid-Afrika.",
     "author_7xx_search": [
       "Bussy, J. H. de"
     ],
@@ -1110,7 +1102,6 @@
     "title_sort": "Map illustrating Mr A Sharpes journey from Lake Nyassa to the Loangwa Upper Zambezi Rivers",
     "title_245a_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers",
     "title_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers",
-    "title_full_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers.",
     "author_1xx_search": "Shawe, W.",
     "author_7xx_search": [
       "Royal Geographical Society (Great Britain)"
@@ -1274,7 +1265,6 @@
     "title_sort": "East Africa showing the recentlyarranged political boundaries",
     "title_245a_display": "East Africa",
     "title_display": "East Africa : showing the recently-arranged political boundaries",
-    "title_full_display": "East Africa : showing the recently-arranged political boundaries.",
     "author_1xx_search": "Royal Geographical Society (Great Britain)",
     "author_other_facet": [
       "Royal Geographical Society (Great Britain)"
@@ -1411,7 +1401,6 @@
     "title_sort": "Plan van de geproclameerde Goud Velden te Witwatersrand ZAR",
     "title_245a_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.",
     "title_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R",
-    "title_full_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.",
     "author_7xx_search": [
       "Rissik, Johann, 1857-1925"
     ],
@@ -1542,7 +1531,6 @@
     "title_sort": "South Africa by Jas Wyld Geographer to the Queen",
     "title_245a_display": "South Africa by Jas Wyld, Geographer to the Queen.",
     "title_display": "South Africa by Jas Wyld, Geographer to the Queen",
-    "title_full_display": "South Africa by Jas Wyld, Geographer to the Queen.",
     "author_7xx_search": [
       "Wyld, James, 1812-1887"
     ],
@@ -1677,7 +1665,6 @@
     "title_sort": "Africa",
     "title_245a_display": "Africa",
     "title_display": "Africa",
-    "title_full_display": "Africa.",
     "author_1xx_search": "Bevan, G. Phillips, 1829?-1889",
     "author_person_facet": [
       "Bevan, G. Phillips, 1829?-1889"
@@ -1835,7 +1822,6 @@
     "title_sort": "Birds eye view of the Soudan and surrounding countries",
     "title_245a_display": "Birds eye view of the Soudan and surrounding countries",
     "title_display": "Birds eye view of the Soudan and surrounding countries",
-    "title_full_display": "Birds eye view of the Soudan and surrounding countries.",
     "author_1xx_search": "Maclure.",
     "author_7xx_search": [
       "Macdonald."
@@ -1973,7 +1959,6 @@
     "title_sort": "Map of Africa Showing its most Recent Discoveries",
     "title_245a_display": "Map of Africa Showing its most Recent Discoveries.",
     "title_display": "Map of Africa Showing its most Recent Discoveries",
-    "title_full_display": "Map of Africa Showing its most Recent Discoveries.",
     "author_7xx_search": [
       "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
       "Williams, W. (Wellington)"
@@ -2110,7 +2095,6 @@
     "title_sort": "NordwestAfrika",
     "title_245a_display": "Nordwest-Afrika",
     "title_display": "Nordwest-Afrika",
-    "title_full_display": "Nordwest-Afrika.",
     "author_1xx_search": "Petermann, August.",
     "author_7xx_search": [
       "Hanemann, Fritz.",
@@ -2263,7 +2247,6 @@
     "title_sort": "Africa",
     "title_245a_display": "Africa.",
     "title_display": "Africa",
-    "title_full_display": "Africa.",
     "author_7xx_search": [
       "Tallis, John, 1817-1876",
       "Rapkin, J."
@@ -2405,7 +2388,6 @@
     "title_sort": "Afrika im Massstab v 125000000",
     "title_245a_display": "Afrika im Massstab v. 1:25.000.000",
     "title_display": "Afrika im Massstab v. 1:25.000.000",
-    "title_full_display": "Afrika im Massstab v. 1:25.000.000.",
     "author_1xx_search": "Petermann, A. (August), 1822-1878",
     "author_7xx_search": [
       "Habenicht, H."
@@ -2544,7 +2526,6 @@
     "title_sort": "Afrique",
     "title_245a_display": "Afrique",
     "title_display": "Afrique",
-    "title_full_display": "Afrique.",
     "author_1xx_search": "Andriveau-Goujon, E. (Eugène), 1832-1897",
     "author_person_facet": [
       "Andriveau-Goujon, E. (Eugène), 1832-1897"
@@ -2675,7 +2656,6 @@
     "title_sort": "Africa",
     "title_245a_display": "Africa",
     "title_display": "Africa",
-    "title_full_display": "Africa.",
     "author_1xx_search": "Bartholomew, John, 1831-1893",
     "author_7xx_search": [
       "Adam and Charles Black (Firm)"
@@ -2847,7 +2827,6 @@
     "author_1xx_unstem_search": "A. Rosenfeld",
     "title_245a_display": "Proposal to ARPA and \"Computer Vision\" by A. Rosenfeld, July 28, 1975",
     "title_display": "Proposal to ARPA and \"Computer Vision\" by A. Rosenfeld, July 28, 1975",
-    "title_full_display": "Proposal to ARPA and \"Computer Vision\" by A. Rosenfeld, July 28, 1975.",
     "imprint_display": ["1975-7"],
     "pub_year_isi": 1975,
     "pub_year_no_approx_isi": 1975,
@@ -2976,7 +2955,6 @@
     "title_245a_exact_search": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf",
     "title_245a_unstem_search": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf",
     "title_display": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf",
-    "title_full_display": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf.",
     "title_sort": "TRCourt of AppealsOriginal Decisions2002012002 Vitor Manuel Alves Final COA Decision PORpdf",
     "modsxml_tsi": [
       " TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf Virtual Tribunals: East Timor https://purl.stanford.edu/kh392jb5994 TBD "

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -109,7 +109,7 @@ describe CatalogHelper, type: :helper do
       let(:title) { 'Baldwin of Ford OCist, De sacramento altaris' }
       let(:document) do
         SolrDocument.new(
-          title_full_display: "p. 3:#{title}",
+          title_display: "p. 3:#{title}",
           manuscript_number_tesim: ['MS 198'],
           format_main_ssim: ['Page details']
         )
@@ -123,7 +123,7 @@ describe CatalogHelper, type: :helper do
     context 'bibilography resource' do
       let(:document) do
         SolrDocument.new(
-          title_full_display: 'A Zotero reference',
+          title_display: 'A Zotero reference',
           format_main_ssim: ['Bibliography']
         )
       end


### PR DESCRIPTION
The title_full_display has punctuation that we don't want to display

We are keeping the configured key as title_full_display so that nothing
changes for current exhibits but they will now use the title_display
field from the solr document