### PR TITLE
Avoid inadvertently upscaling deliberately small images

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Exhibits
     config.to_prepare do
       Spotlight::Exhibit.send(:include, ExhibitExtension)
       Spotlight::AttachmentUploader.send(:include, CarrierWave::MiniMagick)
-      Spotlight::AttachmentUploader.send(:process, resize_to_fit: [2000, 2000])
+      Spotlight::AttachmentUploader.send(:process, resize_to_limit: [2000, 2000])
     end
 
     config.druid_regex = /([a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4})/


### PR DESCRIPTION
Fixes #2077

Use the CarrierWave `resize_to_limit` method instead of `resize_to_fit`. The difference? The latter upscales and the former does not.