### PR TITLE
Display specific fields in the index and metadata configuration page only for Parker exhibit

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -267,15 +267,23 @@ class CatalogController < ApplicationController
     config.add_index_field 'format_main_ssim', label: 'Resource type', if: lambda { |context, *_args|
       context.feature_flags.add_resource_type_index_field?
     }
+
+    # Parker specific fields (via Solr)
+    # editor_ssim, university_ssim, range_labels_ssim, and related_document_id_ssim.
+    config.add_index_field 'book_title_ssim', if: lambda { |context, *_args|
+      context.feature_flags.add_parker_index_fields?
+    }
+    config.add_index_field 'university_ssim', label: 'University'
+    config.add_index_field 'edition_ssm', label: 'Edition'
+    config.add_index_field 'range_labels_tesim', label: 'Section'
+    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link
+
     # Fields added by Zotero API BibTeX import
     config.add_index_field 'volume_ssm', label: 'Volume'
     config.add_index_field 'pages_ssm', label: 'Pages'
     config.add_index_field 'doi_ssim', label: 'DOI'
     config.add_index_field 'issue_ssm', label: 'Issue'
-    config.add_index_field 'edition_ssm', label: 'Edition'
-    config.add_index_field 'university_ssim', label: 'University'
     config.add_index_field 'thesis_type_ssm', label: 'Degree Type'
-    config.add_index_field 'book_title_ssim', label: 'Book Title'
     config.add_index_field 'ref_type_ssm', label: 'Reference Type'
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
@@ -287,8 +295,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'incipit_tesim', label: 'Incipit'
     config.add_index_field 'toc_search', label: 'Table of contents', helper_method: :table_of_contents_separator
     config.add_index_field 'manuscript_number_tesim', label: 'Manuscript number'
-    config.add_index_field 'range_labels_tesim', label: 'Section'
-    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link
     config.add_index_field(
       'full_text_tesimv',
       immutable: (config.view.keys - [:list]).push(:show).map { |k| [k, false] }.to_h,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -268,7 +268,7 @@ class CatalogController < ApplicationController
       context.feature_flags.add_resource_type_index_field?
     }
 
-    # Parker specific fields (via Solr)
+    # Parker specific fields we do not wish to show in other exhibits
     # editor_ssim, university_ssim, range_labels_ssim, and related_document_id_ssim.
     config.add_index_field 'book_title_ssim', if: lambda { |context, *_args|
       context.feature_flags.add_parker_index_fields?

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -273,10 +273,18 @@ class CatalogController < ApplicationController
     config.add_index_field 'book_title_ssim', if: lambda { |context, *_args|
       context.feature_flags.add_parker_index_fields?
     }
-    config.add_index_field 'university_ssim', label: 'University'
-    config.add_index_field 'edition_ssm', label: 'Edition'
-    config.add_index_field 'range_labels_tesim', label: 'Section'
-    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link
+    config.add_index_field 'university_ssim', label: 'University', if: lambda { |context, *_args|
+      context.feature_flags.add_parker_index_fields?
+    }
+    config.add_index_field 'edition_ssm', label: 'Edition', if: lambda { |context, *_args|
+      context.feature_flags.add_parker_index_fields?
+    }
+    config.add_index_field 'range_labels_tesim', label: 'Section', if: lambda { |context, *_args|
+      context.feature_flags.add_parker_index_fields?
+    }
+    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link, if: lambda { |context, *_args|
+      context.feature_flags.add_parker_index_fields?
+    }
 
     # Fields added by Zotero API BibTeX import
     config.add_index_field 'volume_ssm', label: 'Volume'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -282,9 +282,10 @@ class CatalogController < ApplicationController
     config.add_index_field 'range_labels_tesim', label: 'Section', if: lambda { |context, *_args|
       context.feature_flags.add_parker_index_fields?
     }
-    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link, if: lambda { |context, *_args|
-      context.feature_flags.add_parker_index_fields?
-    }
+    config.add_index_field 'related_document_id_ssim', label: 'Manuscript', helper_method: :manuscript_link,
+                                                       if: lambda { |context, *_args|
+                                                         context.feature_flags.add_parker_index_fields?
+                                                       }
 
     # Fields added by Zotero API BibTeX import
     config.add_index_field 'volume_ssm', label: 'Volume'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -270,7 +270,7 @@ class CatalogController < ApplicationController
 
     # Parker specific fields we do not wish to show in other exhibits
     # editor_ssim, university_ssim, range_labels_ssim, and related_document_id_ssim.
-    config.add_index_field 'book_title_ssim', if: lambda { |context, *_args|
+    config.add_index_field 'book_title_ssim', label: 'Book Title', if: lambda { |context, *_args|
       context.feature_flags.add_parker_index_fields?
     }
     config.add_index_field 'university_ssim', label: 'University', if: lambda { |context, *_args|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,7 @@ feature_flags:
   index_related_content: false # A feature that will index related SDR content. Initial implemented for Parker's IIIF AnnotationLists
   add_resource_type_index_field: false # Should the resource type field be added as an index/show field. For some exhibits this is desirable
   add_parker_search_fields: false # Parker specific search fields
+  add_parker_index_fields: false # Parker specific index fields
   slack_notifications: false
   uat_embed: false
   search_across: false


### PR DESCRIPTION
Relates to #2622 .

What this PR does:
- Create a new feature flag for parker specific index fields
- Sets that flag to false in the main settings file. 
- In the catalog controller, only adds parker specific fields if that flag is set to true. 

How to test this:
- In local development, create an exhibit with the slug "parker".
- Set up Solr.  Add a single Solr document with the following fields indicating this is a parker exhibit:

```
("exhibit_parker_public_bsi": [
    true
  ],
  "spotlight_exhibit_slug_parker_bsi": [
    true
  ],
  "spotlight_exhibit_slugs_ssim": [
    "parker"
  ]
```
-  create a new settings.local.yml file (or similar). 
Set up:
feature_flags:
  parker:
    add_parker_index_fields: true

You should still see Parker specific fields in the metadata configuration page as well as the actual search results view, and you should not see Parker specific fields in any exhibit that is not Parker. 

I didn't see any specific feature flag tests around values i.e. add_parker_search_fields.  If anyone has thoughts on any tests to add, please feel free to suggest them.

Next step once this is merged: Updating feature flags for parker and parker-test here https://github.com/sul-dlss/shared_configs/blob/exhibits-prod/config/settings/production.yml so that the right values are picked up 