### PR TITLE
Update IIIF link to https://iiif.io

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,7 +31,7 @@ traject:
   processing_thread_pool: 1
 iiif_embed:
   url: https://embed.stanford.edu/iiif
-iiif_dnd_base_url: https://library.stanford.edu/projects/international-image-interoperability-framework/viewers?%{query}
+iiif_dnd_base_url: https://iiif.io?%{query}
 action_mailer:
   default_options:
     from: "example-team@example.com"


### PR DESCRIPTION
After some discussion with Sarah we decided to update the IIIF links to https://iiif.io