### PR TITLE
Add OSD assets to manifest file

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link application.js
 //= link application.css
 //= link application_parker.css
+//= link openseadragon-assets.js


### PR DESCRIPTION
This fixes an issue that prevented us from opening uploaded items in 
local development.