### PR TITLE
Remove deprecated range_limit_panel route

### DIFF
--- a/app/controllers/spotlight/home_pages_controller.rb
+++ b/app/controllers/spotlight/home_pages_controller.rb
@@ -11,10 +11,10 @@ module Spotlight
 
     # rubocop:disable Rails/LexicallyScopedActionFilter
     # Tweak the authorization for the range limit actions
-    before_action :authenticate_user!, except: [:show, :range_limit, :range_limit_panel]
-    skip_authorize_resource only: %i(range_limit range_limit_panel)
+    before_action :authenticate_user!, except: [:show, :range_limit]
+    skip_authorize_resource only: %i(range_limit)
 
-    before_action only: %i(range_limit range_limit_panel) do
+    before_action only: %i(range_limit) do
       authorize! :read, @page
     end
     # rubocop:enable Rails/LexicallyScopedActionFilter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,8 @@ Exhibits::Application.routes.draw do
     resource :purl_resources
 
     concern :searchable, Blacklight::Routes::Searchable.new
-    concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
+    # This should be switched back to RangeSearchable when blacklight_range_limit removes the deprecated 'range_limit_panel/:id' route.
+    concern :range_searchable, BlacklightRangeLimit::Routes::ExhibitsRangeSearchable.new
 
     # this has to come before the Blacklight + Spotlight routes to avoid getting routed as
     # a document request.

--- a/lib/blacklight_range_limit/routes/exhibits_range_searchable.rb
+++ b/lib/blacklight_range_limit/routes/exhibits_range_searchable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BlacklightRangeLimit
+  module Routes
+    # Subclass of BlacklightRangeLimit::Routes::RangeSearchable that removes the deprecated 'range_limit_panel/:id'
+    # route. Bots keep hitting this route, creating a lot of noise in honeybadger.
+    # This file should be removed once blacklight_range_limit removes the route.
+    class ExhibitsRangeSearchable < BlacklightRangeLimit::Routes::RangeSearchable
+      def call(mapper, _options = {})
+        mapper.get 'range_limit', action: 'range_limit'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2431.

Bots (presumably) are hitting the range_limit_panel route in ways that fail, spamming honeybadger. That route appears to be deprecated: https://github.com/projectblacklight/blacklight_range_limit/blob/2f34f9f09e1a9a0a7d5194d2f15ae8021c3f5184/lib/blacklight_range_limit/controller_override.rb#L66

Exhibits does not appear to use that deprecated route. This removes it. Tested on stage, range limit still works.

If this is too fussy, we could try robots.txt first and see if they are respectful bots.