### PR TITLE
Remove ancient thumbnail override

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'config'
 
 gem 'bootstrap'
 gem 'blacklight', '~> 7.15'
-gem 'blacklight-gallery', '~> 3'
+gem 'blacklight-gallery', '~> 3', '>= 3.0.3'
 gem 'blacklight_heatmaps'
 gem 'blacklight-spotlight', '~> 3.0.0.rc3', github: 'projectblacklight/spotlight'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight.git
-  revision: a428350dc5c4921c8327547ddd63f2921425a3fa
+  revision: 92218ca9444d745ac4446b92dc7fd042ffa4ed33
   specs:
     blacklight-spotlight (3.0.0.rc4)
       activejob-status
@@ -44,8 +44,14 @@ GIT
       underscore-rails (~> 1.6)
 
 GEM
-  remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
+  specs:
+    sidekiq-pro (5.2.0)
+      connection_pool (>= 2.2.3)
+      sidekiq (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
   specs:
     actioncable (6.1.3.1)
       actionpack (= 6.1.3.1)
@@ -126,7 +132,7 @@ GEM
     bibtex-ruby (6.0.0)
       latex-decode (~> 0.0)
     bindex (0.8.1)
-    blacklight (7.15.2)
+    blacklight (7.16.0)
       deprecation
       globalid
       i18n (>= 1.7.0)
@@ -135,7 +141,7 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
       view_component (>= 2.23.0)
-    blacklight-gallery (3.0.2)
+    blacklight-gallery (3.0.3)
       blacklight (~> 7.12)
       bootstrap (~> 4.0)
       rails (>= 5.1, < 7)
@@ -321,7 +327,7 @@ GEM
       mime-types (>= 1.0)
     friendly_id (5.4.2)
       activerecord (>= 4.0.0)
-    github-markup (3.0.5)
+    github-markup (4.0.0)
     gli (2.20.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -330,7 +336,7 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     hashdiff (1.0.1)
-    hashie (3.6.0)
+    hashie (4.1.0)
     honeybadger (4.8.0)
     http (4.4.1)
       addressable (~> 2.3)
@@ -343,7 +349,7 @@ GEM
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     i18n-active_record (0.4.0)
       i18n (>= 0.5.0)
@@ -391,7 +397,7 @@ GEM
       multi_json
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    listen (3.5.0)
+    listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.9.0)
@@ -435,6 +441,10 @@ GEM
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-linux)
+      racc (~> 1.4)
     nom-xml (1.1.0)
       activesupport (>= 3.2.18)
       i18n
@@ -461,7 +471,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)
-    purl_fetcher-client (0.4.0)
+    purl_fetcher-client (0.4.1)
       dor-rights-auth
       http
       mods_display
@@ -603,9 +613,6 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-pro (5.2.0)
-      connection_pool (>= 2.2.3)
-      sidekiq (>= 6.1.0)
     signet (0.15.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -744,7 +751,7 @@ DEPENDENCIES
   acts-as-taggable-on
   bibtex-ruby
   blacklight (~> 7.15)
-  blacklight-gallery (~> 3)
+  blacklight-gallery (~> 3, >= 3.0.3)
   blacklight-oembed (~> 1.0)
   blacklight-spotlight (~> 3.0.0.rc3)!
   blacklight_advanced_search

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight.git
-  revision: 92218ca9444d745ac4446b92dc7fd042ffa4ed33
+  revision: 791f5983bc6d154ae5e2b37b9d1f9fda54e92c76
   specs:
     blacklight-spotlight (3.0.0.rc4)
       activejob-status
@@ -141,7 +141,7 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
       view_component (>= 2.23.0)
-    blacklight-gallery (3.0.4)
+    blacklight-gallery (3.1.0)
       blacklight (~> 7.12)
       bootstrap (~> 4.0)
       rails (>= 5.1, < 7)
@@ -410,7 +410,7 @@ GEM
       unf
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
-    marcel (1.0.0)
+    marcel (1.0.1)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
       view_component (>= 2.23.0)
-    blacklight-gallery (3.0.3)
+    blacklight-gallery (3.0.4)
       blacklight (~> 7.12)
       bootstrap (~> 4.0)
       rails (>= 5.1, < 7)

--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -54,11 +54,6 @@
   }
 }
 
-.document-thumbnail img {
-  max-height: 200px;
-  max-width: 100%;
-}
-
 #documents {
   .index_title {
     font-size: 1rem;


### PR DESCRIPTION
This was initially added for #1116, but now breaks #2052.. Since then, I think we've picked square thumbnails that are 100x100 anyway, so I can't see it being useful still 🤷‍♂️ 