### PR TITLE
Adjust metadata display on browse list view

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -21,3 +21,4 @@
 @import "modules/caret";
 @import "modules/search_across";
 @import "modules/exhibit_search_typeahead";
+@import "modules/browse";

--- a/app/assets/stylesheets/modules/browse.scss
+++ b/app/assets/stylesheets/modules/browse.scss
@@ -1,0 +1,10 @@
+// The browse page does not have a sidebar, so some additional
+// column adjustments are needed to make the metadata look okay.
+.blacklight-browse-show .documents-list .document-metadata {
+  dt {
+    @extend .col-xl-2;
+  }
+  dd {
+    @extend .col-xl-10;
+  }
+}


### PR DESCRIPTION
Ideally we'd add the `col-xl-2` and `col-xl-10` classes in the template, but the only way to do that is to create a local version of `Blacklight::MetadataFieldComponent` that has to be configured for each field separately and then would need to be differently configured for the browse and catalog views. This css approach seemed less bad.

Before:
<img width="1345" alt="Screenshot 2024-12-02 at 4 50 51 PM" src="https://github.com/user-attachments/assets/7d0a3249-0f47-494d-add7-78b0af77f40e">

After:
<img width="1335" alt="Screenshot 2024-12-02 at 4 51 36 PM" src="https://github.com/user-attachments/assets/06a0c9e1-d4bf-4ed3-a9c5-c7dfdb0f31e8">
