### PR TITLE
Separate browse h1 css from masthead h1

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -97,7 +97,7 @@
   }
 }
 
-.blacklight-browse h1 {
+.blacklight-browse main h1 {
   font-size: 2rem;
 }
 


### PR DESCRIPTION
Fixes #2039 

A small font size adjustment to make sure that the masthead title is the right size in the browse context. 