### PR TITLE
Apply changes to shared_configs during deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,6 +31,9 @@ set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/sys
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'
+
 namespace :deploy do
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do


### PR DESCRIPTION
I tested this change on staging, and it properly executed:

```
00:51 shared_configs:pull
      01 cd /opt/app/exhibits/exhibits/shared/repo_configs; git pull
      ...
```

Hoping to merge this and then make sure it's pulling the new production shared_configs.