### PR TITLE
Add missing breadcrumb entry to more details page

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -23,6 +23,7 @@ class MetadataController < Spotlight::CatalogController
 
     title = Array(@document[blacklight_config.view_config(:show).title_field]).join(', ')
     add_breadcrumb title, spotlight.polymorphic_path([current_exhibit, @document])
+    add_breadcrumb t('metadata.breadcrumb')
   end
 
   def search_action_url(options = {})

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,7 @@ en:
     abstract: Abstract/Contents
     access: Access conditions
     bibliographic: Bibliographic information
+    breadcrumb: More details
     contact: Contact information
     contributors: Creators/Contributors
     description: Description

--- a/spec/features/metadata_display_spec.rb
+++ b/spec/features/metadata_display_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Metadata display' do
       expect(page).to have_css 'h3', text: 'Afrique Physique'
       expect(page).not_to have_css 'dt', text: 'Title:'
       expect(page).to have_css 'a[download="gk885tn1705.mods.xml"]', text: 'Download'
+      expect(page).to have_css '.breadcrumb-item', text: 'More details'
     end
 
     it 'opens view metadata in modal', js: true do


### PR DESCRIPTION
Before:
<img width="323" alt="Screenshot 2024-10-08 at 10 22 02 AM" src="https://github.com/user-attachments/assets/0d9e71a9-d2a8-4baf-90a9-6011810f7551">

After:
<img width="317" alt="Screenshot 2024-10-08 at 10 21 04 AM" src="https://github.com/user-attachments/assets/2b22ad79-c582-48fe-9036-bcca6943be14">
