### PR TITLE
Don't link the sidekiq initializer on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,7 +20,7 @@ set :log_level, :info
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w(public/robots.txt config/secrets.yml config/database.yml config/blacklight.yml config/honeybadger.yml config/newrelic.yml config/initializers/sidekiq.rb)
+set :linked_files, %w(public/robots.txt config/secrets.yml config/database.yml config/blacklight.yml config/honeybadger.yml config/newrelic.yml)
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads config/settings)


### PR DESCRIPTION
We've moved the initializer into the repo and environment variables. See https://github.com/sul-dlss/exhibits/pull/2278