### PR TITLE
Install yarn before assets:precompile

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,6 +31,19 @@ set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/sys
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+before "deploy:assets:precompile", "deploy:yarn_install"
+
+namespace :deploy do
+  desc 'Run yarn install'
+  task :yarn_install do
+    on roles(:web) do
+      within release_path do
+        execute("cd #{release_path} && yarn install")
+      end
+    end
+  end
+end
+
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 


### PR DESCRIPTION
Should fix the broken deploys:

```
      01 Tasks: TOP => assets:precompile
      01 (See full trace by running task with --trace)
      01 rake aborted!
      01 2023-02-13T15:06:24.766Z pid=2002231 tid=16yp7 INFO: Sidekiq 7.0.3 connecting to Redis with options {:size=>5, :pool_name=>"internal", :url=>"redis://exhibits-db-stage-a.stanford.edu:6379/1"}
      01 SassC::SyntaxError: Error: File to import not found or unreadable: bootstrap-slider/dist/css/bootstrap-slider.
      01         on line 2:1 of app/assets/stylesheets/base.scss
      01         from line 1:1 of app/assets/stylesheets/application.scss
      01 >> @import 'bootstrap-slider/dist/css/bootstrap-slider';

```