### PR TITLE
For item that is a reference, fixes the list of documents which include that reference

### DIFF
--- a/app/assets/javascripts/cited_documents.js
+++ b/app/assets/javascripts/cited_documents.js
@@ -13,17 +13,17 @@
       if (citedDocList[0].innerHTML != '') return;
 
       var data = $el.data();
-      var solrQueryString = data.documentids.join(' OR ');
+      var queryIds = data.documentids.join(' ');
+
 
       $.post(data.path, {
-        q: solrQueryString,
+        ids: queryIds,
         format: 'json',
-        rows: 1000
       }, function (response) {
-        response.data.forEach(function(citedDocEntry) {
+        response.forEach(function(citedDocEntry) {
           var html = '<li class="cited-documents-body">' +
-                ' <a href="' + citedDocEntry.links.self + '">' +
-                citedDocEntry.attributes.title_full_display.attributes.value +
+                ' <a href="' + citedDocEntry['id'] + '">' +
+                citedDocEntry['title_display'] +
                 '</a>' +
                 '</li>';
           citedDocList.append(html);

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -487,7 +487,7 @@ class CatalogController < ApplicationController
   def documents_list
     search_service = Blacklight::SearchService.new(config: blacklight_config)
     ids = params[:ids].present? ? params[:ids].split : []
-    @documents = ids.empty? ? [] : search_service.fetch(ids)
+    @documents = ids.empty? ? [] : search_service.fetch(ids, { :rows => 1000 })
     render json: @documents
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -487,8 +487,6 @@ class CatalogController < ApplicationController
   def documents_list
     search_service = Blacklight::SearchService.new(config: blacklight_config)
     ids = params[:ids].present? ? params[:ids].split : []
-    puts "DOCUMENTS LIST IDS"
-    puts ids.inspect
     @documents = ids.empty? ? [] : search_service.fetch(ids)
     render json: @documents
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -484,6 +484,15 @@ class CatalogController < ApplicationController
     end
   end
 
+  def documents_list
+    search_service = Blacklight::SearchService.new(config: blacklight_config)
+    ids = params[:ids].present? ? params[:ids].split : []
+    puts "DOCUMENTS LIST IDS"
+    puts ids.inspect
+    @documents = ids.empty? ? [] : search_service.fetch(ids)
+    render json: @documents
+  end
+
   class << self
     def document_has_full_text_and_search_is_query?(context, _config, document)
       context.params[:q].present? && document.full_text?

--- a/app/views/catalog/_cited_documents_default.html.erb
+++ b/app/views/catalog/_cited_documents_default.html.erb
@@ -1,7 +1,7 @@
 <% if @document.reference? && @document.cites_other_documents? %>
   <div class='col-md-12 record-metadata-section'
        data-behavior='cited-documents-contents'
-       data-path="<%= search_exhibit_catalog_path(exhibit_id: @exhibit) %>"
+       data-path="<%= url_for([@spotlight, :documents_list]) %>"
        data-parentid="<%= @document.id %>"
        data-documentids="<%= @document.related_document_ids %>"
   >

--- a/app/views/catalog/_cited_documents_default.html.erb
+++ b/app/views/catalog/_cited_documents_default.html.erb
@@ -1,7 +1,7 @@
 <% if @document.reference? && @document.cites_other_documents? %>
   <div class='col-md-12 record-metadata-section'
        data-behavior='cited-documents-contents'
-       data-path="<%= url_for([@spotlight, :documents_list]) %>"
+       data-path="<%= url_for(:documents_list) %>"
        data-parentid="<%= @document.id %>"
        data-documentids="<%= @document.related_document_ids %>"
   >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Exhibits::Application.routes.draw do
     end
 
     get '/search_tips' => 'catalog#search_tips'
+    post '/documents_list' => 'catalog#documents_list', as: :documents_list
 
     resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog'
     resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do

--- a/spec/features/manuscript_display_bibliography_spec.rb
+++ b/spec/features/manuscript_display_bibliography_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Cited manuscripts display on the bibliography show page' do
   end
 
   scenario 'cited documents element data required by async loader comes through to front end' do
-    expect(page).to have_css('div.record-metadata-section[data-path="/default-exhibit/catalog"]')
+    expect(page).to have_css('div.record-metadata-section[data-path="/documents_list"]')
     expect(page).to have_css("div.record-metadata-section[data-parentid=\"#{resource_id}\"]")
     expect(page).to have_css('div.record-metadata-section[data-documentids]')
     expect(page.find('div.record-metadata-section[data-documentids]')['data-documentids']).to eq(citations_string)


### PR DESCRIPTION
Closes #2673 .

Background:

- When a page like https://parker.stanford.edu/parker/catalog/3TZUP2CU is brought up, the "this reference is found in these document bibliographies" section retrieves a list of ids from the "related_document_id_ssim" field (e.g. for 3TZUP2CU), and then generates a list of links to those specific items.  
- The original query was querying the catalog's JSON API directly by sending in an ORed query string with the ids. This query was not limiting to the id field and was effectively a keyword search that could return multiple documents which were not specifically the ones indicated by those ids. 

What this pull request does:
- Sets up another query mechanism, relying on the search service fetch method when given an array of ids, which retrieves the documents with those specific ids.  
- On the Solr side, this appears to be generating a query of this format: "q"=>"{!lucene}id:(wz026zp2442 OR W4DJWZ9C)".  If we query Solr directly through its interface, this appears equivalent: q=id:(wz026zp2442 OR W4DJWZ9C).
