### PR TITLE
Use instance_double of RSolr and RSolr::Client in spec; fixes FrozenError

### DIFF
--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -6,8 +6,14 @@ RSpec.describe 'indexing integration test', type: :feature, vcr: true do
   subject(:dor_harvester) { DorHarvester.new(druid_list: druid, exhibit: exhibit) }
 
   let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:rsolr) { instance_double(RSolr) }
+  let(:rsolr_client) { instance_double(RSolr::Client) }
 
   before do
+    allow(RSolr).to receive(:connect).and_return(rsolr_client)
+    allow(rsolr_client).to receive(:update)
+    allow(rsolr_client).to receive(:commit)
+
     stub_request(:post, /update/)
     %w(xf680rd3068 dx969tv9730 rk684yq9989 ms016pb9280 cf386wt1778 cc842mn9348 kh392jb5994 ws947mh3822 gh795jd5965 hm136qv0310).each do |fixture|
       stub_request(:get, "https://purl.stanford.edu/#{fixture}.xml").to_return(


### PR DESCRIPTION
Fixes FrozenError in https://github.com/sul-dlss/exhibits/pull/2347 from webmock update (and RSolr modifying the response body with `force_encoding`).