### PR TITLE
Add rack-attack.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,3 +135,5 @@ gem 'view_component', '~> 2.82' # ViewComponent 3.x breaks blacklight_range_limi
 # Used for shared reporting https://github.com/sul-dlss/exhibits/issues/2069
 gem 'redis', '~> 5.0'
 gem 'recaptcha', '~> 5.16'
+
+gem 'rack-attack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,6 +515,8 @@ GEM
       stanford-mods
     racc (1.8.0)
     rack (2.2.9)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
     rack-test (2.1.0)
@@ -848,6 +850,7 @@ DEPENDENCIES
   okcomputer
   puma (~> 5.0)
   purl_fetcher-client (~> 0.4)
+  rack-attack
   rack-mini-profiler
   rails (~> 7.0)
   rails-controller-testing

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Rack
+  ##
+  # See https://github.com/kickstarter/rack-attack/blob/master/docs/example_configuration.md
+  # for more configuration options
+  class Attack
+    ### Throttle Spammy Clients ###
+
+    # If any single client IP is making tons of requests, then they're
+    # probably malicious or a poorly-configured scraper. Either way, they
+    # don't deserve to hog all of the app server's CPU. Cut them off!
+    #
+    # Note: If you're serving assets through rack, those requests may be
+    # counted by rack-attack and this throttle may be activated too
+    # quickly. If so, enable the condition to exclude them from tracking.
+
+    # Throttle all requests by IP (60rpm)
+    #
+    # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+    throttle('req/ip', limit: 300, period: 5.minutes, &:ip)
+
+    # Throttle search requests by IP (15rpm)
+    Rack::Attack.throttle('req/search/ip', limit: 15, period: 1.minute) do |req|
+      route = begin
+        Rails.application.routes.recognize_path(req.path) || {}
+      rescue StandardError
+        {}
+      end
+
+      req.ip if route[:controller]&.match?('catalog') && (route[:action] == 'index' || route[:action] == 'facet')
+    end
+
+    # Throttle document actions requests by IP (15rpm)
+    Rack::Attack.throttle('req/actions/ip', limit: 15, period: 1.minute) do |req|
+      route = begin
+        Rails.application.routes.recognize_path(req.path) || {}
+      rescue StandardError
+        {}
+      end
+
+      req.ip if route[:action].in? %w[email sms]
+    end
+
+    # Inform throttled clients about limits and when they will get out of jail
+    Rack::Attack.throttled_response_retry_after_header = true
+    Rack::Attack.throttled_responder = lambda do |request|
+      match_data = request.env['rack.attack.match_data']
+      now = match_data[:epoch_time]
+
+      if Settings.throttling.notify_honeybadger && (
+        ((match_data[:limit] - match_data[:count]) < 5) || (match_data[:count] % 10).zero?
+      )
+        Honeybadger.notify('Throttling request', context: { ip: request.ip, path: request.path }.merge(match_data))
+      end
+
+      headers = {
+        'RateLimit-Limit' => match_data[:limit].to_s,
+        'RateLimit-Remaining' => '0',
+        'RateLimit-Reset' => (now + (match_data[:period] - (now % match_data[:period]))).to_s
+      }
+
+      [429, headers, ["Throttled\n"]]
+    end
+
+    # Safelist the following IP ranges:
+    Rack::Attack.safelist_ip('171.64.0.0/14')
+    Rack::Attack.safelist_ip('10.0.0.0/8')
+    Rack::Attack.safelist_ip('172.16.0.0/12')
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,8 @@ action_mailer:
     from: "example-team@example.com"
   default_url_options:
     host: "example.com"
+throttling:
+  notify_honeybadger: true
 
 nondiscoverable_exhibit_slugs:
   - exhibits-documentation


### PR DESCRIPTION
Because this is kinda annoying:
```
156.146.37.120 - "" [26/Jul/2024:09:20:09 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:10 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12041 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:10 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12043 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:11 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12043 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:10 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12041 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:11 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12041 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:11 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12045 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:12 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12043 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:13 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:12 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12040 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:13 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12042 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:13 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12047 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:13 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12043 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:13 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12043 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:14 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12038 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:15 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12040 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:14 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12046 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:15 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12042 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:15 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12039 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:15 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:15 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12040 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:16 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12047 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:16 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12046 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:16 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:16 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12047 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:17 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12042 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:17 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12046 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:17 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:17 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12043 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:17 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12045 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:18 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12042 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:18 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12045 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:18 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12037 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:19 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:19 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12041 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
156.146.37.120 - "" [26/Jul/2024:09:20:19 -0700] "GET /parker/catalog?f%5Blanguage%5D%5B%5D=Latin HTTP/1.1" 200 12044 "-" "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"

```