### PR TITLE
Remove unnecessary indexing

### DIFF
--- a/lib/traject/dor_config.rb
+++ b/lib/traject/dor_config.rb
@@ -202,40 +202,6 @@ end
 
 to_field 'content_metadata_type_ssm', copy('content_metadata_type_ssim')
 
-each_record do |resource, context|
-  content_metadata = resource.public_xml.at_xpath('/publicObject/contentMetadata')
-  next if content_metadata.blank?
-
-  # Select conventional file images or virtual external ones
-  images = content_metadata.xpath('(resource/file[@mimetype="image/jp2"] | resource/externalFile[@mimetype="image/jp2"])')
-  thumbnail_data = images.first { |node| (node.attr('id') || node.attr('fileId') || '').end_with?('jp2') }
-  context.clipboard['thumbnail_data'] = thumbnail_data
-end
-
-to_field 'content_metadata_first_image_file_name_ssm' do |_resource, accumulator, context|
-  next unless context.clipboard['thumbnail_data']
-
-  # Allow for selection of conventional id's or virtual fileIds
-  file_id = (context.clipboard['thumbnail_data'].attr('id') || context.clipboard['thumbnail_data'].attr('fileId')).gsub('.jp2', '')
-  accumulator << file_id
-end
-
-to_field 'content_metadata_first_image_width_ssm' do |_resource, accumulator, context|
-  next unless context.clipboard['thumbnail_data']
-
-  image_data = context.clipboard['thumbnail_data'].at_xpath('./imageData')
-
-  accumulator << image_data['width']
-end
-
-to_field 'content_metadata_first_image_height_ssm' do |_resource, accumulator, context|
-  next unless context.clipboard['thumbnail_data']
-
-  image_data = context.clipboard['thumbnail_data'].at_xpath('./imageData')
-
-  accumulator << image_data['height']
-end
-
 to_field 'content_metadata_image_iiif_info_ssm', resource_images_iiif_urls do |_resource, accumulator, _context|
   accumulator.map! { |base_url| "#{base_url}/info.json" }
 end

--- a/spec/features/indexing_integration_spec.rb
+++ b/spec/features/indexing_integration_spec.rb
@@ -55,14 +55,10 @@ RSpec.describe 'indexing integration test' do
 
       it 'has content metadata fields' do
         expect(document).to include content_metadata_type_ssim: ['image'],
-                                    content_metadata_first_image_file_name_ssm: ['xf680rd3068_00_0001'],
-                                    content_metadata_first_image_width_ssm: ['1794'],
-                                    content_metadata_first_image_height_ssm: ['2627'],
-                                    content_metadata_image_iiif_info_ssm: %w(https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/info.json https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0002/info.json),
-                                    thumbnail_square_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/square/100,100/0/default.jpg', 'https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0002/square/100,100/0/default.jpg'],
-                                    thumbnail_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/full/!400,400/0/default.jpg', 'https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0002/full/!400,400/0/default.jpg'],
-                                    large_image_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/full/!1000,1000/0/default.jpg', 'https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0002/full/!1000,1000/0/default.jpg'],
-                                    full_image_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/full/!3000,3000/0/default.jpg', 'https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0002/full/!3000,3000/0/default.jpg']
+                                    thumbnail_square_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/square/100,100/0/default.jpg'],
+                                    thumbnail_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/full/!400,400/0/default.jpg'],
+                                    large_image_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/full/!1000,1000/0/default.jpg'],
+                                    full_image_url_ssm: ['https://stacks.stanford.edu/image/iiif/xf680rd3068%2Fxf680rd3068_00_0001/full/!3000,3000/0/default.jpg']
       end
 
       it 'has MODS title fields' do
@@ -226,14 +222,10 @@ RSpec.describe 'indexing integration test' do
 
       it 'has content metadata fields' do
         expect(document).to include content_metadata_type_ssim: ['image'],
-                                    content_metadata_first_image_file_name_ssm: ['PC0170_s1_E_0204'],
-                                    content_metadata_first_image_width_ssm: ['4488'],
-                                    content_metadata_first_image_height_ssm: ['6738'],
-                                    content_metadata_image_iiif_info_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/info.json https://stacks.stanford.edu/image/iiif/tp006ms8736%2FPC0170_s1_E_0205/info.json),
-                                    thumbnail_square_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/square/100,100/0/default.jpg https://stacks.stanford.edu/image/iiif/tp006ms8736%2FPC0170_s1_E_0205/square/100,100/0/default.jpg),
-                                    thumbnail_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/full/!400,400/0/default.jpg https://stacks.stanford.edu/image/iiif/tp006ms8736%2FPC0170_s1_E_0205/full/!400,400/0/default.jpg),
-                                    large_image_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/full/!1000,1000/0/default.jpg https://stacks.stanford.edu/image/iiif/tp006ms8736%2FPC0170_s1_E_0205/full/!1000,1000/0/default.jpg),
-                                    full_image_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/full/!3000,3000/0/default.jpg https://stacks.stanford.edu/image/iiif/tp006ms8736%2FPC0170_s1_E_0205/full/!3000,3000/0/default.jpg)
+                                    thumbnail_square_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/square/100,100/0/default.jpg),
+                                    thumbnail_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/full/!400,400/0/default.jpg),
+                                    large_image_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/full/!1000,1000/0/default.jpg),
+                                    full_image_url_ssm: %w(https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204/full/!3000,3000/0/default.jpg)
       end
     end
   end

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -1,10 +1,9 @@
-[{
+[
+  {
     "id": "hj066rn6500",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -15,28 +14,13 @@
     "title_245a_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea",
     "title_display": "Posesiones españolas en Africa, Costa Occidental ..., Golfo de Guinea",
     "author_1xx_search": "Chias, Benito.",
-    "author_person_facet": [
-      "Chias, Benito."
-    ],
+    "author_person_facet": ["Chias, Benito."],
     "author_sort": "Chias BenitoPosesiones españolas en Africa Costa Occidental  Golfo de Guinea",
-    "author_person_display": [
-      "Chias, Benito."
-    ],
-    "author_person_full_display": [
-      "Chias, Benito."
-    ],
-    "topic_search": [
-      "map",
-      "Colonies"
-    ],
-    "geographic_search": [
-      "Africa",
-      "Spain"
-    ],
-    "subject_other_subvy_search": [
-      "Maps",
-      "Maps"
-    ],
+    "author_person_display": ["Chias, Benito."],
+    "author_person_full_display": ["Chias, Benito."],
+    "topic_search": ["map", "Colonies"],
+    "geographic_search": ["Africa", "Spain"],
+    "subject_other_subvy_search": ["Maps", "Maps"],
     "subject_all_search": [
       "map",
       "Colonies",
@@ -45,29 +29,15 @@
       "Maps",
       "Maps"
     ],
-    "topic_facet": [
-      "Colonies"
-    ],
-    "geographic_facet": [
-      "Africa",
-      "Spain"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "Spanish"
-    ],
+    "topic_facet": ["Colonies"],
+    "geographic_facet": ["Africa", "Spain"],
+    "format_main_ssim": ["Map"],
+    "language": ["Spanish"],
     "physical": [
       "2 maps on 1 sheet : col. ; 23 x 15 cm. and 23 x 15 cm., sheet 38 x 27 cm."
     ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "sp",
-      "Barcelona"
-    ],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["sp", "Barcelona"],
     "pub_year_isi": 1940,
     "pub_date_sort": "1940",
     "pub_year_no_approx_isi": 1940,
@@ -81,46 +51,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "hj066rn6500_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["hj066rn6500_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W18°--E51°/N37°--S35°)."
-    ],
+    "coordinates_tesim": ["(W18°--E51°/N37°--S35°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "hj066rn6500_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "9310"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "6523"
-    ],
-    "content_metadata_image_iiif_info_ssm": [
-      "https://stacks.stanford.edu/image/iiif/hj066rn6500%2Fhj066rn6500_00_0001/info.json"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "thumbnail_square_url_ssm": [
       "https://stacks.stanford.edu/image/iiif/hj066rn6500%2Fhj066rn6500_00_0001/square/100,100/0/default.jpg"
     ],
@@ -144,9 +88,7 @@
     "id": "wd297xz1362",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -164,39 +106,16 @@
     "author_corp_display": [
       "Great Britain War Office. General Staff. Geographical Section."
     ],
-    "topic_search": [
-      "map"
-    ],
-    "geographic_search": [
-      "Africa"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Africa",
-      "Maps"
-    ],
-    "geographic_facet": [
-      "Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : col."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "enk",
-      "[London"
-    ],
+    "topic_search": ["map"],
+    "geographic_search": ["Africa"],
+    "subject_other_subvy_search": ["Maps"],
+    "subject_all_search": ["map", "Africa", "Maps"],
+    "geographic_facet": ["Africa"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : col."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["enk", "[London"],
     "pub_year_isi": 1928,
     "pub_date_sort": "1928",
     "pub_year_no_approx_isi": 1928,
@@ -210,46 +129,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "wd297xz1362_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["wd297xz1362_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W16°--E28°/N13°--S15°)."
-    ],
+    "coordinates_tesim": ["(W16°--E28°/N13°--S15°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-16.0, 28.0, 13.0, -15.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-16.0, 28.0, 13.0, -15.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "wd297xz1362_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "18000"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "8400"
-    ],
-    "content_metadata_image_iiif_info_ssm": [
-      "https://stacks.stanford.edu/image/iiif/wd297xz1362%2Fwd297xz1362_00_0001/info.json"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "thumbnail_square_url_ssm": [
       "https://stacks.stanford.edu/image/iiif/wd297xz1362%2Fwd297xz1362_00_0001/square/100,100/0/default.jpg"
     ],
@@ -267,9 +160,7 @@
     "id": "xy658qf4887",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -280,57 +171,21 @@
     "title_245a_display": "Atlas Vidal. Lablache",
     "title_display": "Atlas Vidal. Lablache",
     "author_1xx_search": "Vidal de La Blache, Paul, 1845-1918",
-    "author_person_facet": [
-      "Vidal de La Blache, Paul, 1845-1918"
-    ],
+    "author_person_facet": ["Vidal de La Blache, Paul, 1845-1918"],
     "author_sort": "Vidal de La Blache Paul 18451918Atlas Vidal Lablache",
-    "author_person_display": [
-      "Vidal de La Blache, Paul, 1845-1918"
-    ],
-    "author_person_full_display": [
-      "Vidal de La Blache, Paul, 1845-1918"
-    ],
-    "topic_search": [
-      "map",
-      "Atlas"
-    ],
-    "geographic_search": [
-      "World",
-      "Africa"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Atlas",
-      "World",
-      "Africa",
-      "Maps"
-    ],
-    "topic_facet": [
-      "Atlas"
-    ],
-    "geographic_facet": [
-      "World",
-      "Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "French"
-    ],
-    "physical": [
-      "Flles : col. ; 44 x 29 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "fr",
-      "Paris"
-    ],
+    "author_person_display": ["Vidal de La Blache, Paul, 1845-1918"],
+    "author_person_full_display": ["Vidal de La Blache, Paul, 1845-1918"],
+    "topic_search": ["map", "Atlas"],
+    "geographic_search": ["World", "Africa"],
+    "subject_other_subvy_search": ["Maps"],
+    "subject_all_search": ["map", "Atlas", "World", "Africa", "Maps"],
+    "topic_facet": ["Atlas"],
+    "geographic_facet": ["World", "Africa"],
+    "format_main_ssim": ["Map"],
+    "language": ["French"],
+    "physical": ["Flles : col. ; 44 x 29 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["fr", "Paris"],
     "pub_year_isi": 1921,
     "pub_date_sort": "1921",
     "pub_year_no_approx_isi": 1921,
@@ -344,44 +199,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "xy658qf4887_00_0001.jp2",
-      "xy658qf4887_00_0002.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["xy658qf4887_00_0001.jp2", "xy658qf4887_00_0002.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W35°--E63°/N37°--S35°)."
-    ],
+    "coordinates_tesim": ["(W35°--E63°/N37°--S35°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-35.0, 63.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-35.0, 63.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "xy658qf4887_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "13088"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9214"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/xy658qf4887%2Fxy658qf4887_00_0001/info.json",
       "https://stacks.stanford.edu/image/iiif/xy658qf4887%2Fxy658qf4887_00_0002/info.json"
@@ -412,9 +243,7 @@
     "id": "wk210cf6868",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -425,18 +254,9 @@
     "title_245a_display": "Africa: Industries and Communications",
     "title_display": "Africa: Industries and Communications",
     "author_sort": "􏿿 Africa Industries and Communications",
-    "topic_search": [
-      "Industries and Communications-"
-    ],
-    "geographic_search": [
-      "Africa",
-      "WORLD"
-    ],
-    "subject_other_subvy_search": [
-      "1906-1908",
-      "Maps",
-      "Atlases"
-    ],
+    "topic_search": ["Industries and Communications-"],
+    "geographic_search": ["Africa", "WORLD"],
+    "subject_other_subvy_search": ["1906-1908", "Maps", "Atlases"],
     "subject_all_search": [
       "Industries and Communications-",
       "Africa",
@@ -445,32 +265,14 @@
       "Maps",
       "Atlases"
     ],
-    "topic_facet": [
-      "Industries and Communications-"
-    ],
-    "geographic_facet": [
-      "Africa",
-      "WORLD"
-    ],
-    "era_facet": [
-      "1906-1908"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : col. ; 35 x 47 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "xx",
-      "London : George Phillip and Son"
-    ],
+    "topic_facet": ["Industries and Communications-"],
+    "geographic_facet": ["Africa", "WORLD"],
+    "era_facet": ["1906-1908"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : col. ; 35 x 47 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["xx", "London : George Phillip and Son"],
     "pub_year_isi": 1906,
     "pub_date_sort": "1906",
     "pub_year_no_approx_isi": 1906,
@@ -484,40 +286,19 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "wk210cf6868_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["wk210cf6868_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W18°--E51°/N37°--S35°)."
-    ],
+    "coordinates_tesim": ["(W18°--E51°/N37°--S35°)."],
     "folder_ssi": null,
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "wk210cf6868_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "9613"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "12623"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/wk210cf6868%2Fwk210cf6868_00_0001/info.json"
     ],
@@ -544,9 +325,7 @@
     "id": "hx676nr2846",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -557,30 +336,14 @@
     "title_245a_display": "Ruwenzori",
     "title_display": "Ruwenzori : to illustrate a paper by G.F. Scott-Elliot",
     "author_1xx_search": "Ravenstein, Ernst Georg, 1834-1913",
-    "author_7xx_search": [
-      "Royal Geographical Society (Great Britain)"
-    ],
-    "author_person_facet": [
-      "Ravenstein, Ernst Georg, 1834-1913"
-    ],
-    "author_other_facet": [
-      "Royal Geographical Society (Great Britain)"
-    ],
+    "author_7xx_search": ["Royal Geographical Society (Great Britain)"],
+    "author_person_facet": ["Ravenstein, Ernst Georg, 1834-1913"],
+    "author_other_facet": ["Royal Geographical Society (Great Britain)"],
     "author_sort": "Ravenstein Ernst Georg 18341913Ruwenzori to illustrate a paper by GF ScottElliot",
-    "author_corp_display": [
-      "Royal Geographical Society (Great Britain)"
-    ],
-    "author_person_display": [
-      "Ravenstein, Ernst Georg, 1834-1913"
-    ],
-    "author_person_full_display": [
-      "Ravenstein, Ernst Georg, 1834-1913"
-    ],
-    "topic_search": [
-      "map",
-      "Travel",
-      "Discovery and exploration"
-    ],
+    "author_corp_display": ["Royal Geographical Society (Great Britain)"],
+    "author_person_display": ["Ravenstein, Ernst Georg, 1834-1913"],
+    "author_person_full_display": ["Ravenstein, Ernst Georg, 1834-1913"],
+    "topic_search": ["map", "Travel", "Discovery and exploration"],
     "geographic_search": [
       "Ruwenzori Mountains (Congo and Uganda)",
       "Ruwenzori Mountains (Congo and Uganda)"
@@ -588,11 +351,7 @@
     "subject_other_search": [
       "Elliot, G. F. Scott (George Francis Scott), 1862-1934"
     ],
-    "subject_other_subvy_search": [
-      "Maps",
-      "Maps",
-      "Maps"
-    ],
+    "subject_other_subvy_search": ["Maps", "Maps", "Maps"],
     "subject_all_search": [
       "map",
       "Travel",
@@ -613,22 +372,11 @@
       "Ruwenzori Mountains (Congo and Uganda)",
       "Ruwenzori Mountains (Congo and Uganda)"
     ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : col. ; 27 x 25 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "enk",
-      "[London]"
-    ],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : col. ; 27 x 25 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["enk", "[London]"],
     "pub_year_isi": 1895,
     "pub_date_sort": "1895",
     "pub_year_no_approx_isi": 1895,
@@ -642,43 +390,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "hx676nr2846_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["hx676nr2846_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(E29°--E31°/N1°--N0°)."
-    ],
+    "coordinates_tesim": ["(E29°--E31°/N1°--N0°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(29.0, 31.0, 1.0, 0.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(29.0, 31.0, 1.0, 0.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "hx676nr2846_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "6998"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "5742"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/hx676nr2846%2Fhx676nr2846_00_0001/info.json"
     ],
@@ -704,9 +429,7 @@
     "id": "nz926xc1513",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -717,37 +440,22 @@
     "title_245a_display": "Map of South Africa.",
     "title_display": "Map of South Africa",
     "author_sort": "􏿿 Map of South Africa",
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps",
-      "Southern Africa"
-    ],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps", "Southern Africa"],
     "subject_all_search": [
       "map",
       "Digital maps",
       "Africa--Maps",
       "Southern Africa"
     ],
-    "geographic_facet": [
-      "Africa--Maps",
-      "Southern Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "48.5 x 66.5 cm"
-    ],
+    "geographic_facet": ["Africa--Maps", "Southern Africa"],
+    "format_main_ssim": ["Map"],
+    "physical": ["48.5 x 66.5 cm"],
     "url_suppl": [
       "http://purl.stanford.edu/yn681zp0153",
       "https://purl.stanford.edu/qb438pg7646"
     ],
-    "pub_search": [
-      "Unknown"
-    ],
+    "pub_search": ["Unknown"],
     "pub_year_isi": 1892,
     "pub_date_sort": "1892",
     "pub_year_no_approx_isi": 1892,
@@ -761,44 +469,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_0256.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_0256.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-
-    ],
+    "coordinates_tesim": [],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": [],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_0256"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "12599"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9706"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/nz926xc1513%2FAM_0256/info.json"
     ],
@@ -823,66 +507,33 @@
     "id": "gk885tn1705",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
     "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods:mods xmlns:xforms=\"http://www.w3.org/2002/xforms\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xxforms=\"http://orbeon.org/oxf/xml/xforms\">\n  <mods:identifier type=\"local\" displayLabel=\"Norwich ID\">NOR 0148</mods:identifier>\n  <mods:titleInfo type=\"main\">\n    <mods:title>Afrique Physique.</mods:title>\n  </mods:titleInfo>\n  <mods:originInfo>\n    <mods:dateCreated encoding=\"w3cdtf\" keyDate=\"yes\" qualifier=\"inferred\">1891</mods:dateCreated>\n    <mods:place>\n      <mods:placeTerm type=\"text\">Paris</mods:placeTerm>\n    </mods:place>\n    <mods:publisher>Migeon, J.</mods:publisher>\n  </mods:originInfo>\n  <mods:physicalDescription>\n    <mods:extent>31 x 42 cm</mods:extent>\n  </mods:physicalDescription>\n  <mods:subject>\n    <mods:cartographics>\n      <mods:scale>Scale in kilometers</mods:scale>\n      <mods:coordinates>(W 18°--E 51°/N 37°--S 35°)</mods:coordinates>\n    </mods:cartographics>\n  </mods:subject>\n  <mods:subject authority=\"lcsh\">\n    <mods:geographic authorityURI=\"http://id.loc.gov/authorities/subjects/sh85001569\">Africa--Maps</mods:geographic>\n  </mods:subject>\n  <mods:typeOfResource>cartographic</mods:typeOfResource>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2010043385\">\n    <mods:namePart>Migeon, J.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">creator</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:name type=\"personal\" authority=\"naf\" xlink:href=\"http://id.loc.gov/authorities/names/no2013137479\">\n    <mods:namePart>Lorsignol, G.</mods:namePart>\n    <mods:role>\n      <mods:roleTerm type=\"text\" authority=\"marcrelator\">engraver</mods:roleTerm>\n    </mods:role>\n  </mods:name>\n  <mods:titleInfo type=\"translated\">\n    <mods:title>Physical map of Africa.</mods:title>\n  </mods:titleInfo>\n  <mods:note>Insets: Engraving of diamond fields by Fillatreau and Soudain. Heights of peaks and depths of lakes in Africa.</mods:note>\n  <mods:note>Colored</mods:note>\n  <mods:note displayLabel=\"References\" type=\"reference\">Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C. Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0148, p. 167</mods:note>\n  <mods:note displayLabel=\"Provenance\" type=\"provenance\">Dr. Oscar I. Norwich</mods:note>\n  <mods:genre>map</mods:genre>\n  <mods:genre>Digital maps</mods:genre>\n  <mods:relatedItem type=\"otherFormat\" displayLabel=\"Georeferenced Map\">\n    <mods:titleInfo>\n      <mods:title>Afrique Physique (Raster Image)</mods:title>\n    </mods:titleInfo>\n    <mods:location>\n      <mods:url>http://purl.stanford.edu/zb162wk6653</mods:url>\n    </mods:location>\n  </mods:relatedItem>\n  <mods:relatedItem type=\"host\">\n    <mods:titleInfo>\n      <mods:title>Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865</mods:title>\n    </mods:titleInfo>\n    <mods:location>\n      <mods:url>https://purl.stanford.edu/qb438pg7646</mods:url>\n    </mods:location>\n    <mods:typeOfResource collection=\"yes\"/>\n  </mods:relatedItem>\n  <mods:relatedItem type=\"constituent\">\n    <mods:titleInfo>\n      <mods:title>Constituent Title</mods:title>\n    </mods:titleInfo>\n    <mods:note>Constituent note</mods:note>\n  </mods:relatedItem>\n  <mods:accessCondition type=\"useAndReproduction\">To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu.</mods:accessCondition>\n  <mods:accessCondition type=\"copyright\">Property rights reside with the repository. Copyright © Stanford University. All Rights Reserved.</mods:accessCondition>\n</mods:mods>\n",
     "title_245a_search": "Afrique Physique.",
     "title_245_search": "Afrique Physique.",
-    "title_variant_search": [
-      "Physical map of Africa."
-    ],
+    "title_variant_search": ["Physical map of Africa."],
     "title_sort": "Afrique Physique",
     "title_245a_display": "Afrique Physique.",
     "title_display": "Afrique Physique",
-    "author_7xx_search": [
-      "Migeon, J.",
-      "Lorsignol, G."
-    ],
-    "author_person_facet": [
-      "Migeon, J.",
-      "Lorsignol, G."
-    ],
+    "author_7xx_search": ["Migeon, J.", "Lorsignol, G."],
+    "author_person_facet": ["Migeon, J.", "Lorsignol, G."],
     "author_sort": "􏿿 Afrique Physique",
-    "author_person_display": [
-      "Migeon, J.",
-      "Lorsignol, G."
-    ],
-    "author_person_full_display": [
-      "Migeon, J.",
-      "Lorsignol, G."
-    ],
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Digital maps",
-      "Africa--Maps"
-    ],
-    "geographic_facet": [
-      "Africa--Maps"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "31 x 42 cm"
-    ],
+    "author_person_display": ["Migeon, J.", "Lorsignol, G."],
+    "author_person_full_display": ["Migeon, J.", "Lorsignol, G."],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps"],
+    "subject_all_search": ["map", "Digital maps", "Africa--Maps"],
+    "geographic_facet": ["Africa--Maps"],
+    "format_main_ssim": ["Map"],
+    "physical": ["31 x 42 cm"],
     "url_suppl": [
       "http://purl.stanford.edu/zb162wk6653",
       "https://purl.stanford.edu/qb438pg7646"
     ],
-    "pub_search": [
-      "Paris"
-    ],
+    "pub_search": ["Paris"],
     "pub_year_isi": 1891,
     "pub_date_sort": "1891",
     "pub_year_no_approx_isi": 1891,
@@ -896,48 +547,21 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_0098.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_0098.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
-    "author_no_collector_ssim": [
-      "Migeon, J.",
-      "Lorsignol, G."
-    ],
+    "author_no_collector_ssim": ["Migeon, J.", "Lorsignol, G."],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W 18°--E 51°/N 37°--S 35°)"
-    ],
+    "coordinates_tesim": ["(W 18°--E 51°/N 37°--S 35°)"],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_0098"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "11592"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9207"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/gk885tn1705%2FAM_0098/info.json"
     ],
@@ -962,9 +586,7 @@
     "id": "zm589dr6916",
     "exhibit_default-exhibit_public_bsi": false,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -974,49 +596,24 @@
     "title_sort": "Kaart van ZuidAfrika",
     "title_245a_display": "Kaart van Zuid-Afrika.",
     "title_display": "Kaart van Zuid-Afrika",
-    "author_7xx_search": [
-      "Bussy, J. H. de"
-    ],
-    "author_person_facet": [
-      "Bussy, J. H. de"
-    ],
+    "author_7xx_search": ["Bussy, J. H. de"],
+    "author_person_facet": ["Bussy, J. H. de"],
     "author_sort": "􏿿 Kaart van ZuidAfrika",
-    "author_person_display": [
-      "Bussy, J. H. de"
-    ],
-    "author_person_full_display": [
-      "Bussy, J. H. de"
-    ],
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps",
-      "Africa, Southern"
-    ],
+    "author_person_display": ["Bussy, J. H. de"],
+    "author_person_full_display": ["Bussy, J. H. de"],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps", "Africa, Southern"],
     "subject_all_search": [
       "map",
       "Digital maps",
       "Africa--Maps",
       "Africa, Southern"
     ],
-    "geographic_facet": [
-      "Africa--Maps",
-      "Africa, Southern"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "34 x 41 cm"
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/qb438pg7646"
-    ],
-    "pub_search": [
-      "Amsterdam"
-    ],
+    "geographic_facet": ["Africa--Maps", "Africa, Southern"],
+    "format_main_ssim": ["Map"],
+    "physical": ["34 x 41 cm"],
+    "url_suppl": ["https://purl.stanford.edu/qb438pg7646"],
+    "pub_search": ["Amsterdam"],
     "pub_year_isi": 1890,
     "pub_date_sort": "1890",
     "pub_year_w_approx_isi": 1890,
@@ -1029,47 +626,21 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_0500.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_0500.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
-    "author_no_collector_ssim": [
-      "Bussy, J. H. de"
-    ],
+    "author_no_collector_ssim": ["Bussy, J. H. de"],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(E 14°--E 34°/S 21°--S 35°)"
-    ],
+    "coordinates_tesim": ["(E 14°--E 34°/S 21°--S 35°)"],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(14.0, 34.0, -21.0, -35.0)"
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": ["ENVELOPE(14.0, 34.0, -21.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_0500"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "10513"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "8963"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/zm589dr6916%2FAM_0500/info.json"
     ],
@@ -1090,9 +661,7 @@
     "id": "by513wd0839",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1103,43 +672,22 @@
     "title_245a_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers",
     "title_display": "Map illustrating Mr. A. Sharpe's journey from Lake Nyassa to the Loangwa & Upper Zambezi Rivers",
     "author_1xx_search": "Shawe, W.",
-    "author_7xx_search": [
-      "Royal Geographical Society (Great Britain)"
-    ],
-    "author_person_facet": [
-      "Shawe, W."
-    ],
-    "author_other_facet": [
-      "Royal Geographical Society (Great Britain)"
-    ],
+    "author_7xx_search": ["Royal Geographical Society (Great Britain)"],
+    "author_person_facet": ["Shawe, W."],
+    "author_other_facet": ["Royal Geographical Society (Great Britain)"],
     "author_sort": "Shawe WMap illustrating Mr A Sharpes journey from Lake Nyassa to the Loangwa  Upper Zambezi Rivers",
-    "author_corp_display": [
-      "Royal Geographical Society (Great Britain)"
-    ],
-    "author_person_display": [
-      "Shawe, W."
-    ],
-    "author_person_full_display": [
-      "Shawe, W."
-    ],
+    "author_corp_display": ["Royal Geographical Society (Great Britain)"],
+    "author_person_display": ["Shawe, W."],
+    "author_person_full_display": ["Shawe, W."],
     "topic_search": [
       "map",
       "Travel",
       "Discovery and exploration",
       "Discovery and exploration"
     ],
-    "geographic_search": [
-      "Zambia",
-      "Malawi"
-    ],
-    "subject_other_search": [
-      "Sharpe, Alfred, 1853-1935"
-    ],
-    "subject_other_subvy_search": [
-      "Maps",
-      "Maps",
-      "Maps"
-    ],
+    "geographic_search": ["Zambia", "Malawi"],
+    "subject_other_search": ["Sharpe, Alfred, 1853-1935"],
+    "subject_other_subvy_search": ["Maps", "Maps", "Maps"],
     "subject_all_search": [
       "map",
       "Travel",
@@ -1158,26 +706,12 @@
       "Discovery and exploration",
       "Sharpe, Alfred, 1853-1935"
     ],
-    "geographic_facet": [
-      "Zambia",
-      "Malawi"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : col. ; 21 x 21 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "enk",
-      "[London]"
-    ],
+    "geographic_facet": ["Zambia", "Malawi"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : col. ; 21 x 21 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["enk", "[London]"],
     "pub_year_isi": 1890,
     "pub_date_sort": "1890",
     "pub_year_no_approx_isi": 1890,
@@ -1191,43 +725,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "by513wd0839_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["by513wd0839_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(E29°--E35/°S12°--S16°)."
-    ],
+    "coordinates_tesim": ["(E29°--E35/°S12°--S16°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": [],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "by513wd0839_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "6212"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "4155"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/by513wd0839%2Fby513wd0839_00_0001/info.json"
     ],
@@ -1253,9 +764,7 @@
     "id": "ht152fg3281",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1266,51 +775,20 @@
     "title_245a_display": "East Africa",
     "title_display": "East Africa : showing the recently-arranged political boundaries",
     "author_1xx_search": "Royal Geographical Society (Great Britain)",
-    "author_other_facet": [
-      "Royal Geographical Society (Great Britain)"
-    ],
+    "author_other_facet": ["Royal Geographical Society (Great Britain)"],
     "author_sort": "Royal Geographical Society Great BritainEast Africa showing the recentlyarranged political boundaries",
-    "author_corp_display": [
-      "Royal Geographical Society (Great Britain)"
-    ],
-    "topic_search": [
-      "map",
-      "Boundaries"
-    ],
-    "geographic_search": [
-      "Africa, Eastern"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Boundaries",
-      "Africa, Eastern",
-      "Maps"
-    ],
-    "topic_facet": [
-      "Boundaries"
-    ],
-    "geographic_facet": [
-      "Africa, Eastern"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : col. ; 21 x 25 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "enk",
-      "[London]"
-    ],
+    "author_corp_display": ["Royal Geographical Society (Great Britain)"],
+    "topic_search": ["map", "Boundaries"],
+    "geographic_search": ["Africa, Eastern"],
+    "subject_other_subvy_search": ["Maps"],
+    "subject_all_search": ["map", "Boundaries", "Africa, Eastern", "Maps"],
+    "topic_facet": ["Boundaries"],
+    "geographic_facet": ["Africa, Eastern"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : col. ; 21 x 25 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["enk", "[London]"],
     "pub_year_isi": 1887,
     "pub_date_sort": "1887",
     "pub_year_no_approx_isi": 1887,
@@ -1324,43 +802,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "ht152fg3281_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["ht152fg3281_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(E20°--E51°/N37°--S5°)."
-    ],
+    "coordinates_tesim": ["(E20°--E51°/N37°--S5°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(20.0, 51.0, 37.0, -5.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(20.0, 51.0, 37.0, -5.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "ht152fg3281_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "6528"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "4119"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/ht152fg3281%2Fht152fg3281_00_0001/info.json"
     ],
@@ -1386,9 +841,7 @@
     "id": "cx876zn3079",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1401,46 +854,19 @@
     "title_sort": "Plan van de geproclameerde Goud Velden te Witwatersrand ZAR",
     "title_245a_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R.",
     "title_display": "Plan van de geproclameerde Goud Velden te Witwatersrand, Z.A.R",
-    "author_7xx_search": [
-      "Rissik, Johann, 1857-1925"
-    ],
-    "author_person_facet": [
-      "Rissik, Johann, 1857-1925"
-    ],
+    "author_7xx_search": ["Rissik, Johann, 1857-1925"],
+    "author_person_facet": ["Rissik, Johann, 1857-1925"],
     "author_sort": "􏿿 Plan van de geproclameerde Goud Velden te Witwatersrand ZAR",
-    "author_person_display": [
-      "Rissik, Johann, 1857-1925"
-    ],
-    "author_person_full_display": [
-      "Rissik, Johann, 1857-1925"
-    ],
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Digital maps",
-      "Africa--Maps"
-    ],
-    "geographic_facet": [
-      "Africa--Maps"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "12 x 23.5 cm"
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/qb438pg7646"
-    ],
-    "pub_search": [
-      "Pretoria"
-    ],
+    "author_person_display": ["Rissik, Johann, 1857-1925"],
+    "author_person_full_display": ["Rissik, Johann, 1857-1925"],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps"],
+    "subject_all_search": ["map", "Digital maps", "Africa--Maps"],
+    "geographic_facet": ["Africa--Maps"],
+    "format_main_ssim": ["Map"],
+    "physical": ["12 x 23.5 cm"],
+    "url_suppl": ["https://purl.stanford.edu/qb438pg7646"],
+    "pub_search": ["Pretoria"],
     "pub_year_isi": 1886,
     "pub_date_sort": "1886",
     "pub_year_no_approx_isi": 1886,
@@ -1454,47 +880,21 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_0261.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_0261.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
-    "author_no_collector_ssim": [
-      "Rissik, Johann, 1857-1925"
-    ],
+    "author_no_collector_ssim": ["Rissik, Johann, 1857-1925"],
     "box_ssi": null,
-    "coordinates_tesim": [
-
-    ],
+    "coordinates_tesim": [],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": [],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_0261"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "10870"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "8263"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/cx876zn3079%2FAM_0261/info.json"
     ],
@@ -1519,9 +919,7 @@
     "id": "rn350bb9484",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1531,50 +929,27 @@
     "title_sort": "South Africa by Jas Wyld Geographer to the Queen",
     "title_245a_display": "South Africa by Jas Wyld, Geographer to the Queen.",
     "title_display": "South Africa by Jas Wyld, Geographer to the Queen",
-    "author_7xx_search": [
-      "Wyld, James, 1812-1887"
-    ],
-    "author_person_facet": [
-      "Wyld, James, 1812-1887"
-    ],
+    "author_7xx_search": ["Wyld, James, 1812-1887"],
+    "author_person_facet": ["Wyld, James, 1812-1887"],
     "author_sort": "􏿿 South Africa by Jas Wyld Geographer to the Queen",
-    "author_person_display": [
-      "Wyld, James, 1812-1887"
-    ],
-    "author_person_full_display": [
-      "Wyld, James, 1812-1887"
-    ],
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps",
-      "Southern Africa"
-    ],
+    "author_person_display": ["Wyld, James, 1812-1887"],
+    "author_person_full_display": ["Wyld, James, 1812-1887"],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps", "Southern Africa"],
     "subject_all_search": [
       "map",
       "Digital maps",
       "Africa--Maps",
       "Southern Africa"
     ],
-    "geographic_facet": [
-      "Africa--Maps",
-      "Southern Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "52 x 82 cm"
-    ],
+    "geographic_facet": ["Africa--Maps", "Southern Africa"],
+    "format_main_ssim": ["Map"],
+    "physical": ["52 x 82 cm"],
     "url_suppl": [
       "http://purl.stanford.edu/fc567hs5733",
       "https://purl.stanford.edu/qb438pg7646"
     ],
-    "pub_search": [
-      "London"
-    ],
+    "pub_search": ["London"],
     "pub_year_isi": 1886,
     "pub_date_sort": "1886",
     "pub_year_no_approx_isi": 1886,
@@ -1588,47 +963,21 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_604.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_604.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
-    "author_no_collector_ssim": [
-      "Wyld, James, 1812-1887"
-    ],
+    "author_no_collector_ssim": ["Wyld, James, 1812-1887"],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(E 6°59′--E 41°44′/S 5°8′--S 37°32′)"
-    ],
+    "coordinates_tesim": ["(E 6°59′--E 41°44′/S 5°8′--S 37°32′)"],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(6.0, 41.0, -5.0, -37.0)"
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": ["ENVELOPE(6.0, 41.0, -5.0, -37.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_604"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "14944"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "10412"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/rn350bb9484%2FAM_604/info.json"
     ],
@@ -1653,9 +1002,7 @@
     "id": "rg759wj0953",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1666,27 +1013,13 @@
     "title_245a_display": "Africa",
     "title_display": "Africa",
     "author_1xx_search": "Bevan, G. Phillips, 1829?-1889",
-    "author_person_facet": [
-      "Bevan, G. Phillips, 1829?-1889"
-    ],
+    "author_person_facet": ["Bevan, G. Phillips, 1829?-1889"],
     "author_sort": "Bevan G Phillips 18291889Africa",
-    "author_person_display": [
-      "Bevan, G. Phillips, 1829?-1889"
-    ],
-    "author_person_full_display": [
-      "Bevan, G. Phillips, 1829?-1889"
-    ],
-    "topic_search": [
-      "map",
-      "Relief models",
-      "World maps"
-    ],
-    "geographic_search": [
-      "Africa"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
+    "author_person_display": ["Bevan, G. Phillips, 1829?-1889"],
+    "author_person_full_display": ["Bevan, G. Phillips, 1829?-1889"],
+    "topic_search": ["map", "Relief models", "World maps"],
+    "geographic_search": ["Africa"],
+    "subject_other_subvy_search": ["Maps"],
     "subject_all_search": [
       "map",
       "Relief models",
@@ -1694,29 +1027,13 @@
       "Africa",
       "Maps"
     ],
-    "topic_facet": [
-      "Relief models",
-      "World maps"
-    ],
-    "geographic_facet": [
-      "Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 col. map. 22 x 26 cm. on sheet 25 x 30 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "enk",
-      "London"
-    ],
+    "topic_facet": ["Relief models", "World maps"],
+    "geographic_facet": ["Africa"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 col. map. 22 x 26 cm. on sheet 25 x 30 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["enk", "London"],
     "pub_year_isi": 1885,
     "pub_date_sort": "1885",
     "pub_year_no_approx_isi": 1885,
@@ -1736,40 +1053,19 @@
       "rg759wj0953_00_00_0002.jp2",
       "rg759wj0953_00_00_0003.jp2"
     ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W18°--E51°/N37°--S35°)."
-    ],
+    "coordinates_tesim": ["(W18°--E51°/N37°--S35°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "rg759wj0953_00_0003"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "6254"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "11236"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_0003/info.json",
       "https://stacks.stanford.edu/image/iiif/rg759wj0953%2Frg759wj0953_00_00_0001/info.json",
@@ -1810,9 +1106,7 @@
     "id": "pb900ct4951",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1823,60 +1117,25 @@
     "title_245a_display": "Birds eye view of the Soudan and surrounding countries",
     "title_display": "Birds eye view of the Soudan and surrounding countries",
     "author_1xx_search": "Maclure.",
-    "author_7xx_search": [
-      "Macdonald."
-    ],
-    "author_person_facet": [
-      "Maclure.",
-      "Macdonald."
-    ],
+    "author_7xx_search": ["Macdonald."],
+    "author_person_facet": ["Maclure.", "Macdonald."],
     "author_sort": "MaclureBirds eye view of the Soudan and surrounding countries",
-    "author_person_display": [
-      "Maclure.",
-      "Macdonald."
-    ],
-    "author_person_full_display": [
-      "Maclure.",
-      "Macdonald."
-    ],
-    "geographic_search": [
-      "Sudan -"
-    ],
-    "subject_other_subvy_search": [
-      "1884",
-      "Views"
-    ],
-    "subject_all_search": [
-      "Sudan -",
-      "1884",
-      "Views"
-    ],
-    "geographic_facet": [
-      "Sudan -"
-    ],
-    "era_facet": [
-      "1884"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : col."
-    ],
+    "author_person_display": ["Maclure.", "Macdonald."],
+    "author_person_full_display": ["Maclure.", "Macdonald."],
+    "geographic_search": ["Sudan -"],
+    "subject_other_subvy_search": ["1884", "Views"],
+    "subject_all_search": ["Sudan -", "1884", "Views"],
+    "geographic_facet": ["Sudan -"],
+    "era_facet": ["1884"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : col."],
     "toc_search": [
       "With portraits of General Gordon and Colonel Stewart, and four inset views of Khartoum and other notable sites.",
       "With tables giving distances between most important towns."
     ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "enk",
-      "[S.l.]"
-    ],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["enk", "[S.l.]"],
     "pub_year_isi": 1884,
     "pub_date_sort": "1884",
     "pub_year_no_approx_isi": 1884,
@@ -1890,40 +1149,19 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "pb900ct4951_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["pb900ct4951_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(E12°--E54°/N35°--N6°)."
-    ],
+    "coordinates_tesim": ["(E12°--E54°/N35°--N6°)."],
     "folder_ssi": null,
-    "geographic_srpt": [
-      "ENVELOPE(12.0, 54.0, 35.0, 6.0)"
-    ],
+    "geographic_srpt": ["ENVELOPE(12.0, 54.0, 35.0, 6.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "pb900ct4951_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "13897"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9834"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/pb900ct4951%2Fpb900ct4951_00_0001/info.json"
     ],
@@ -1947,9 +1185,7 @@
     "id": "gm036df2527",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -1976,34 +1212,17 @@
       "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
       "Williams, W. (Wellington)"
     ],
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Digital maps",
-      "Africa--Maps"
-    ],
-    "geographic_facet": [
-      "Africa--Maps"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "27 x 34 cm"
-    ],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps"],
+    "subject_all_search": ["map", "Digital maps", "Africa--Maps"],
+    "geographic_facet": ["Africa--Maps"],
+    "format_main_ssim": ["Map"],
+    "physical": ["27 x 34 cm"],
     "url_suppl": [
       "http://purl.stanford.edu/px984sn6906",
       "https://purl.stanford.edu/qb438pg7646"
     ],
-    "pub_search": [
-      "Philadelphia"
-    ],
+    "pub_search": ["Philadelphia"],
     "pub_year_isi": 1881,
     "pub_date_sort": "1881",
     "pub_year_no_approx_isi": 1881,
@@ -2017,12 +1236,8 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_0100.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_0100.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
@@ -2031,34 +1246,14 @@
       "Williams, W. (Wellington)"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W 18°--E 51°/N 37°--S 35°)"
-    ],
+    "coordinates_tesim": ["(W 18°--E 51°/N 37°--S 35°)"],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_0100"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "8686"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "7557"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/gm036df2527%2FAM_0100/info.json"
     ],
@@ -2083,9 +1278,7 @@
     "id": "wr055hy7401",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -2096,10 +1289,7 @@
     "title_245a_display": "Nordwest-Afrika",
     "title_display": "Nordwest-Afrika",
     "author_1xx_search": "Petermann, August.",
-    "author_7xx_search": [
-      "Hanemann, Fritz.",
-      "Habenicht, Hermann."
-    ],
+    "author_7xx_search": ["Hanemann, Fritz.", "Habenicht, Hermann."],
     "author_person_facet": [
       "Petermann, August.",
       "Hanemann, Fritz.",
@@ -2123,13 +1313,7 @@
       "Gold Coast",
       "Senegambia"
     ],
-    "subject_other_subvy_search": [
-      "Maps",
-      "Maps",
-      "Maps",
-      "Maps",
-      "Maps"
-    ],
+    "subject_other_subvy_search": ["Maps", "Maps", "Maps", "Maps", "Maps"],
     "subject_all_search": [
       "Africa, North",
       "Africa, West",
@@ -2149,22 +1333,11 @@
       "Gold Coast",
       "Senegambia"
     ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "German"
-    ],
-    "physical": [
-      "1 Map. : col ; 43 x 36 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "gw",
-      "Gotha"
-    ],
+    "format_main_ssim": ["Map"],
+    "language": ["German"],
+    "physical": ["1 Map. : col ; 43 x 36 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["gw", "Gotha"],
     "pub_year_isi": 1881,
     "pub_date_sort": "1881",
     "pub_year_no_approx_isi": 1881,
@@ -2178,40 +1351,19 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "wr055hy7401_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["wr055hy7401_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W30°--E20°/N37°--S2°)."
-    ],
+    "coordinates_tesim": ["(W30°--E20°/N37°--S2°)."],
     "folder_ssi": null,
-    "geographic_srpt": [
-      "ENVELOPE(-30.0, 20.0, 37.0, -2.0)"
-    ],
+    "geographic_srpt": ["ENVELOPE(-30.0, 20.0, 37.0, -2.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "wr055hy7401_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "11416"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9342"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/wr055hy7401%2Fwr055hy7401_00_0001/info.json"
     ],
@@ -2227,17 +1379,13 @@
     "full_image_url_ssm": [
       "https://stacks.stanford.edu/image/iiif/wr055hy7401%2Fwr055hy7401_00_0001/full/!3000,3000/0/default.jpg"
     ],
-    "general_notes_ssim": [
-      "Stieler's Hand-Atlas No. 69. - with 3 insets."
-    ]
+    "general_notes_ssim": ["Stieler's Hand-Atlas No. 69. - with 3 insets."]
   },
   {
     "id": "qy240vt8937",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -2247,51 +1395,22 @@
     "title_sort": "Africa",
     "title_245a_display": "Africa.",
     "title_display": "Africa",
-    "author_7xx_search": [
-      "Tallis, John, 1817-1876",
-      "Rapkin, J."
-    ],
-    "author_person_facet": [
-      "Tallis, John, 1817-1876",
-      "Rapkin, J."
-    ],
+    "author_7xx_search": ["Tallis, John, 1817-1876", "Rapkin, J."],
+    "author_person_facet": ["Tallis, John, 1817-1876", "Rapkin, J."],
     "author_sort": "􏿿 Africa",
-    "author_person_display": [
-      "Tallis, John, 1817-1876",
-      "Rapkin, J."
-    ],
-    "author_person_full_display": [
-      "Tallis, John, 1817-1876",
-      "Rapkin, J."
-    ],
-    "topic_search": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_search": [
-      "Africa--Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Digital maps",
-      "Africa--Maps"
-    ],
-    "geographic_facet": [
-      "Africa--Maps"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "physical": [
-      "24 x 32 cm"
-    ],
+    "author_person_display": ["Tallis, John, 1817-1876", "Rapkin, J."],
+    "author_person_full_display": ["Tallis, John, 1817-1876", "Rapkin, J."],
+    "topic_search": ["map", "Digital maps"],
+    "geographic_search": ["Africa--Maps"],
+    "subject_all_search": ["map", "Digital maps", "Africa--Maps"],
+    "geographic_facet": ["Africa--Maps"],
+    "format_main_ssim": ["Map"],
+    "physical": ["24 x 32 cm"],
     "url_suppl": [
       "http://purl.stanford.edu/zm534vp6363",
       "https://purl.stanford.edu/qb438pg7646"
     ],
-    "pub_search": [
-      "London"
-    ],
+    "pub_search": ["London"],
     "pub_year_isi": 1880,
     "pub_date_sort": "1880",
     "pub_year_no_approx_isi": 1880,
@@ -2305,48 +1424,21 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "AM_0250.jp2"
-    ],
-    "collection": [
-      "qb438pg7646"
-    ],
+    "file_id": ["AM_0250.jp2"],
+    "collection": ["qb438pg7646"],
     "collection_with_title": [
       "qb438pg7646-|-Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865"
     ],
-    "author_no_collector_ssim": [
-      "Tallis, John, 1817-1876",
-      "Rapkin, J."
-    ],
+    "author_no_collector_ssim": ["Tallis, John, 1817-1876", "Rapkin, J."],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W 18°--E 51°/N 37°--S 35°)"
-    ],
+    "coordinates_tesim": ["(W 18°--E 51°/N 37°--S 35°)"],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map",
-      "Digital maps"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map", "Digital maps"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "image"
-    ],
-    "content_metadata_type_ssm": [
-      "image"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "AM_0250"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "11036"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9084"
-    ],
+    "content_metadata_type_ssim": ["image"],
+    "content_metadata_type_ssm": ["image"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/qy240vt8937%2FAM_0250/info.json"
     ],
@@ -2372,9 +1464,7 @@
     "id": "fx703zs6529",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -2389,9 +1479,7 @@
     "title_245a_display": "Afrika im Massstab v. 1:25.000.000",
     "title_display": "Afrika im Massstab v. 1:25.000.000",
     "author_1xx_search": "Petermann, A. (August), 1822-1878",
-    "author_7xx_search": [
-      "Habenicht, H."
-    ],
+    "author_7xx_search": ["Habenicht, H."],
     "author_person_facet": [
       "Petermann, A. (August), 1822-1878",
       "Habenicht, H."
@@ -2405,39 +1493,16 @@
       "Petermann, A. (August), 1822-1878",
       "Habenicht, H."
     ],
-    "topic_search": [
-      "map"
-    ],
-    "geographic_search": [
-      "Africa"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Africa",
-      "Maps"
-    ],
-    "geographic_facet": [
-      "Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "German"
-    ],
-    "physical": [
-      "1 map : col. ; 34 x 40 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "gw",
-      "Gotha"
-    ],
+    "topic_search": ["map"],
+    "geographic_search": ["Africa"],
+    "subject_other_subvy_search": ["Maps"],
+    "subject_all_search": ["map", "Africa", "Maps"],
+    "geographic_facet": ["Africa"],
+    "format_main_ssim": ["Map"],
+    "language": ["German"],
+    "physical": ["1 map : col. ; 34 x 40 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["gw", "Gotha"],
     "pub_year_isi": 1880,
     "pub_date_sort": "1880",
     "pub_year_no_approx_isi": 1880,
@@ -2451,43 +1516,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "fx703zs6529_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["fx703zs6529_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W18°--E73°/N37°--S34°)."
-    ],
+    "coordinates_tesim": ["(W18°--E73°/N37°--S34°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 73.0, 37.0, -34.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 73.0, 37.0, -34.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "fx703zs6529_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "11423"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "9431"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/fx703zs6529%2Ffx703zs6529_00_0001/info.json"
     ],
@@ -2514,9 +1556,7 @@
     "id": "qy458yc1855",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -2527,49 +1567,20 @@
     "title_245a_display": "Afrique",
     "title_display": "Afrique",
     "author_1xx_search": "Andriveau-Goujon, E. (Eugène), 1832-1897",
-    "author_person_facet": [
-      "Andriveau-Goujon, E. (Eugène), 1832-1897"
-    ],
+    "author_person_facet": ["Andriveau-Goujon, E. (Eugène), 1832-1897"],
     "author_sort": "AndriveauGoujon E Eugène 18321897Afrique",
-    "author_person_display": [
-      "Andriveau-Goujon, E. (Eugène), 1832-1897"
-    ],
-    "author_person_full_display": [
-      "Andriveau-Goujon, E. (Eugène), 1832-1897"
-    ],
-    "topic_search": [
-      "map"
-    ],
-    "geographic_search": [
-      "Africa"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Africa",
-      "Maps"
-    ],
-    "geographic_facet": [
-      "Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "French"
-    ],
-    "physical": [
-      "1 map : hand col. ; 61 x 45 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "fr",
-      "Paris"
-    ],
+    "author_person_display": ["Andriveau-Goujon, E. (Eugène), 1832-1897"],
+    "author_person_full_display": ["Andriveau-Goujon, E. (Eugène), 1832-1897"],
+    "topic_search": ["map"],
+    "geographic_search": ["Africa"],
+    "subject_other_subvy_search": ["Maps"],
+    "subject_all_search": ["map", "Africa", "Maps"],
+    "geographic_facet": ["Africa"],
+    "format_main_ssim": ["Map"],
+    "language": ["French"],
+    "physical": ["1 map : hand col. ; 61 x 45 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["fr", "Paris"],
     "pub_year_isi": 1880,
     "pub_date_sort": "1880",
     "pub_year_no_approx_isi": 1880,
@@ -2583,43 +1594,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "qy458yc1855_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["qy458yc1855_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W18°--E51°/N37°--S35°)."
-    ],
+    "coordinates_tesim": ["(W18°--E51°/N37°--S35°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-18.0, 51.0, 37.0, -35.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-18.0, 51.0, 37.0, -35.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "qy458yc1855_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "16810"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "12784"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/qy458yc1855%2Fqy458yc1855_00_0001/info.json"
     ],
@@ -2644,9 +1632,7 @@
     "id": "ct493wg6431",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "exhibit_default-exhibit_tags_ssim": null,
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
@@ -2657,58 +1643,23 @@
     "title_245a_display": "Africa",
     "title_display": "Africa",
     "author_1xx_search": "Bartholomew, John, 1831-1893",
-    "author_7xx_search": [
-      "Adam and Charles Black (Firm)"
-    ],
-    "author_person_facet": [
-      "Bartholomew, John, 1831-1893"
-    ],
-    "author_other_facet": [
-      "Adam and Charles Black (Firm)"
-    ],
+    "author_7xx_search": ["Adam and Charles Black (Firm)"],
+    "author_person_facet": ["Bartholomew, John, 1831-1893"],
+    "author_other_facet": ["Adam and Charles Black (Firm)"],
     "author_sort": "Bartholomew John 18311893Africa",
-    "author_corp_display": [
-      "Adam and Charles Black (Firm)"
-    ],
-    "author_person_display": [
-      "Bartholomew, John, 1831-1893"
-    ],
-    "author_person_full_display": [
-      "Bartholomew, John, 1831-1893"
-    ],
-    "topic_search": [
-      "map"
-    ],
-    "geographic_search": [
-      "Africa"
-    ],
-    "subject_other_subvy_search": [
-      "Maps"
-    ],
-    "subject_all_search": [
-      "map",
-      "Africa",
-      "Maps"
-    ],
-    "geographic_facet": [
-      "Africa"
-    ],
-    "format_main_ssim": [
-      "Map"
-    ],
-    "language": [
-      "English"
-    ],
-    "physical": [
-      "1 map : hand col. ; 53 x 42 cm."
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/ct961sj2730"
-    ],
-    "pub_search": [
-      "stk",
-      "Edinburgh"
-    ],
+    "author_corp_display": ["Adam and Charles Black (Firm)"],
+    "author_person_display": ["Bartholomew, John, 1831-1893"],
+    "author_person_full_display": ["Bartholomew, John, 1831-1893"],
+    "topic_search": ["map"],
+    "geographic_search": ["Africa"],
+    "subject_other_subvy_search": ["Maps"],
+    "subject_all_search": ["map", "Africa", "Maps"],
+    "geographic_facet": ["Africa"],
+    "format_main_ssim": ["Map"],
+    "language": ["English"],
+    "physical": ["1 map : hand col. ; 53 x 42 cm."],
+    "url_suppl": ["https://purl.stanford.edu/ct961sj2730"],
+    "pub_search": ["stk", "Edinburgh"],
     "pub_year_isi": 1879,
     "pub_date_sort": "1879",
     "pub_year_no_approx_isi": 1879,
@@ -2722,43 +1673,20 @@
     "access_facet": "Online",
     "display_type": "image",
     "building_facet": "Stanford Digital Repository",
-    "file_id": [
-      "ct493wg6431_00_0001.jp2"
-    ],
-    "collection": [
-      "ct961sj2730"
-    ],
+    "file_id": ["ct493wg6431_00_0001.jp2"],
+    "collection": ["ct961sj2730"],
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
     "box_ssi": null,
-    "coordinates_tesim": [
-      "(W20°--E50°/N40°--S40°)."
-    ],
+    "coordinates_tesim": ["(W20°--E50°/N40°--S40°)."],
     "folder_ssi": null,
-    "genre_ssim": [
-      "map"
-    ],
-    "geographic_srpt": [
-      "ENVELOPE(-20.0, 50.0, 40.0, -40.0)"
-    ],
+    "genre_ssim": ["map"],
+    "geographic_srpt": ["ENVELOPE(-20.0, 50.0, 40.0, -40.0)"],
     "location_ssi": null,
     "series_ssi": null,
-    "content_metadata_type_ssim": [
-      "map"
-    ],
-    "content_metadata_type_ssm": [
-      "map"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "ct493wg6431_00_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "11069"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "14750"
-    ],
+    "content_metadata_type_ssim": ["map"],
+    "content_metadata_type_ssm": ["map"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/ct493wg6431%2Fct493wg6431_00_0001/info.json"
     ],
@@ -2785,18 +1713,27 @@
     "id": "zy575vf8599",
     "exhibit_default-exhibit_public_bsi": true,
     "spotlight_exhibit_slug_default-exhibit_bsi": true,
-    "spotlight_exhibit_slugs_ssim": [
-      "default-exhibit"
-    ],
+    "spotlight_exhibit_slugs_ssim": ["default-exhibit"],
     "spotlight_resource_id_ssim": null,
     "spotlight_resource_type_ssim": "dor_harvesters",
     "collection": ["ms016pb9280"],
-    "collection_with_title": ["Edward A. Feigenbaum papers, 1950-2007 (inclusive)-|-ms016pb9280"],
+    "collection_with_title": [
+      "Edward A. Feigenbaum papers, 1950-2007 (inclusive)-|-ms016pb9280"
+    ],
     "author_person_facet": ["A. Rosenfeld"],
     "author_person_display": ["A. Rosenfeld"],
     "author_person_full_display": ["A. Rosenfeld"],
-    "topic_display": ["Proposal", "Artificial intelligence", "Expert systems (Computer science)", "Computer science"],
-    "topic_facet": ["Artificial intelligence", "Expert systems (Computer science)", "Computer science"],
+    "topic_display": [
+      "Proposal",
+      "Artificial intelligence",
+      "Expert systems (Computer science)",
+      "Computer science"
+    ],
+    "topic_facet": [
+      "Artificial intelligence",
+      "Expert systems (Computer science)",
+      "Computer science"
+    ],
     "format_main_ssim": ["Book"],
     "language": ["English"],
     "physical": ["1 document ; 25 pages"],
@@ -2807,18 +1744,147 @@
     "identifier_ssim": ["SC0340_1986-052_zy575vf8599"],
     "content_metadata_type_ssim": ["book"],
     "content_metadata_type_ssm": ["book"],
-    "content_metadata_first_image_file_name_ssm": ["zy575vf8599_00001"],
-    "content_metadata_first_image_width_ssm": ["2635"],
-    "content_metadata_first_image_height_ssm": ["3423"],
-    "content_metadata_image_iiif_info_ssm": ["https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/info.json", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/info.json"],
-    "thumbnail_square_url_ssm": ["https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/square/100,100/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/square/100,100/0/default.jpg"],
-    "thumbnail_url_ssm": ["https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/full/!400,400/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/full/!400,400/0/default.jpg"],
-    "large_image_url_ssm": ["https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/full/!1000,1000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/full/!1000,1000/0/default.jpg"],
-    "full_image_url_ssm": ["https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/full/!3000,3000/0/default.jpg", "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/full/!3000,3000/0/default.jpg"],
+    "content_metadata_image_iiif_info_ssm": [
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/info.json",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/info.json"
+    ],
+    "thumbnail_square_url_ssm": [
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/square/100,100/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/square/100,100/0/default.jpg"
+    ],
+    "thumbnail_url_ssm": [
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/full/!400,400/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/full/!400,400/0/default.jpg"
+    ],
+    "large_image_url_ssm": [
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/full/!1000,1000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/full/!1000,1000/0/default.jpg"
+    ],
+    "full_image_url_ssm": [
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00001/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00002/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00003/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00004/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00005/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00006/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00007/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00008/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00009/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00010/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00011/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00012/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00013/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00014/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00015/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00016/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00017/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00018/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00019/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00020/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00021/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00022/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00023/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00024/full/!3000,3000/0/default.jpg",
+      "https://stacks.stanford.edu/image/iiif/zy575vf8599%2Fzy575vf8599_00025/full/!3000,3000/0/default.jpg"
+    ],
     "donor_tags_ssim": ["AI", "ARPA", "CS 225"],
     "general_notes_ssim": ["Proposal (1975/7); p. 25"],
     "identifier_displayLabel_ssim": ["Source ID-|-SC0340_1986-052_zy575vf8599"],
-    "repository_ssim": ["Stanford University. Libraries. Department of Special Collections and University Archives"],
+    "repository_ssim": [
+      "Stanford University. Libraries. Department of Special Collections and University Archives"
+    ],
     "modsxml": "\u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e\n\u003cmods xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.loc.gov/mods/v3\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd\" version=\"3.5\"\u003e\n  \u003ctypeOfResource\u003etext\u003c/typeOfResource\u003e\n  \u003cgenre\u003eProposal\u003c/genre\u003e\n  \u003ctitleInfo\u003e\n    \u003ctitle\u003eProposal to ARPA and \"Computer Vision\" by A. Rosenfeld, July 28, 1975\u003c/title\u003e\n  \u003c/titleInfo\u003e\n  \u003cname type=\"personal\" usage=\"primary\"\u003e\n    \u003cnamePart\u003eA. Rosenfeld\u003c/namePart\u003e\n    \u003crole\u003e\n      \u003croleTerm type=\"text\" authority=\"marcrelator\" authorityURI=\"http://id.loc.gov/vocabulary/relators\" valueURI=\"http://id.loc.gov/vocabulary/relators/cre\"\u003eCreator\u003c/roleTerm\u003e\n    \u003c/role\u003e\n  \u003c/name\u003e\n  \u003coriginInfo\u003e\n    \u003cdateCreated encoding=\"w3cdtf\" keyDate=\"yes\"\u003e1975-7\u003c/dateCreated\u003e\n    \u003cissuance\u003emonographic\u003c/issuance\u003e\n  \u003c/originInfo\u003e\n  \u003cphysicalDescription\u003e\n    \u003cextent\u003e1 document ; 25 pages\u003c/extent\u003e\n    \u003cdigitalOrigin\u003ereformatted digital\u003c/digitalOrigin\u003e\n    \u003cinternetMediaType\u003eapplication/pdf\u003c/internetMediaType\u003e\n  \u003c/physicalDescription\u003e\n  \u003cnote type=\"preferred citation\"\u003eCall Number: SC0340, Accession: 1986-052, Box: 39, Folder: 1, Title: AI Handbook 1975\u003c/note\u003e\n  \u003cnote displayLabel=\"Donor tags\"\u003eAI\u003c/note\u003e\n  \u003cnote displayLabel=\"Donor tags\"\u003eARPA\u003c/note\u003e\n  \u003cnote displayLabel=\"Donor tags\"\u003eCS 225\u003c/note\u003e\n  \u003cnote\u003eProposal (1975/7); p. 25\u003c/note\u003e\n  \u003csubject authority=\"lcsh\" valueURI=\"http://id.loc.gov/authorities/subjects/sh85008180\"\u003e\n    \u003ctopic\u003eArtificial intelligence\u003c/topic\u003e\n  \u003c/subject\u003e\n  \u003csubject authority=\"lcsh\" valueURI=\"http://id.loc.gov/authorities/subjects/sh85046450\"\u003e\n    \u003ctopic\u003eExpert systems (Computer science)\u003c/topic\u003e\n  \u003c/subject\u003e\n  \u003csubject authority=\"lcsh\" valueURI=\"http://id.loc.gov/authorities/subjects/sh89003285\"\u003e\n    \u003ctopic\u003eComputer science\u003c/topic\u003e\n  \u003c/subject\u003e\n  \u003clocation\u003e\n    \u003cphysicalLocation type=\"repository\" displayLabel=\"Repository\" authorityURI=\"http://id.loc.gov/authorities/names\" valueURI=\"http://id.loc.gov/authorities/names/no2014019980\"\u003eStanford University. Libraries. Department of Special Collections and University Archives\u003c/physicalLocation\u003e\n    \u003cphysicalLocation\u003eCall Number: SC0340, Accession: 1986-052, Box: 39, Folder: 1\u003c/physicalLocation\u003e\n  \u003c/location\u003e\n  \u003cidentifier type=\"local\" displayLabel=\"Source ID\"\u003eSC0340_1986-052_zy575vf8599\u003c/identifier\u003e\n  \u003clanguage\u003e\n    \u003clanguageTerm type=\"code\" authority=\"iso639-2b\"\u003eeng\u003c/languageTerm\u003e\n  \u003c/language\u003e\n  \u003crecordInfo\u003e\n    \u003clanguageOfCataloging\u003e\n      \u003clanguageTerm authority=\"iso639-2b\"\u003eeng\u003c/languageTerm\u003e\n    \u003c/languageOfCataloging\u003e\n    \u003crecordContentSource authority=\"marcorg\"\u003eCSt\u003c/recordContentSource\u003e\n    \u003crecordOrigin\u003eDescription mapped to MODS from SaltWorks, original scanned file name: SC340_1986-052_b39_f01_i0007.\u003c/recordOrigin\u003e\n  \u003c/recordInfo\u003e\n  \u003crelatedItem type=\"host\"\u003e\n    \u003ctitleInfo\u003e\n      \u003ctitle\u003eEdward A. Feigenbaum papers, 1950-2007 (inclusive)\u003c/title\u003e\n    \u003c/titleInfo\u003e\n    \u003clocation\u003e\n      \u003curl\u003ehttps://purl.stanford.edu/ms016pb9280\u003c/url\u003e\n    \u003c/location\u003e\n    \u003ctypeOfResource collection=\"yes\"/\u003e\n  \u003c/relatedItem\u003e\n  \u003caccessCondition type=\"useAndReproduction\"\u003eThe materials are open for research use and may be used freely for non-commercial purposes with an attribution. For commercial permission requests, please contact the Stanford University Archives (universityarchives@stanford.edu).\u003c/accessCondition\u003e\n\u003c/mods\u003e\n",
     "druid": "zy575vf8599",
     "url_fulltext": ["https://purl.stanford.edu/zy575vf8599"],
@@ -2837,55 +1903,24 @@
     "series_ssi": "1986-052",
     "folder_name_ssi": "AI Handbook 1975",
     "iiif_manifest_url_ssi": "https://purl.stanford.edu/zy575vf8599/iiif/manifest",
-    "full_text_tesimv": ["f \" CS\u003eZ7$: /. i n - 4x THE PROPOSAL This proposal specifies both our long term direction and our specific as planned for the next two years. We relate these goals to goals past progress, immediate practical needs, and long term scientific objectives. Since many of the scientific objectives cited are deep and demanding, readers should understand that considerably more than two years will be required for full solution. THE FOUNDATIONS From the beginning our purpose has been to make machines more intelligent, \" partly to make them intelligence. more useful and partly to learn about the nature of Certainly the need to make machines smarter is clear. It is also clear that the ideas of Artificial Intelligence are the principal scientific path toward making machines smarter. How soon will it happen and how much will it cost? What makes prediction difficult, of course, is the non-linear relationship between the level of technical development and the payoff. For any combination of Artificial Intelligence paired with a need, there is some threshold on costs and capabilities such that on and on the other, revolution. The pocket calculator phenomenon is one example of this that is known to everyone. the corner. one side, little happens, The pocket computer is around We believe that there are many areas in which Artificial Intelligence will produce its own revolutions resembling that of the pocket calculator in their swiftness. i \" Two particularly promising areas are these: ! * DRAFT: JULY 1, 1975 D PROPOSAL TO ARPA 2 \" The combination of large data base handling, intelligent interfacing of software tools and people, and natural language interface engineering. This revolution will be based on a qualitative advance in which programs understand, to a significant degree, the information they are handling; the current technology merely applies manipulative rituals that do not use much of the knowldege embedded in the data bases being manipulated. ??? The application of the ideas of artificial intelligence to computer vision and manipulation for productivity technology, vehicle guidance, and image understanding. Again, the breakthrough will depend on the use of representations of the meanings, uses, and special features of the objects to be sensed and \" manipulated. These are only what we view as immediate areas of maximum opportunity. Many others are suggested by the following sample: \" DRAFT: JULY 1, 1975 \" 3 PROPOSAL TO ARPA SOME AREAS OF APPLICATION Manufacturing Assembling Electronic Systems Assembling Small Mechanical Devices Mining Coal Mining In Dangerous Mines Undersea Recovery Of Manganese Nodules Farming Selective Harvesting With Mixed Crops Pest Control Pruning Repair And Maintenance Vehicle Debugging Floor Care Purposeful Monitoring \" Intelligent Autopilots Shipboard Functions Automatic Programming Management Reports Inventory Control Production Scheduling Quality Control Management Assistance Very Large Data Bases Intelligent PERT Networks Scheduling People and Groups Question Referral News Summarizing Document Draft Polishing \" DRAFT: JULY 1, 1975 Logistics 4 PROPOSAL TO ARPA \" Routing Intelligent Substitution Equipment Sharing Medicine Diagnosis Intensive Care Monitoring Treatment Management Radiation Therapy Setup Education Intelligent CAI Systems Information Retrieval Fire Fighting Fearless Firemen Apparatus Allocation Theft Prevention Trackers How can such objectives be reached? Certainly for smart machines to make an impact in areas like those mentioned, the smart machines must exhibit variety of talents associated with intelligence. a Computer vision, English \" understanding, learning and debugging, and expert problem solving all must be understood. It is natural then that considerable effort has gone into understanding these things. Happily we get back to them both by way of our desire to lay the foundation for applications and by way of our hope to understand intelligence for its own sake. \" DRAFT: JULY 1, 1975 \" GENERAL OBJECTIVE: TO MAKE MACHINES SMARTER TO MAKE MACHINES MORE USEFUL \" PROPOSAL TO ARPA 5 TO UNDERSTAND INTELLIGENCE Areas Of Application Systems To Be Understood Intelligent Terminals Image And Scene Analysis Very Large Data Bases Speech And Text Understanding Remote Guidance Learning and Debugging Photo Interpretation Expert Problem Solving Logistics Common Sense Reasoning Purposeful Monitoring Goal Understanding Repair And Maintenance Cleaning Manufacturing and Mining Medicine Education As the diagram suggests, it has been sensible during the gestation years to \" be organized around themes like computer vision, English undestanding, learning and debugging, and expert problem solving. It is through these particular thrusts that we have learned a great deal about what regarded as central theoretical issues: are now DRAFT: JULY 1, 1975 PROPOSAL TO ARPA 6 \" SOME CENTRAL THEORETICAL ISSUES Knowledge Representation Constraint Exploitation Search And Control Classification And Deduction Programming Methodology Goal Directed Versus Bottom Up Grouping Serial Versus Parallel THE FUTURE The Structure OJ The Laboratory Is Evolving With The Science The Artificial Intelligence Laboratory is widely recognized as one of the world's principal sources of ideas, experimental prototypes, and feasibility demonstrations on the frontier of computer science. It would not be \" appropriate for the laboratory to concentrate on producing operational systems in areas like that of very large data bases, but it does seem appropriate to begin thinking in terms of what AI can lead to in the near term and to begin producing the basic research results lying just in front of prototype production. To this end, we now see ourselves organized into a new structure that draws not only from the desire to understand various dimensions of intelligence but also from a more direct interest in applications challenges on one side and an interest in the emerging central issues on the other. Manifestly the boundaries are to be soft, not hard, and as has been common in the past, much flow among the particular subgroups is expected. \" DRAFT: JULY 1, 1975 \" 7 PROPOSAL TO ARPA Applications Oriented Basic Studies Because natural language research has made much progress along with parallel advances in our theories of knowledge, a considerable portion of our resources should be assigned to a unified program on very large data bases, intelligent terminals, and natural language interface engineering. Part of our efforts for the remainder of 1975 will be directed at bringing this area up to speed. Applications Oriented Vision And Manipulation We have spent considerable time and effort in developing facility that is at \" a laboratory once powerful, easy to copy, and relatively inexpensive. It has been developed using electronic circuit board assembly as the test problem. It is now time to redirect the use of this facility to other pressing problems by selecting the best of many alternatives for of this important allocation resource. Fully automatic assembly of small mechanical devices seems appropriate. Part of the image understanding problem also seems to be promising. Issues Oriented Basic Studies The study of basic issues with domains selected to facilitate understanding remains crucial to our program. Within this collection of topics we see continued work on the representation of knowledge, perhaps problem our most pressing area, as well as on expert problem solving, common sense physical reasoning, problem solving by analogy, learning, and constraint driven \" problem solving of the sort exposed by studies in computer vision. This last mentioned work on computer vision is believed to be critical for long PROPOSAL TO ARPA 8 DRAFT: JULY 1, 1975 range progress on visual interpretation problems that require nearly all of a large array of image points to be processed. \" Systems And Systems Concepts _ Progress in Artificial Intelligence is facilitated by adequate equipment. Indeed, many of its great accomplishments have involved programs that too large and to complex to be produced concepts wa have developed. are without the frontier time sharing Now time sharing is well established, but newer, even more revolutionary opportunities have emerged. It therefore seems wise to continue our systems concepts leadership, both because of our own needs in Artificial Intelligence and because of the profound impact we believe these computer ideas will soon have on the computer consuming community. RECENT PROGRESS \" This introduction closes with a summary of recent progress organized around the topics which correspond to our past foci. These are: Representing Knowledge and Expert Problem Solving Understanding Natural Language Understanding Vision Productivity Technology Learning and Debugging Systems and Architecture and New Programs \" DRAFT: JULY 1, 1975 \" 9 PROPOSAL TO ARPA Representing Knowledge And Expert Problem Solving Sussman and his students have made progress in the direction of understanding debugging and the expert problem solving process in the particular domain of electronic circuitry. Sussman and Stallman, for example, completed a program and a paper in March of 1975, \"Heuristic Techniques in Computer Aided Circuit Analysis.\" The program understands circuits well enough to determine proper operating voltages and currents by common-sense reasoning, rather than by solving network equations. now handle the rather complicated circuits found in IC chips. It can Specifically, the circuitry of a UA74I op amp has been successfully analyzed. Experts in the electronics field have shown considerable interest in this new, \" knowledge-based, common sense approach. Sussman believes that the principles will transfer smoothly to other domains and become a general theory of debugging applicable to all engineered systems. Fahlman and Grossman have done extensive work on a new representational scheme which we believe may have considerable consequences with respect to future machine architectures. Fahlman and Grossman argue for a network of nodes and relationships from which knowledge is retrieved by parallel searches along A-KIND-OF and other links. germinating Their thoughts have been over the past year, but the work was too preliminary to allow commitment to writing until recently. Now both Fahlman and Grossman have completed papers which outline theories, propose experiments, and define, in the case of Grossman, specific application possibilities in the very large data base area. New hardware progress in the integrated circuit industry provides some hope that machines oriented toward such searches may become \" practical, given that simulation on serial machines proves the ideas sound. Sandewall has concentrated on the data base problem as well, but with with a view toward dealing with some immediate problems of data base DRAFT: JULY 1, 1975 PROPOSAL TO ARPA 10 He has worked out a block structured organization and self description. scheme capable of handling both procedures and data, designed to -^ooth the interface between programs on one side and a collection of data bases on the other. \" It is expected that his evolving theory will particularly influence our proposed work on very large data bases. prototype system of programs Sandewall has finished a that illustrate his ideas. Understanding Natural Language Pratt and his students have concentrated on the problem of dealing with efficiency issues in parsing natural language text. This effort takes us in the comfortable direction of preparing for the time when real application of natural language systems will make a theoretical understanding of the efficiency issue of great practical importance. Pratt's paper of January, 1975, presents an optimality proof demonstrating that LINGOL's parsing algorithm is optimal among those of its class in the sense that all the \" phrases that it builds up can be used. Meanwhile Marcus has completed the programming of a new parsing based on the wait-and-see philosophy for handling ambiguity. system Instead of picking one option at all decision points with the risk of being stuck with costly retreat, Marcus' system carries all options forward, decision only when the decision can be made with certainty. making a The design of this parser was finished by the end of 1974; implementation took place during 1975 and is just now complete. The next task is to augment the small grammer Marcus has used in debugging his parser with a much more complete grammar, one large enough to be a good interface to various intelligent terminal or large data base modules. Progress has also been made problem of generating language. on the relatively neglected linguistic This involves, among other things, a need \" DRAFT: JULY 1, 1975 11 PROPOSAL TO ARPA jfflj||. to know what the listener already knows. Thesis studying the problem. puts forth, There is McDonald has completed an M.S. no program embodiment of the ideas it but creating and experimenting with such a program seems sensible and is planned. Understanding Vision Gene Freuder has developed a system for visual recognition, implications for the general problem of control. with The system is intended to provide the flexibility required to deal with realistic visual scenes; he is looking at hammers, not stylized models, but everyday, toolbox hammers, under natural occlusion). \" conditions (e.g. lighting, background, orientation, He is studying directly the interaction of knowledge and control required in an integrated pass at the entire task, rather than looking at the attendant problems of image processing in detail. Particular results, as they are acquired, combine with general visual knowledge to \"suggest\" and \"advise\" further processing. This process, called \"active knowledge,\" extends and implements the principles of \"heterarchy\" and \"domain directed processing\" pioneered in this laboratory. Since description has long been regarded as the key to success with any difficult problem in artificial intelligence, Hollerbach's work on describing curved objects is another important step forward. developed an approach towards shape description based He has on prototype modification and generalized cylinders, a notion invented by Binford at Stanford. His programs describe and identify pottery from vase outlines well enough to be remarkably consistent with the descriptions and identifications given by archeologists. \" The resulting descriptions seem very natural and suitable for dealing with many sorts of objects besides pottery. The emphasis throughout has been to develop useful, qualitative PROPOSAL TO ARPA 12 DRAFT: JULY 1, 1975 descriptions which bring out the significant features and subordinate lesser ones. Marr and his students continue to look at vision from another point of \" view, that of concentration on thoroughly understanding the problem of translating image arrays into symbolic descriptions without the intervention of high level knowledge. Their thesis is that real image understanding cannot be done without very solid programs working at this level. This seems directly on the critical path leading toward real image basic work understanding, be it of ordinary scenes or ERTS type data. As of January, 1975, the work had concentrated on discovering what features of one- dimensional intensity profiles could reliably provide information about edge types and such modifiers as sharpness of edge focus. Since then, the edge and edge modifier work has been extended to two dimensions with satisfactory results. The most important work, however, has been on the problem of grouping the very lowest level symbolic descriptions of edges together into larger symbolic aggregates and the subsequent realization that a new theory of texture will result from this work. \" Marr has invented about four new grouping algorithms and prototype programs have been written for them. Some experiments with these prototype programs have been encouraging, but for the experimentation needed, the programs will have to be rewritten for the sake of efficiency. Working with image arrays is time consuming and requires more than the usual attention to program efficiency. Typical of other work directed by Marr is a theory of visual light source detection developed by Ullmann. which were: Several factors were examined, among absolute intensity values, intensity compared with the average illumination in the scene, both local and global contrast, and lightness contrast. A surprising experimental result was that these factors were shown to be insufficient for explaining our ability to detect light in the visual field, even under very simple conditions. sources While high enough \" DRAFT: JULY 1, 1975 \" PROPOSAL TO ARPA 13 contrast, for example, is a sufficient condition for creating the perception of radiance, it was shown that a light source can sometimes be detected in cases where the contrast is very low. A method for detecting light sources was then proposed and implemented, based on the comparison of two ratios: for a given pair of adjacent areas, both intensities-ratio and gradientsratio are computed. should be equal. The method can If neither of the areas is a light source the ratios If they are not equal, one of the areas is a light source. thereby detect the source and compute its intensity. A collection of our previous papers on vision, learning, representation has just been published by McGraw-Hill, under the !___. \" title. and The I. A. Rosenfeld July 28, 1975 \" Computer Vision (\"Vertical Slice\" of the AI chapter of the COSERS book) 1. Nature of the area (including brief history and elementary survey) Perception and cognition, as functions of intelligent beings, are very difficult to separate. A view widely held by psychologists is that perception is an active process, in which environment, and hypotheses are formed about the nature of the sensory information is sought that will confirm or refute these hypotheses. This view of. perception as a form of problem-solving S is held by most researchers in AI. For this reason, research on computer perception is treated here as a part of AI \" . [Only com-. puter vision will be treated here; computer audition, particularly speech understanding, will be covered by R. Reddy.] computer The mid-1950 s marks the onset of serious work on the analysis of images.. Applications that began to be investigated characters, of at that time included the recognition of printed cells in photomicrographs, of \"events\" in photographs of nuclear bubble chambers, and of military targets in aerial photographs. The approaches used belonged to the area now called pattern recognition, rather than AI ; but in those early days, little dis- tinction was made between these areas. Since the early 19605, there has been a marked divergence \" between the pattern recognition and AI approaches to computer analysis of images. The former approach has continued to stress the use of ad hoc image features in combination with statistical I i classification techniques. \" More recently, it has also made use of \"syntactic\" methods in which images are recognized, by a \"parsing\" process, as being built up hierarchically out of primitive con- stituents. The AI approach, by contrast, has employed problem- solving methodologies based on extensive use of knowledge about the class of images (or scenes) to be analyzed. A large number of references on image analysis can be found in (Rosenfeld, 1969, 1972 / 1973, 1974, 1975.) Our review of computer image analysis will cover only work based on the AI approach, to which the term \"computer vision\" is usually restricted. Much of the work on computer vision has dealt with images of scenes containing solid objects viewed from close by. These are the sort of images with which a robot vision system must usually cope in using vision to guide its motor activities, manipulation and locomotion. including The analysis of such images is usually called \"scene analysis\", to distinguish it from the analysis of images that are essentially two-dimensional, such as photomicrographs (which show cross-sections) show projections) , , radiographs (which ...ir '\" satellite imagery (in which terrain relief is negligible), documents, diagrams, maps, etc. However, the methods of computer vision are equally applicable to these latter classes of images; the term need not be restricted to \"three-dimensional\" scene analysis. \" \" 2. T-PRRarch highlights [Note- should be expanded to basic AI principles each program; but I without seeing the draft of the body of the chapter.] This material emphasize the introduced by can't do that computer analysis of scenes conThe pioneering effort in (1965). His objects is due to Roberts taining three-dimensional objects each of which can be scenes contain sets of polyhedral objects, such as recby combining a few primitive constructed prisms. tangular parallepipeds and triangular A photograph of the visible edges of such a scene is digitized, and are detected. \" Straight lines the_ objects are fitted to the detected edge into a line drawing. points, thus converting the photograph are next extracted, and it is Polygons formed by the lines equivalent to polygonal determined whether they are topological^ objects. If so, a projec of any of the \"model\" primitive faces sought that relates the observed tive coordinate transformation is are found In this way, (partial) matches polygon to the model. between the model and the drawing. The program attempts to way, as composed of comaccount for the entire drawing, in this binations of the models. Roberts' program worked well on \"clean\" input in which the was good contrast between lighting was controlled so that there It would have had more trouble faces of the polyhedra. adjacent \" arbitrary lighting conditions, in with noisy data obtained under have been successfully which not all the inter-face edges would would have failed. detected, so that the model matching process I \" The program knew that it was dealing with polyhedra of a certain the de- class, but it was unable to use this knowledge to direct tection of edges in the original picture. It performed only \"bottom-up\" analysis, with little or no provision for backup when trouble is encountered at the higher levels. By contrast, a more recent program, due to Shirai (1973, about, the class 1975) makes much better use of prior knowledge of scenes being analyzed. This program begins by attempting to are expected to detect the most obvious edges in the scene, which be edges between the polyhedra and the background. When this has been done, the program can hypothesize other edges-(particularly, \" those that separate two polyhedra) ledge that only polyhedra are present, , based on its know- and it can then direct these a more sensitive edge detection operator to look for edges at the appropriate locations. Internal edges (dihedral angles) of the individual polyhedra can then be found in turn. At each stage, previous results, in conjunction with models of missing lines. polyhedra, are used to propose the most plausible Unlike the hierarchical program of Roberts, there is no. rigid separation of the processing into \"levels\"; edge detection, line fitting, and model fitting all operate in a cooperative fashion. , This program illustrates the notion of heterarchical as opposed to hierarchical, organization. analysis Since the mid 1960 5, many other significant scene \" programs have been written. Many of these have dealt only with scenes containing polyhedra; and some have even assumed that perfect line drawings of such scenes, rather than images, were \" An important given. contribution on the line drawing level was developed rules for linking regions in made by Guzman (1968), who object; he was thus drawing that (probably) belong to the same . a objects without the use of able to segment the drawing into that bemodels. Falk (1972) used similar rules to link lines long to the same object, and thus overcome some of the problems that arise when lines are missing detected) . Theoretical (i.e., when edges fail to be bases for Guzman's approach established independently by Huffman (1971) were and Clowes (1971). drawings of polyMore recently, rules for interpreting line /Migle, hedra in which a line may represent not only a dihedral developed by Waltz but also a shadow or crack, were demonstrated \" (1975), who of that in a typical scene, only a small fraction (convex or the possible combinations of line interpretations etc.) can be mutually concave dihedral, occluding edge, shadow, consistent. consider scenes A few investigators have also begun to containing curved objects. face shape from shading (1975). Other work has Techniques for reconstructing sur- information are discussed by Horn made use of range data to determine shape, cylinders and or has allowed only developable surfaces (e.g., analysis of cones) Mention should also be made of work on the. . images of human faces (e.g., Kelly (1971)); in this last case, with a known once the face outline is located, one is dealing \" positions. set of facial features in approximately known Over vision the last few years, efforts have begun to apply computer methods to the analysis of natural indoor and outdoor- scenes with some success. , \" indicates, As the above brief review extensive work in scene world\" scenes containing only analysis has been done for \"blocks scenes, or even with polyhedra, but efforts dealing with natural scenes, have only been exmore general classes of artificial to be done in extending compuploratory thus far. Much remains class of situations. In ter vision techniques to a broader dialog with addition, if machines are to engage in effective humans about the machines input allowed) scenes (e.g., Turing's test with image must be able to understand human visual limitations. vision research must Thus computer ing of human Many \" eventually include the model- visual perception processes. X .\" of the challenges facing computer vision research during the coming years are common to other areas of AI as well. effectively structuring Notable among these is the problem of to be representing knowledge about the class of scenes and analyzed. requires In particular, computer vision generally knowledge at a variety of levels; at the \"low\" purpose\") end of the scale, knowledge texture, etc. (or \"general- about illumination, surface is needed, while at the \"high\" (or specialized) of (say) common end, one needs to know about the functions a wide range of knowhousehold objects. Integration of such ledge sources presents a challenging problem. [Analogous remarks understanding area; here the low end can be made in the speech etc., and the high end, involves speech production mechanisms, On the relationship between general-purpose word meanings.] \" computer vision see (Zucker, and special-purpose knowledge in Rosenfeld and Davis, 1975). / \" to Much of the knowledge used in computer vision relates but the \"objects\" that appear in the scene being analyzed; precisely despatial locations of these objects are often not word [Analogously, in speech understanding, phoneme and fined. boundaries are not precisely localizable. ] This suggests the about need for data structures capable of storing information may be mutually in \"fuzzily\" defined entities, many of which compatible. situation contrasted with, may be say, language understanding, where discrete data structures natural should The by be adequate; or with the discrete data structures used Winston (1975) . _*\" r - special Coping with unfamiliar or unexpected -input poses \" challenges to any AI system. Somehow, the system must choose appropriate frames (Minsky, 1975) within which to analyze the preinput; but this choice must itself be based on some sort of liminary analysis of the input. Little is known about the form take; but it presumably that such a preliminary analysis might analysis, should be largely data-driven. In the case of scene the use of local a possible approach to this problem involves input feature detection operations, applied to the scene in a sort of conhighly parallel fashion, perhaps followed by some straint checking procedure, which might take the form of a Hummel, and parallel \"relaxation\" process (e.g., Rosenfeld, Zucker, \" 1975; Tenenbaum, 1975). \" 3. Interfaces being applied to Computer vision techniques are increasingly real-world problems, particularly in Examples of mation. the field of industrial auto- applications include device assembly, circuit board layout, and inspection. Much of this work is still in have progress, but a number of convincing demonstration programs 1980's, computer been written, and it is expected that by the vision will begin to have a significant impact on industrial At the same time, the computer vision approach will practice. be increasingly applied in areas of computer image analysis that reup to now have been the domain of pattern recognition for example, analysis of handwriting, photomicrosearchers ??? \" graphs and radiographs, satellite imagery, and so on. demandComputer vision research has served as an especially realing testing area for AI methodology, since it deals with solve the world, noisy, multidimensional input. The efforts to computer vision problem have thus stimulated the development of solving languages, AI techniques, e.g., in such areas as problem control structures, and computer networks. turn, have spearheaded general advances in the languages and sys- tems area of computer science. \" These techniques, in \" 4. Other topics one to students, and The AI area has long been an attractive Many of the leading computer vision is no exception to this rule. universities in the offer courses on the subject, in addition to courses pattern related non-AI areas of image processing and recognition. large amounts Computer vision research requires exceptionally generally quite voluminous of computer time, since the input is black-and-white TV image occupies over 250,000 bytes standard (one of digital storage), and elaborate processing is usually^, for image In addition, special peripheral devices necessary. \" for such deinput/output are necessary; but the growing market a few tens of vices has made them available for as little as thousands of dollars. field in Funding for basic research in the computer vision year. is currently at a level of $1 to $2 million per the U.S.A. image (The dividing, lines between computer vision, processing, The draw sharply.), and pattern recognition are difficult to NSF, and NASA. major sources of this funding are ARPA, Activities (Carnegieare concentrated at some of the major AI laboratories a few other univerMellon, MIT, SRI, Stanford), as well as at sities (Maryland, Pennsylvania, and NASA's JPL. Outside the Texas, among others) U.S.A., there are centers in several countries, notably Great Britain, Japan, and the U.S.S.R. \" and at The including students number of researchers involved is perhaps 200, The formal publication rate is not and supporting personnel. high (as compared to the rates in image processing or pattern recognition) ; the papers appear primarily in AI meeting proceedings (IJCAI, MI) and in the journal Artificial Intelligence. \" in meeting Unpublished reports and short papers cited.] proceedings have generally not been [Note: References by computer, Computing Rosenfeld (1969), Picture processing A. 147-176. 1, Surveys (1973), Progress in picture processing: 1969 71, 81-108. ibid. 5, 1972, Computer Graphics (1972), Picture processing: Prncp??sina 394-416. 1, and Image Processing 1. (1974), Picture processing: 1973, ibid^_3, (1975), Picture processing: 1974, ibid. 4, 178-194. 133-155. T L ' G Roberts (1965) , Machine perception of dids in J. T. Tippett et al., eds Optical Information three-dimensional C^t^^^Elec^o159-197. , Processing, MIT Press, * line finder for Y. Shirai (1973), A context-sensitive 4, 95-119. of polyhedra, Artificial Intelligence \" recognition^ using knowledge (1975), Analyzing intensity arrays aEout-Bcenes, in P. H. Winston, cd., The^SJ^hp^ogy_ol_Comr^ Vision, McGraw-Hill, 93-113. Decomposition of a visual scene into three _Conf. , 291-304. dimensional bodies, Proc. Fall Joint Computer of imperfect line data as a threeG. Falk (1972), Interpretation 101-144. dimensional scene, Artificial Intelligence 3. A n Guzman (1968), sentences, Huffman (1971), Impossible objects as nonsense eds., Machine Intelligence^, and D. B Edinburgh Univ. Press, 295-323. Intelligence 2, (1971), On seeing things, Artificial Sichie, Meltzer A ii M. B. Clowes 79-116. n Understanding line drawings of scenes with of Computer shadows, in P. H. Winston, cd., The Psychology Vision, McGraw-Hill, 19-91. Waltz (1975) , from shading information, ibid., B. Horn (1975), Obtaining shape 115-155. \" M using (1971), Edge detection in pictures by computer IntelliD. Michie, eds., Machine planning, in B. Meltzer and Press, 297-409. gence 6, Edinburgh Univ. D S. W. Kelly Zucker, A. Rosenfeld, and L. S. Davis (1975), General- purpose models: expectations about the unexpected, Proc. . r \" 4 IJCAI, in press. , Learning structural descriptions from examples, in P. H. Winston, cd., The Psychology of Computer Vision, McGraw-Hill, 157-209. P. H. Winston (1975) M. Minsky (1975), A framework for representing knowledge, ibid. 211-277. , A. Rosenfeld, R. A. Hummel, and S. W. Zucker (1975), Scene labelling by relazation operations, lEEE Trans. SMC, submitted. J. M. Tenenbaum (1975) , personal communication. X X \" "]
+    "full_text_tesimv": [
+      "f \" CS\u003eZ7$: /. i n - 4x THE PROPOSAL This proposal specifies both our long term direction and our specific as planned for the next two years. We relate these goals to goals past progress, immediate practical needs, and long term scientific objectives. Since many of the scientific objectives cited are deep and demanding, readers should understand that considerably more than two years will be required for full solution. THE FOUNDATIONS From the beginning our purpose has been to make machines more intelligent, \" partly to make them intelligence. more useful and partly to learn about the nature of Certainly the need to make machines smarter is clear. It is also clear that the ideas of Artificial Intelligence are the principal scientific path toward making machines smarter. How soon will it happen and how much will it cost? What makes prediction difficult, of course, is the non-linear relationship between the level of technical development and the payoff. For any combination of Artificial Intelligence paired with a need, there is some threshold on costs and capabilities such that on and on the other, revolution. The pocket calculator phenomenon is one example of this that is known to everyone. the corner. one side, little happens, The pocket computer is around We believe that there are many areas in which Artificial Intelligence will produce its own revolutions resembling that of the pocket calculator in their swiftness. i \" Two particularly promising areas are these: ! * DRAFT: JULY 1, 1975 D PROPOSAL TO ARPA 2 \" The combination of large data base handling, intelligent interfacing of software tools and people, and natural language interface engineering. This revolution will be based on a qualitative advance in which programs understand, to a significant degree, the information they are handling; the current technology merely applies manipulative rituals that do not use much of the knowldege embedded in the data bases being manipulated. ??? The application of the ideas of artificial intelligence to computer vision and manipulation for productivity technology, vehicle guidance, and image understanding. Again, the breakthrough will depend on the use of representations of the meanings, uses, and special features of the objects to be sensed and \" manipulated. These are only what we view as immediate areas of maximum opportunity. Many others are suggested by the following sample: \" DRAFT: JULY 1, 1975 \" 3 PROPOSAL TO ARPA SOME AREAS OF APPLICATION Manufacturing Assembling Electronic Systems Assembling Small Mechanical Devices Mining Coal Mining In Dangerous Mines Undersea Recovery Of Manganese Nodules Farming Selective Harvesting With Mixed Crops Pest Control Pruning Repair And Maintenance Vehicle Debugging Floor Care Purposeful Monitoring \" Intelligent Autopilots Shipboard Functions Automatic Programming Management Reports Inventory Control Production Scheduling Quality Control Management Assistance Very Large Data Bases Intelligent PERT Networks Scheduling People and Groups Question Referral News Summarizing Document Draft Polishing \" DRAFT: JULY 1, 1975 Logistics 4 PROPOSAL TO ARPA \" Routing Intelligent Substitution Equipment Sharing Medicine Diagnosis Intensive Care Monitoring Treatment Management Radiation Therapy Setup Education Intelligent CAI Systems Information Retrieval Fire Fighting Fearless Firemen Apparatus Allocation Theft Prevention Trackers How can such objectives be reached? Certainly for smart machines to make an impact in areas like those mentioned, the smart machines must exhibit variety of talents associated with intelligence. a Computer vision, English \" understanding, learning and debugging, and expert problem solving all must be understood. It is natural then that considerable effort has gone into understanding these things. Happily we get back to them both by way of our desire to lay the foundation for applications and by way of our hope to understand intelligence for its own sake. \" DRAFT: JULY 1, 1975 \" GENERAL OBJECTIVE: TO MAKE MACHINES SMARTER TO MAKE MACHINES MORE USEFUL \" PROPOSAL TO ARPA 5 TO UNDERSTAND INTELLIGENCE Areas Of Application Systems To Be Understood Intelligent Terminals Image And Scene Analysis Very Large Data Bases Speech And Text Understanding Remote Guidance Learning and Debugging Photo Interpretation Expert Problem Solving Logistics Common Sense Reasoning Purposeful Monitoring Goal Understanding Repair And Maintenance Cleaning Manufacturing and Mining Medicine Education As the diagram suggests, it has been sensible during the gestation years to \" be organized around themes like computer vision, English undestanding, learning and debugging, and expert problem solving. It is through these particular thrusts that we have learned a great deal about what regarded as central theoretical issues: are now DRAFT: JULY 1, 1975 PROPOSAL TO ARPA 6 \" SOME CENTRAL THEORETICAL ISSUES Knowledge Representation Constraint Exploitation Search And Control Classification And Deduction Programming Methodology Goal Directed Versus Bottom Up Grouping Serial Versus Parallel THE FUTURE The Structure OJ The Laboratory Is Evolving With The Science The Artificial Intelligence Laboratory is widely recognized as one of the world's principal sources of ideas, experimental prototypes, and feasibility demonstrations on the frontier of computer science. It would not be \" appropriate for the laboratory to concentrate on producing operational systems in areas like that of very large data bases, but it does seem appropriate to begin thinking in terms of what AI can lead to in the near term and to begin producing the basic research results lying just in front of prototype production. To this end, we now see ourselves organized into a new structure that draws not only from the desire to understand various dimensions of intelligence but also from a more direct interest in applications challenges on one side and an interest in the emerging central issues on the other. Manifestly the boundaries are to be soft, not hard, and as has been common in the past, much flow among the particular subgroups is expected. \" DRAFT: JULY 1, 1975 \" 7 PROPOSAL TO ARPA Applications Oriented Basic Studies Because natural language research has made much progress along with parallel advances in our theories of knowledge, a considerable portion of our resources should be assigned to a unified program on very large data bases, intelligent terminals, and natural language interface engineering. Part of our efforts for the remainder of 1975 will be directed at bringing this area up to speed. Applications Oriented Vision And Manipulation We have spent considerable time and effort in developing facility that is at \" a laboratory once powerful, easy to copy, and relatively inexpensive. It has been developed using electronic circuit board assembly as the test problem. It is now time to redirect the use of this facility to other pressing problems by selecting the best of many alternatives for of this important allocation resource. Fully automatic assembly of small mechanical devices seems appropriate. Part of the image understanding problem also seems to be promising. Issues Oriented Basic Studies The study of basic issues with domains selected to facilitate understanding remains crucial to our program. Within this collection of topics we see continued work on the representation of knowledge, perhaps problem our most pressing area, as well as on expert problem solving, common sense physical reasoning, problem solving by analogy, learning, and constraint driven \" problem solving of the sort exposed by studies in computer vision. This last mentioned work on computer vision is believed to be critical for long PROPOSAL TO ARPA 8 DRAFT: JULY 1, 1975 range progress on visual interpretation problems that require nearly all of a large array of image points to be processed. \" Systems And Systems Concepts _ Progress in Artificial Intelligence is facilitated by adequate equipment. Indeed, many of its great accomplishments have involved programs that too large and to complex to be produced concepts wa have developed. are without the frontier time sharing Now time sharing is well established, but newer, even more revolutionary opportunities have emerged. It therefore seems wise to continue our systems concepts leadership, both because of our own needs in Artificial Intelligence and because of the profound impact we believe these computer ideas will soon have on the computer consuming community. RECENT PROGRESS \" This introduction closes with a summary of recent progress organized around the topics which correspond to our past foci. These are: Representing Knowledge and Expert Problem Solving Understanding Natural Language Understanding Vision Productivity Technology Learning and Debugging Systems and Architecture and New Programs \" DRAFT: JULY 1, 1975 \" 9 PROPOSAL TO ARPA Representing Knowledge And Expert Problem Solving Sussman and his students have made progress in the direction of understanding debugging and the expert problem solving process in the particular domain of electronic circuitry. Sussman and Stallman, for example, completed a program and a paper in March of 1975, \"Heuristic Techniques in Computer Aided Circuit Analysis.\" The program understands circuits well enough to determine proper operating voltages and currents by common-sense reasoning, rather than by solving network equations. now handle the rather complicated circuits found in IC chips. It can Specifically, the circuitry of a UA74I op amp has been successfully analyzed. Experts in the electronics field have shown considerable interest in this new, \" knowledge-based, common sense approach. Sussman believes that the principles will transfer smoothly to other domains and become a general theory of debugging applicable to all engineered systems. Fahlman and Grossman have done extensive work on a new representational scheme which we believe may have considerable consequences with respect to future machine architectures. Fahlman and Grossman argue for a network of nodes and relationships from which knowledge is retrieved by parallel searches along A-KIND-OF and other links. germinating Their thoughts have been over the past year, but the work was too preliminary to allow commitment to writing until recently. Now both Fahlman and Grossman have completed papers which outline theories, propose experiments, and define, in the case of Grossman, specific application possibilities in the very large data base area. New hardware progress in the integrated circuit industry provides some hope that machines oriented toward such searches may become \" practical, given that simulation on serial machines proves the ideas sound. Sandewall has concentrated on the data base problem as well, but with with a view toward dealing with some immediate problems of data base DRAFT: JULY 1, 1975 PROPOSAL TO ARPA 10 He has worked out a block structured organization and self description. scheme capable of handling both procedures and data, designed to -^ooth the interface between programs on one side and a collection of data bases on the other. \" It is expected that his evolving theory will particularly influence our proposed work on very large data bases. prototype system of programs Sandewall has finished a that illustrate his ideas. Understanding Natural Language Pratt and his students have concentrated on the problem of dealing with efficiency issues in parsing natural language text. This effort takes us in the comfortable direction of preparing for the time when real application of natural language systems will make a theoretical understanding of the efficiency issue of great practical importance. Pratt's paper of January, 1975, presents an optimality proof demonstrating that LINGOL's parsing algorithm is optimal among those of its class in the sense that all the \" phrases that it builds up can be used. Meanwhile Marcus has completed the programming of a new parsing based on the wait-and-see philosophy for handling ambiguity. system Instead of picking one option at all decision points with the risk of being stuck with costly retreat, Marcus' system carries all options forward, decision only when the decision can be made with certainty. making a The design of this parser was finished by the end of 1974; implementation took place during 1975 and is just now complete. The next task is to augment the small grammer Marcus has used in debugging his parser with a much more complete grammar, one large enough to be a good interface to various intelligent terminal or large data base modules. Progress has also been made problem of generating language. on the relatively neglected linguistic This involves, among other things, a need \" DRAFT: JULY 1, 1975 11 PROPOSAL TO ARPA jfflj||. to know what the listener already knows. Thesis studying the problem. puts forth, There is McDonald has completed an M.S. no program embodiment of the ideas it but creating and experimenting with such a program seems sensible and is planned. Understanding Vision Gene Freuder has developed a system for visual recognition, implications for the general problem of control. with The system is intended to provide the flexibility required to deal with realistic visual scenes; he is looking at hammers, not stylized models, but everyday, toolbox hammers, under natural occlusion). \" conditions (e.g. lighting, background, orientation, He is studying directly the interaction of knowledge and control required in an integrated pass at the entire task, rather than looking at the attendant problems of image processing in detail. Particular results, as they are acquired, combine with general visual knowledge to \"suggest\" and \"advise\" further processing. This process, called \"active knowledge,\" extends and implements the principles of \"heterarchy\" and \"domain directed processing\" pioneered in this laboratory. Since description has long been regarded as the key to success with any difficult problem in artificial intelligence, Hollerbach's work on describing curved objects is another important step forward. developed an approach towards shape description based He has on prototype modification and generalized cylinders, a notion invented by Binford at Stanford. His programs describe and identify pottery from vase outlines well enough to be remarkably consistent with the descriptions and identifications given by archeologists. \" The resulting descriptions seem very natural and suitable for dealing with many sorts of objects besides pottery. The emphasis throughout has been to develop useful, qualitative PROPOSAL TO ARPA 12 DRAFT: JULY 1, 1975 descriptions which bring out the significant features and subordinate lesser ones. Marr and his students continue to look at vision from another point of \" view, that of concentration on thoroughly understanding the problem of translating image arrays into symbolic descriptions without the intervention of high level knowledge. Their thesis is that real image understanding cannot be done without very solid programs working at this level. This seems directly on the critical path leading toward real image basic work understanding, be it of ordinary scenes or ERTS type data. As of January, 1975, the work had concentrated on discovering what features of one- dimensional intensity profiles could reliably provide information about edge types and such modifiers as sharpness of edge focus. Since then, the edge and edge modifier work has been extended to two dimensions with satisfactory results. The most important work, however, has been on the problem of grouping the very lowest level symbolic descriptions of edges together into larger symbolic aggregates and the subsequent realization that a new theory of texture will result from this work. \" Marr has invented about four new grouping algorithms and prototype programs have been written for them. Some experiments with these prototype programs have been encouraging, but for the experimentation needed, the programs will have to be rewritten for the sake of efficiency. Working with image arrays is time consuming and requires more than the usual attention to program efficiency. Typical of other work directed by Marr is a theory of visual light source detection developed by Ullmann. which were: Several factors were examined, among absolute intensity values, intensity compared with the average illumination in the scene, both local and global contrast, and lightness contrast. A surprising experimental result was that these factors were shown to be insufficient for explaining our ability to detect light in the visual field, even under very simple conditions. sources While high enough \" DRAFT: JULY 1, 1975 \" PROPOSAL TO ARPA 13 contrast, for example, is a sufficient condition for creating the perception of radiance, it was shown that a light source can sometimes be detected in cases where the contrast is very low. A method for detecting light sources was then proposed and implemented, based on the comparison of two ratios: for a given pair of adjacent areas, both intensities-ratio and gradientsratio are computed. should be equal. The method can If neither of the areas is a light source the ratios If they are not equal, one of the areas is a light source. thereby detect the source and compute its intensity. A collection of our previous papers on vision, learning, representation has just been published by McGraw-Hill, under the !___. \" title. and The I. A. Rosenfeld July 28, 1975 \" Computer Vision (\"Vertical Slice\" of the AI chapter of the COSERS book) 1. Nature of the area (including brief history and elementary survey) Perception and cognition, as functions of intelligent beings, are very difficult to separate. A view widely held by psychologists is that perception is an active process, in which environment, and hypotheses are formed about the nature of the sensory information is sought that will confirm or refute these hypotheses. This view of. perception as a form of problem-solving S is held by most researchers in AI. For this reason, research on computer perception is treated here as a part of AI \" . [Only com-. puter vision will be treated here; computer audition, particularly speech understanding, will be covered by R. Reddy.] computer The mid-1950 s marks the onset of serious work on the analysis of images.. Applications that began to be investigated characters, of at that time included the recognition of printed cells in photomicrographs, of \"events\" in photographs of nuclear bubble chambers, and of military targets in aerial photographs. The approaches used belonged to the area now called pattern recognition, rather than AI ; but in those early days, little dis- tinction was made between these areas. Since the early 19605, there has been a marked divergence \" between the pattern recognition and AI approaches to computer analysis of images. The former approach has continued to stress the use of ad hoc image features in combination with statistical I i classification techniques. \" More recently, it has also made use of \"syntactic\" methods in which images are recognized, by a \"parsing\" process, as being built up hierarchically out of primitive con- stituents. The AI approach, by contrast, has employed problem- solving methodologies based on extensive use of knowledge about the class of images (or scenes) to be analyzed. A large number of references on image analysis can be found in (Rosenfeld, 1969, 1972 / 1973, 1974, 1975.) Our review of computer image analysis will cover only work based on the AI approach, to which the term \"computer vision\" is usually restricted. Much of the work on computer vision has dealt with images of scenes containing solid objects viewed from close by. These are the sort of images with which a robot vision system must usually cope in using vision to guide its motor activities, manipulation and locomotion. including The analysis of such images is usually called \"scene analysis\", to distinguish it from the analysis of images that are essentially two-dimensional, such as photomicrographs (which show cross-sections) show projections) , , radiographs (which ...ir '\" satellite imagery (in which terrain relief is negligible), documents, diagrams, maps, etc. However, the methods of computer vision are equally applicable to these latter classes of images; the term need not be restricted to \"three-dimensional\" scene analysis. \" \" 2. T-PRRarch highlights [Note- should be expanded to basic AI principles each program; but I without seeing the draft of the body of the chapter.] This material emphasize the introduced by can't do that computer analysis of scenes conThe pioneering effort in (1965). His objects is due to Roberts taining three-dimensional objects each of which can be scenes contain sets of polyhedral objects, such as recby combining a few primitive constructed prisms. tangular parallepipeds and triangular A photograph of the visible edges of such a scene is digitized, and are detected. \" Straight lines the_ objects are fitted to the detected edge into a line drawing. points, thus converting the photograph are next extracted, and it is Polygons formed by the lines equivalent to polygonal determined whether they are topological^ objects. If so, a projec of any of the \"model\" primitive faces sought that relates the observed tive coordinate transformation is are found In this way, (partial) matches polygon to the model. between the model and the drawing. The program attempts to way, as composed of comaccount for the entire drawing, in this binations of the models. Roberts' program worked well on \"clean\" input in which the was good contrast between lighting was controlled so that there It would have had more trouble faces of the polyhedra. adjacent \" arbitrary lighting conditions, in with noisy data obtained under have been successfully which not all the inter-face edges would would have failed. detected, so that the model matching process I \" The program knew that it was dealing with polyhedra of a certain the de- class, but it was unable to use this knowledge to direct tection of edges in the original picture. It performed only \"bottom-up\" analysis, with little or no provision for backup when trouble is encountered at the higher levels. By contrast, a more recent program, due to Shirai (1973, about, the class 1975) makes much better use of prior knowledge of scenes being analyzed. This program begins by attempting to are expected to detect the most obvious edges in the scene, which be edges between the polyhedra and the background. When this has been done, the program can hypothesize other edges-(particularly, \" those that separate two polyhedra) ledge that only polyhedra are present, , based on its know- and it can then direct these a more sensitive edge detection operator to look for edges at the appropriate locations. Internal edges (dihedral angles) of the individual polyhedra can then be found in turn. At each stage, previous results, in conjunction with models of missing lines. polyhedra, are used to propose the most plausible Unlike the hierarchical program of Roberts, there is no. rigid separation of the processing into \"levels\"; edge detection, line fitting, and model fitting all operate in a cooperative fashion. , This program illustrates the notion of heterarchical as opposed to hierarchical, organization. analysis Since the mid 1960 5, many other significant scene \" programs have been written. Many of these have dealt only with scenes containing polyhedra; and some have even assumed that perfect line drawings of such scenes, rather than images, were \" An important given. contribution on the line drawing level was developed rules for linking regions in made by Guzman (1968), who object; he was thus drawing that (probably) belong to the same . a objects without the use of able to segment the drawing into that bemodels. Falk (1972) used similar rules to link lines long to the same object, and thus overcome some of the problems that arise when lines are missing detected) . Theoretical (i.e., when edges fail to be bases for Guzman's approach established independently by Huffman (1971) were and Clowes (1971). drawings of polyMore recently, rules for interpreting line /Migle, hedra in which a line may represent not only a dihedral developed by Waltz but also a shadow or crack, were demonstrated \" (1975), who of that in a typical scene, only a small fraction (convex or the possible combinations of line interpretations etc.) can be mutually concave dihedral, occluding edge, shadow, consistent. consider scenes A few investigators have also begun to containing curved objects. face shape from shading (1975). Other work has Techniques for reconstructing sur- information are discussed by Horn made use of range data to determine shape, cylinders and or has allowed only developable surfaces (e.g., analysis of cones) Mention should also be made of work on the. . images of human faces (e.g., Kelly (1971)); in this last case, with a known once the face outline is located, one is dealing \" positions. set of facial features in approximately known Over vision the last few years, efforts have begun to apply computer methods to the analysis of natural indoor and outdoor- scenes with some success. , \" indicates, As the above brief review extensive work in scene world\" scenes containing only analysis has been done for \"blocks scenes, or even with polyhedra, but efforts dealing with natural scenes, have only been exmore general classes of artificial to be done in extending compuploratory thus far. Much remains class of situations. In ter vision techniques to a broader dialog with addition, if machines are to engage in effective humans about the machines input allowed) scenes (e.g., Turing's test with image must be able to understand human visual limitations. vision research must Thus computer ing of human Many \" eventually include the model- visual perception processes. X .\" of the challenges facing computer vision research during the coming years are common to other areas of AI as well. effectively structuring Notable among these is the problem of to be representing knowledge about the class of scenes and analyzed. requires In particular, computer vision generally knowledge at a variety of levels; at the \"low\" purpose\") end of the scale, knowledge texture, etc. (or \"general- about illumination, surface is needed, while at the \"high\" (or specialized) of (say) common end, one needs to know about the functions a wide range of knowhousehold objects. Integration of such ledge sources presents a challenging problem. [Analogous remarks understanding area; here the low end can be made in the speech etc., and the high end, involves speech production mechanisms, On the relationship between general-purpose word meanings.] \" computer vision see (Zucker, and special-purpose knowledge in Rosenfeld and Davis, 1975). / \" to Much of the knowledge used in computer vision relates but the \"objects\" that appear in the scene being analyzed; precisely despatial locations of these objects are often not word [Analogously, in speech understanding, phoneme and fined. boundaries are not precisely localizable. ] This suggests the about need for data structures capable of storing information may be mutually in \"fuzzily\" defined entities, many of which compatible. situation contrasted with, may be say, language understanding, where discrete data structures natural should The by be adequate; or with the discrete data structures used Winston (1975) . _*\" r - special Coping with unfamiliar or unexpected -input poses \" challenges to any AI system. Somehow, the system must choose appropriate frames (Minsky, 1975) within which to analyze the preinput; but this choice must itself be based on some sort of liminary analysis of the input. Little is known about the form take; but it presumably that such a preliminary analysis might analysis, should be largely data-driven. In the case of scene the use of local a possible approach to this problem involves input feature detection operations, applied to the scene in a sort of conhighly parallel fashion, perhaps followed by some straint checking procedure, which might take the form of a Hummel, and parallel \"relaxation\" process (e.g., Rosenfeld, Zucker, \" 1975; Tenenbaum, 1975). \" 3. Interfaces being applied to Computer vision techniques are increasingly real-world problems, particularly in Examples of mation. the field of industrial auto- applications include device assembly, circuit board layout, and inspection. Much of this work is still in have progress, but a number of convincing demonstration programs 1980's, computer been written, and it is expected that by the vision will begin to have a significant impact on industrial At the same time, the computer vision approach will practice. be increasingly applied in areas of computer image analysis that reup to now have been the domain of pattern recognition for example, analysis of handwriting, photomicrosearchers ??? \" graphs and radiographs, satellite imagery, and so on. demandComputer vision research has served as an especially realing testing area for AI methodology, since it deals with solve the world, noisy, multidimensional input. The efforts to computer vision problem have thus stimulated the development of solving languages, AI techniques, e.g., in such areas as problem control structures, and computer networks. turn, have spearheaded general advances in the languages and sys- tems area of computer science. \" These techniques, in \" 4. Other topics one to students, and The AI area has long been an attractive Many of the leading computer vision is no exception to this rule. universities in the offer courses on the subject, in addition to courses pattern related non-AI areas of image processing and recognition. large amounts Computer vision research requires exceptionally generally quite voluminous of computer time, since the input is black-and-white TV image occupies over 250,000 bytes standard (one of digital storage), and elaborate processing is usually^, for image In addition, special peripheral devices necessary. \" for such deinput/output are necessary; but the growing market a few tens of vices has made them available for as little as thousands of dollars. field in Funding for basic research in the computer vision year. is currently at a level of $1 to $2 million per the U.S.A. image (The dividing, lines between computer vision, processing, The draw sharply.), and pattern recognition are difficult to NSF, and NASA. major sources of this funding are ARPA, Activities (Carnegieare concentrated at some of the major AI laboratories a few other univerMellon, MIT, SRI, Stanford), as well as at sities (Maryland, Pennsylvania, and NASA's JPL. Outside the Texas, among others) U.S.A., there are centers in several countries, notably Great Britain, Japan, and the U.S.S.R. \" and at The including students number of researchers involved is perhaps 200, The formal publication rate is not and supporting personnel. high (as compared to the rates in image processing or pattern recognition) ; the papers appear primarily in AI meeting proceedings (IJCAI, MI) and in the journal Artificial Intelligence. \" in meeting Unpublished reports and short papers cited.] proceedings have generally not been [Note: References by computer, Computing Rosenfeld (1969), Picture processing A. 147-176. 1, Surveys (1973), Progress in picture processing: 1969 71, 81-108. ibid. 5, 1972, Computer Graphics (1972), Picture processing: Prncp??sina 394-416. 1, and Image Processing 1. (1974), Picture processing: 1973, ibid^_3, (1975), Picture processing: 1974, ibid. 4, 178-194. 133-155. T L ' G Roberts (1965) , Machine perception of dids in J. T. Tippett et al., eds Optical Information three-dimensional C^t^^^Elec^o159-197. , Processing, MIT Press, * line finder for Y. Shirai (1973), A context-sensitive 4, 95-119. of polyhedra, Artificial Intelligence \" recognition^ using knowledge (1975), Analyzing intensity arrays aEout-Bcenes, in P. H. Winston, cd., The^SJ^hp^ogy_ol_Comr^ Vision, McGraw-Hill, 93-113. Decomposition of a visual scene into three _Conf. , 291-304. dimensional bodies, Proc. Fall Joint Computer of imperfect line data as a threeG. Falk (1972), Interpretation 101-144. dimensional scene, Artificial Intelligence 3. A n Guzman (1968), sentences, Huffman (1971), Impossible objects as nonsense eds., Machine Intelligence^, and D. B Edinburgh Univ. Press, 295-323. Intelligence 2, (1971), On seeing things, Artificial Sichie, Meltzer A ii M. B. Clowes 79-116. n Understanding line drawings of scenes with of Computer shadows, in P. H. Winston, cd., The Psychology Vision, McGraw-Hill, 19-91. Waltz (1975) , from shading information, ibid., B. Horn (1975), Obtaining shape 115-155. \" M using (1971), Edge detection in pictures by computer IntelliD. Michie, eds., Machine planning, in B. Meltzer and Press, 297-409. gence 6, Edinburgh Univ. D S. W. Kelly Zucker, A. Rosenfeld, and L. S. Davis (1975), General- purpose models: expectations about the unexpected, Proc. . r \" 4 IJCAI, in press. , Learning structural descriptions from examples, in P. H. Winston, cd., The Psychology of Computer Vision, McGraw-Hill, 157-209. P. H. Winston (1975) M. Minsky (1975), A framework for representing knowledge, ibid. 211-277. , A. Rosenfeld, R. A. Hummel, and S. W. Zucker (1975), Scene labelling by relazation operations, lEEE Trans. SMC, submitted. J. M. Tenenbaum (1975) , personal communication. X X \" "
+    ]
   },
   {
     "id": "cb774wc3448",
-    "exhibit_test-exhibit_public_bsi": [
-      true
-    ],
-    "spotlight_exhibit_slug_test-exhibit_bsi": [
-      true
-    ],
-    "spotlight_exhibit_slugs_ssim": [
-      "test-exhibit"
-    ],
-    "spotlight_resource_id_ssim": [
-      "gid://exhibits/DorHarvester/20"
-    ],
-    "spotlight_resource_type_ssim": [
-      "dor_harvesters"
-    ],
-    "collection": [
-      "kh392jb5994"
-    ],
-    "collection_search": [
-      "kh392jb5994"
-    ],
-    "collection_with_title": [
-      "kh392jb5994-|-Virtual Tribunals: East Timor"
-    ],
-    "collection_titles_ssim": [
-      "Virtual Tribunals: East Timor"
-    ],
-    "url_suppl": [
-      "https://purl.stanford.edu/kh392jb5994"
-    ],
-    "content_metadata_type_ssim": [
-      "book"
-    ],
-    "content_metadata_type_ssm": [
-      "book"
-    ],
-    "content_metadata_first_image_file_name_ssm": [
-      "EastTimor_TR-Court_of_AppealsOriginal_Decisions_2002_01-2002_Vitor_Manuel_Alves_Final_COA_Decision_POR_0001"
-    ],
-    "content_metadata_first_image_width_ssm": [
-      "2498"
-    ],
-    "content_metadata_first_image_height_ssm": [
-      "3541"
-    ],
+    "exhibit_test-exhibit_public_bsi": [true],
+    "spotlight_exhibit_slug_test-exhibit_bsi": [true],
+    "spotlight_exhibit_slugs_ssim": ["test-exhibit"],
+    "spotlight_resource_id_ssim": ["gid://exhibits/DorHarvester/20"],
+    "spotlight_resource_type_ssim": ["dor_harvesters"],
+    "collection": ["kh392jb5994"],
+    "collection_search": ["kh392jb5994"],
+    "collection_with_title": ["kh392jb5994-|-Virtual Tribunals: East Timor"],
+    "collection_titles_ssim": ["Virtual Tribunals: East Timor"],
+    "url_suppl": ["https://purl.stanford.edu/kh392jb5994"],
+    "content_metadata_type_ssim": ["book"],
+    "content_metadata_type_ssm": ["book"],
     "content_metadata_image_iiif_info_ssm": [
       "https://stacks.stanford.edu/image/iiif/cb774wc3448%2FEastTimor_TR-Court_of_AppealsOriginal_Decisions_2002_01-2002_Vitor_Manuel_Alves_Final_COA_Decision_POR_0001/info.json",
       "https://stacks.stanford.edu/image/iiif/cb774wc3448%2FEastTimor_TR-Court_of_AppealsOriginal_Decisions_2002_01-2002_Vitor_Manuel_Alves_Final_COA_Decision_POR_0002/info.json",
@@ -2942,12 +1977,8 @@
     ],
     "modsxml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mods xmlns=\"http://www.loc.gov/mods/v3\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" version=\"3.6\" xsi:schemaLocation=\"http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd\">\n  <titleInfo>\n    <title>TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf</title>\n  </titleInfo>\n  <relatedItem type=\"host\">\n    <titleInfo>\n      <title>Virtual Tribunals: East Timor</title>\n    </titleInfo>\n    <location>\n      <url>https://purl.stanford.edu/kh392jb5994</url>\n    </location>\n    <typeOfResource collection=\"yes\"/>\n  </relatedItem>\n  <accessCondition type=\"useAndReproduction\">TBD</accessCondition>\n</mods>\n",
     "druid": "cb774wc3448",
-    "url_fulltext": [
-      "https://purl.stanford.edu/cb774wc3448"
-    ],
-    "display_type": [
-      "book"
-    ],
+    "url_fulltext": ["https://purl.stanford.edu/cb774wc3448"],
+    "display_type": ["book"],
     "title_245_search": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf.",
     "title_245_unstem_search": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf.",
     "title_245a_display": "TR-Court of AppealsOriginal Decisions/2002/01-2002 Vitor Manuel Alves Final COA Decision POR.pdf",


### PR DESCRIPTION
We now take care of all of this with a IIIF manifest. All public XML files already have the `thumb` node, so we don't need to duplicate this logic anymore.