### PR TITLE
Change iiif link to https://library.stanford.edu/iiif

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,7 +31,7 @@ traject:
   processing_thread_pool: 1
 iiif_embed:
   url: https://embed.stanford.edu/iiif
-iiif_dnd_base_url: https://library.stanford.edu/iiif-viewers?%{query}
+iiif_dnd_base_url: https://library.stanford.edu/iiif?%{query}
 action_mailer:
   default_options:
     from: "example-team@example.com"


### PR DESCRIPTION
Fixes the iiif link. See https://github.com/sul-dlss/SearchWorks/issues/4374