### PR TITLE
Extra error handling for external IIIF thumbnails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,14 +44,8 @@ GIT
       underscore-rails (~> 1.6)
 
 GEM
-  remote: https://gems.contribsys.com/
-  specs:
-    sidekiq-pro (5.2.0)
-      connection_pool (>= 2.2.3)
-      sidekiq (>= 6.1.0)
-
-GEM
   remote: https://rubygems.org/
+  remote: https://gems.contribsys.com/
   specs:
     actioncable (6.1.3.1)
       actionpack (= 6.1.3.1)
@@ -613,6 +607,9 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-pro (5.2.0)
+      connection_pool (>= 2.2.3)
+      sidekiq (>= 6.1.0)
     signet (0.15.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -642,7 +639,7 @@ GEM
       actionpack
       rack-timeout (>= 0.4.0)
       railties (>= 5)
-    solr_wrapper (3.1.1)
+    solr_wrapper (3.1.2)
       http
       retriable
       ruby-progressbar

--- a/app/models/spotlight/resources/iiif_manifest.rb
+++ b/app/models/spotlight/resources/iiif_manifest.rb
@@ -42,6 +42,8 @@ module Spotlight
       end
 
       def iiif_thumbnail_service?(content_resource)
+        return unless content_resource.respond_to?(:dig)
+
         content_resource&.dig('service', 'profile')&.match? 'api/image'
       end
     end


### PR DESCRIPTION
Related to #1987 #2048 and Fixes #2069

Fixes an indexing error that was throwing out this manifest from Cultural Japan:
https://api.cultural.jp/iiif/metmuseum-54052/manifest