### PR TITLE
Do not override the base font size

### DIFF
--- a/app/assets/stylesheets/modules/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/modules/bootstrap_overrides.scss
@@ -3,7 +3,6 @@
 }
 
 body {
-  font-size: 0.9375rem;
   line-height: 1.428571429;
   margin-bottom: 0;
 }


### PR DESCRIPTION
Using the default (16px) is more accessible.