### PR TITLE
Don't set expectations on nil.

### DIFF
--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -15,7 +15,7 @@ describe Spotlight::Resources::Upload do
 
   before do
     allow(Riiif::Image).to receive(:new).with(upload_id).and_return(riiif_image)
-    allow(upload).to receive(:file_present?).and_return(true)
+    allow(upload).to receive(:file_present?).and_return(true) if upload
   end
 
   describe '#to_solr' do


### PR DESCRIPTION
Fixes this warning from the console:
> WARNING: An expectation of `:file_present?` was set on `nil`. To allow expectations on `nil` and suppress this message, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`.