### PR TITLE
update skip link classes

### DIFF
--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -37,9 +37,9 @@
   <body class="<%= render_body_class %>">
     <div id="su-wrap"> <!-- #su-wrap start -->
       <div id="su-content"> <!-- #su-content start -->
-        <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
-          <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
-          <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+        <nav id="skip-link" role="navigation" class="visually-hidden-focusable sr-only sr-only-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
+          <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'd-inline-flex p-2 m-1', data: { turbolinks: 'false' } %>
+          <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'd-inline-flex p-2 m-1', data: { turbolinks: 'false' } %>
           <%= content_for(:skip_links) %>
         </nav>
 


### PR DESCRIPTION
Closes #2575 

This pull request replaces the classes for the parent item as well as the individual skip link links (search field and main container) to match what is in Blacklight 8 currently. 