### PR TITLE
Stop executing recaptcha on every page load

### DIFF
--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -14,14 +14,13 @@
         </div>
       </div>
       <%= f.hidden_field :current_url %>
-      <%= recaptcha_v3(action: 'feedback') %>
+      <%= recaptcha_v3(action: 'feedback', inline_script: false) %>
       <script type="text/javascript">
         document.forms.new_contact_form.addEventListener('submit', async function(e) {
           e.preventDefault();
-          const response = await window.executeRecaptchaForFeedbackAsync();
-          if (response) {
-            setInputWithRecaptchaResponseTokenForFeedback('g-recaptcha-response-data-feedback', response);
-          }
+          const response = await grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", { action: 'feedback' });
+          const element = document.getElementById('g-recaptcha-response-data-feedback');
+          if (element) element.value = response;
           this.submit();
         });
       </script>


### PR DESCRIPTION
The recaptcha gem currently immediately executes the recaptcha when using their inline script:

https://github.com/ambethia/recaptcha/blob/37b6fed2045c425d50cd8b5aeb43cd960c24fac3/lib/recaptcha/helpers.rb#L197

This is every page in Exhibits that has a feedback form (even if not visible).

We're using their suggested method of executing the recaptcha on submit to avoid needing to worry about the short timeout period. In this case that initial execution is pointless because it is overwritten on submit.

It seems like the honeybadger issue from #2444 and another, 'grecaptcha is not defined' could likely be eliminated (or drastically reduced) by restricting the execution to legit attempts at filling out the feedback form. This PR cuts out the initial execution.