### PR TITLE
Override transparent background set on search box by twitter-typeahead

### DIFF
--- a/app/assets/stylesheets/modules/exhibit_search_typeahead.scss
+++ b/app/assets/stylesheets/modules/exhibit_search_typeahead.scss
@@ -1,4 +1,10 @@
 .exhibit-search-typeahead {
+  .tt-input {
+    // Override the transparent background added inline
+    // by twitter-typeahead
+    background-color: $navbar-default-bg !important;
+  }
+
   .tt-dropdown-menu {
     width: 100%;
   }


### PR DESCRIPTION
Fixes #2244 

Before:
<img width="508" alt="Screen Shot 2022-12-20 at 5 26 00 PM" src="https://user-images.githubusercontent.com/458247/208778995-35a5991d-8b27-441c-ab23-ce6ab8a48373.png">

After:
<img width="511" alt="Screen Shot 2022-12-20 at 5 25 41 PM" src="https://user-images.githubusercontent.com/458247/208779012-34a39cc4-17c8-426d-a8bd-b7bc4b8ab0b2.png">
