### PR TITLE
Update Spotlight to v3.5.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       blacklight (>= 7.0, < 9)
       rails
       ruby-oembed
-    blacklight-spotlight (3.5.0.3)
+    blacklight-spotlight (3.5.0.4)
       activejob-status
       acts-as-taggable-on (>= 5.0, < 10)
       autoprefixer-rails


### PR DESCRIPTION
Spotlight v3.5.0.4 supports identifying the cause of the indexing errors reported here https://github.com/sul-dlss/exhibits/issues/2461