### PR TITLE
Display a meaningful error message when a reserved search/browse name is used

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,14 @@ en:
         header: Section heading
       dor_harvester:
         druid_list: Object IDs
+      spotlight/search:
+        friendly_id: The title
+    errors:
+      models:
+        spotlight/search:
+          attributes:
+            friendly_id:
+              exclusion: '"%{value}" is reserved and cannot be used. Please choose a different title.'
 
   catalog:
     index:

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Browse category adminstration', :js do
+  let(:exhibit) { create(:exhibit) }
+  let(:exhibit_curator) { create(:exhibit_curator, exhibit: exhibit) }
+  let(:title) { 'New category title' }
+
+  before do
+    login_as exhibit_curator
+    visit spotlight.exhibit_searches_path(exhibit, anchor: 'browse-categories')
+    click_link('Edit')
+    find('#search_title').set(title)
+    click_button('Save changes')
+  end
+
+  it 'updates the browse category title' do
+    expect(page).to have_content('The browse category was successfully updated.')
+  end
+
+  context 'when a reserved word is used to title a browse category' do
+    let(:title) { 'images' }
+
+    it 'displays an error message' do
+      expect(page).to have_content('The title "images" is reserved and cannot be used.')
+    end
+  end
+end


### PR DESCRIPTION
Fixes: #2584 

Before:
<img width="601" alt="Screenshot 2024-10-09 at 9 49 16 AM" src="https://github.com/user-attachments/assets/ad6fb09a-31df-4fae-9619-53fcd57e397b">

After:
<img width="645" alt="Screenshot 2024-10-09 at 9 48 15 AM" src="https://github.com/user-attachments/assets/32f84796-1ea1-4557-a368-6d2e5dd63e67">
