### PR TITLE
Change the default label for spotlight_upload_date_tesim

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -51,3 +51,4 @@ en:
     search:
       fields:
         spotlight_upload_title_tesim: Title
+        spotlight_uploaded_date_tesim: Uploaded date

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -51,4 +51,4 @@ en:
     search:
       fields:
         spotlight_upload_title_tesim: Title
-        spotlight_uploaded_date_tesim: Uploaded date
+        spotlight_upload_date_tesim: Uploaded date


### PR DESCRIPTION
The default label for spotlight_upload_date_tesim was "Date", on the metadata configuration page (e.g. https://exhibits.stanford.edu/a11y-for-soda/metadata_configuration/edit), this has the same label as `date_ssim`, so an editor is unable to distinguish between the two. 

This overrides the Spotlight default so that we don't have two identical labels: https://github.com/projectblacklight/spotlight/blob/9c0ae85b1417c186a0dc49512ead23e9785331bf/config/locales/spotlight.en.yml#L812