### PR TITLE
Include Sir Trevor icons from Spotlight

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -47,3 +47,6 @@ $input-btn-focus-color: $input-focus-border-color !important;
 
 $sidebar-link-color: $color-black-80;
 $sidebar-link-active-color: $color-cardinal-red;
+
+// Sir Trevor
+$accent-color: $primary;

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -46,6 +46,7 @@
     <%= description %>
     <%= twitter_card %>
     <%= opengraph %>
+    <%= javascript_tag "Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}'" %>
   </head>
   <body class="<%= render_body_class %>">
     <div id="su-wrap"> <!-- #su-wrap start -->


### PR DESCRIPTION
Fixes #2475.

The default colors changed a bit in https://github.com/projectblacklight/spotlight/pull/2913. The accent-color seems to be the only intentional change relevant to Exhibits.