### PR TITLE
Pin view_component gem to version 2.50.0 temporarily

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ gem 'ruby-oembed'
 gem 'okcomputer'
 gem 'friendly_id', '~> 5.4'
 gem 'sitemap_generator'
+gem 'view_component', '2.50.0'
 
 source 'https://gems.contribsys.com/' do
   gem 'sidekiq-pro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -843,6 +843,7 @@ DEPENDENCIES
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data
   uglifier (>= 2.7.2)
+  view_component (= 2.50.0)
   web-console (>= 4.1.0)
   webdrivers
   webmock


### PR DESCRIPTION
Since we need to get out a deploy of this repo today, and there is a holdup [related to view_component 2.51.0](https://github.com/github/view_component/issues/1315), we are pinning the version to 2.50.0 until next week's deploy.

@corylown 