### PR TITLE
Ensure that a single paragraph description is html-safe

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -5,6 +5,11 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
+  # Which tags do we accept in the metadata.
+  # From https://github.com/sul-dlss/mods_display/blob/2c7b6faef791e7d0d6ae27711bfc7687e1c0dc3d/app/helpers/mods_display/record_helper.rb#L74
+  # And also the "p" tag.
+  PERMITTED_TAGS = %w(a dl dd dt i b em strong cite br p).freeze
+
   # @note thumbnail handling moves to a presenter in Blacklight 7.
   # Overriding Blacklight so that all references display thumbnails
   #
@@ -47,11 +52,10 @@ module CatalogHelper
     return if options[:value].blank?
 
     values = split_on_white_space(options[:value])
+             .map { |value| sanitize(value, tags: PERMITTED_TAGS) }
     return values.first if values.count == 1
 
-    safe_join(values.collect do |content|
-      content_tag('p', content.html_safe) # rubocop:disable Rails/OutputSafety
-    end)
+    safe_join(values.map { |content| tag.p content })
   end
 
   def table_of_contents_separator(options = {})

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -61,17 +61,23 @@ describe CatalogHelper, type: :helper do
   end
 
   describe '#paragraph_joined_content' do
+    subject(:content) { helper.paragraph_joined_content(value: value) }
+
     context 'single description' do
+      let(:value) { %w(<p>stuff</p>) }
+
       it 'returns a description' do
-        expect(helper.paragraph_joined_content(value: %w(<p>stuff</p>))).to eq '<p>stuff</p>'
+        expect(content).to eq '<p>stuff</p>'
+        expect(content).to be_html_safe
       end
     end
 
     context 'multiple descriptions' do
+      let(:value) { %W[<p>stuff</p> hello\nworld] }
+
       it 'returns the descriptions joined by paragraphs' do
-        expect(
-          helper.paragraph_joined_content(value: %W[<p>stuff</p> hello\nworld])
-        ).to eq '<p><p>stuff</p></p><p>hello</p><p>world</p>'
+        expect(content).to eq '<p><p>stuff</p></p><p>hello</p><p>world</p>'
+        expect(content).to be_html_safe
       end
     end
   end


### PR DESCRIPTION
This allows italic tags from the metadata to display on the page