### PR TITLE
Remove unnecessary CSS selector

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -97,10 +97,6 @@
   }
 }
 
-.blacklight-browse h1 {
-  font-size: 2rem;
-}
-
 .item-count {
   color: $cool-grey;
   font-size: 1.25rem;


### PR DESCRIPTION
There is a noticeable shifting in size of the exhibit title text in the masthead when you move from to and from a Browse page from any other page:

https://user-images.githubusercontent.com/101482/110867883-c2c64600-8284-11eb-86a1-9013aa3f1884.mov

I thought I had a fix but realized I need to look at one other potential issue involved so am making this a draft for now.