### PR TITLE
Pin uri gem until carrierwave incompatibility is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,7 @@ gem 'acts-as-taggable-on'
 gem 'mods_display', '~> 1.6'
 gem 'slack-ruby-client'
 gem 'blacklight-oembed', '~> 1.0'
+gem 'uri', '< 1' # pinned until https://github.com/carrierwaveuploader/carrierwave/issues/2759 is fixed
 
 # Used for shared reporting https://github.com/sul-dlss/exhibits/issues/2069
 gem 'redis', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -985,6 +985,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data
+  uri (< 1)
   web-console (>= 4.1.0)
   webmock
 


### PR DESCRIPTION
See https://github.com/carrierwaveuploader/carrierwave/issues/2759