### PR TITLE
Remove unnecessary call to collapse

### DIFF
--- a/app/assets/javascripts/full_text_collapse.js
+++ b/app/assets/javascripts/full_text_collapse.js
@@ -36,6 +36,4 @@ Blacklight.onLoad(function(){
       }
     }
   });
-
-  $('dd.blacklight-full_text_tesimv').collapse({ toggle: false });
 });


### PR DESCRIPTION
I don't this this is needed after the move to Bootstrap 5. This fixes the `Full text highlighting when a document has non-english full text stems Portuguese properly` issue. Turns out it was a flappy test, just flappy in the worst direction...