### PR TITLE
Display heatmap results below the map

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -39,3 +39,4 @@
 //= require table_of_contents
 //= require custom-file-input
 //= require site_search_type_toggle
+//= require blacklight_heatmaps_overrides

--- a/app/assets/javascripts/blacklight_heatmaps_overrides.js
+++ b/app/assets/javascripts/blacklight_heatmaps_overrides.js
@@ -1,0 +1,22 @@
+// Override the leaflet sidebar to update our own documents container that appears below the map.
+L.Control.ExhibitsSidebar = L.Control.Sidebar.extend({
+  show: function() {
+  },
+
+  setContent: function(content) {
+    document.getElementById("heatmaps-documents-list").innerHTML = content;
+  }
+});
+
+L.control.sidebar = function(id, options) {
+  return new L.Control.ExhibitsSidebar(id, options);
+};
+
+// Override the basemap config to add noWrap.
+BlacklightHeatmaps.Basemaps.positron = L.tileLayer(
+  'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+    detectRetina: true,
+    noWrap: true,
+  }
+);

--- a/app/assets/stylesheets/modules/blacklight_heatmaps_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_heatmaps_overrides.scss
@@ -6,3 +6,8 @@
     height: 250px;
   }
 }
+
+.blacklight-heatmaps-index-map-container #heatmaps-documents-list {
+  height: 400px;
+  overflow-y: auto;
+}

--- a/app/helpers/blacklight/maps_helper_override.rb
+++ b/app/helpers/blacklight/maps_helper_override.rb
@@ -3,6 +3,16 @@
 module Blacklight
   # Override Blacklight::MapsHelper from blacklight_heatmaps
   module MapsHelperOverride
+    def sidebar_template
+      <<-HTMLTEMPLATE
+      <li>
+        <h3 class='index_title document-title-heading'>
+          <a href="{url}">{title}</a>
+        </h3>
+      </li>
+      HTMLTEMPLATE
+    end
+
     private
 
     ##

--- a/app/views/catalog/_document_heatmaps.html.erb
+++ b/app/views/catalog/_document_heatmaps.html.erb
@@ -1,0 +1,13 @@
+<div class='blacklight-heatmaps-index-map-container' data-turbolinks="false">
+  <%= index_map_div %>
+  <%= content_tag(:div, id: 'index-map-sidebar') do %>
+  <% end %>
+  <div class="mt-3">
+    <p id="map-interaction-hint" class="mb-0" aria-label="Instructions" role="note">
+      Interact with the map to update results.
+    </p>
+  </div>
+  <div id="documents" class="mt-2">
+    <ul id="heatmaps-documents-list" aria-live="polite" aria-label="Search results" aria-atomic="true"></ul>
+  </div>
+</div>


### PR DESCRIPTION
Addresses two requested changes that came out of https://github.com/sul-dlss/exhibits/issues/2611:

* Move the results out of the sidebar to provide more visual map space
* Display a single world map

I cannot emphasize enough that this does not alter which results are displayed. They are the same as the original sidebar results, which are sometimes confusing/not ideal.

It's probably easiest to test on stage. This exhibit has a good number of items with location data:

https://exhibits-stage.stanford.edu/lancani-test-cb