### PR TITLE
Move the fq to remove exhibit items into the search builder

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,7 +48,6 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: 'search',
-      fq: '-document_type_ssi:exhibit',
       # Wipe out the values of the `all_search*` and `full_text*` fields using clever solr tricks to deal with
       # cases (like rarebooks) that have abundant full text data (to the tune of 1MB per object.. times 8) that
       # cause search results to slow to a crawl. We don't actually use these fields for displaying results,

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -10,6 +10,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightHeatmaps::SolrFacetHeatmapBehavior
 
   include Spotlight::SearchBuilder
+  self.default_processor_chain += [:limit_to_exhibit_items]
 
   ##
   # modify JSON API behavior to limit the `rows` (or `per_page`) parameter
@@ -24,5 +25,9 @@ class SearchBuilder < Blacklight::SearchBuilder
             else
               [@rows.to_i, (blacklight_config.max_per_page_for_api || 1_000)].min # ensure under max
             end
+  end
+
+  def limit_to_exhibit_items(solr_params)
+    solr_params.append_filter_query '-document_type_ssi:exhibit'
   end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -78,4 +78,8 @@ RSpec.describe SearchBuilder do
       expect(builder.to_hash).to include(rows: 100)
     end
   end
+
+  it 'removes exhibit records' do
+    expect(builder.to_hash[:fq]).to include '-document_type_ssi:exhibit'
+  end
 end


### PR DESCRIPTION
This should work around a solr query parameter merging issue where the `default_solr_params` fq value overwrote anything the browse category produced. Moving it into the search builder feels appropriate -- it's not so much a default as a hard requirement 🤷 

An alternative/additional fix is in https://github.com/projectblacklight/blacklight/pull/2457, which should have blacklight preserve our values.