### PR TITLE
Move shared ActiveJob status code into the repo

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,12 @@
-Sidekiq::Client.reliable_push! unless Rails.env.test?
-
 Sidekiq.configure_server do |config|
-  config.super_fetch!
-  config.reliable_scheduler!
-  config.logger.level = Object.const_get(Settings.sidekiq.logger_level)
+  config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL', "redis://localhost:6379/1") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL', "redis://localhost:6379/1") }
+end
+
+if ENV['JOB_STATUS_REDIS_URL']
+  # Shared activejob status reporting 
+  ActiveJob::Status.store = ActiveSupport::Cache::RedisCacheStore.new(url: ENV.fetch('JOB_STATUS_REDIS_URL'))
 end


### PR DESCRIPTION
Previously this was kept in shared configs, which allowed us to accidentally remove the redis gem. Once this PR and https://github.com/sul-dlss/puppet/pull/9053 are merged, then we can remove the initializers from shared configs.