### PR TITLE
Ensuring bibliography shows full reference

### DIFF
--- a/app/assets/javascripts/bibliography.js
+++ b/app/assets/javascripts/bibliography.js
@@ -56,15 +56,13 @@
       if (index > toggleIndex && total > toggleThreshold) {
         elClass += ' hide-bibliography';
       }
-      var parsedHtml = $.map($.parseHTML($.parseHTML(bibEntry.attributes.formatted_bibliography_ts.attributes.value)[0].textContent), function(value) {
-        // If it is HTML, return that, if not just return the text
-        if (value.outerHTML) {
-          return value.outerHTML;
-        }
-        return value.textContent;
-      }).join('');
+
+      // This string contains the formatted bibliography for this item.
+      // This string can contain HTML elements as well which should be displayed correctly.
+      var formatted_bibliography = bibEntry.attributes.formatted_bibliography_ts.attributes.value;
+     
       return '<p class="' + elClass + '">' +
-                parsedHtml +
+                formatted_bibliography +
               ' <a href="' + bibEntry.links.self + '">' +
                 '[View full reference]' +
               '</a>' +


### PR DESCRIPTION
Code that was included to support the display of italics in the formatted bibliography string is now only displaying the part of the reference string preceding any embedded HTML elements.  The title of items can be italicized, which means the former code was not displaying that section (although it must have worked previously). 

This pull request removes the html parsing code and allows the full string to be displayed.  The HTML tags, such as <i>, still display correctly in the page (i.e show the text actually italicized)