### PR TITLE
Override SirTrevor to work around a niche chrome-specific bug

### DIFF
--- a/app/assets/javascripts/sir_trevor_block_overrides.js
+++ b/app/assets/javascripts/sir_trevor_block_overrides.js
@@ -8,3 +8,9 @@ SirTrevor.Blocks.SolrDocumentsEmbed = (function(){
     }
   });
 })();
+
+// work around for https://bugs.chromium.org/p/chromium/issues/detail?id=1262589&q=contenteditable&can=1
+if (navigator.userAgentData && navigator.userAgentData.brands &&
+    Boolean(navigator.userAgentData.brands.find(function(b) { return b.brand === 'Chromium' && parseFloat(b.version, 10) >= 95 && parseFloat(b.version, 10) < 97; }))) {
+  SirTrevor.Blocks.Text.prototype.editorHTML = "<div class=\"st-text-block\" spellcheck=\"false\" contenteditable=\"true\"></div>";
+}


### PR DESCRIPTION
If using another browser isn't possible, this is a maybe-not-a-good-idea way to fix the behavior in chrome.

See #2138.