### PR TITLE
Fix search tips route arguments

### DIFF
--- a/app/components/search_tips_link_component.rb
+++ b/app/components/search_tips_link_component.rb
@@ -3,7 +3,7 @@
 # Search tips link for the catalog navbar
 class SearchTipsLinkComponent < ViewComponent::Base
   def search_tips_path
-    helpers.search_tips_exhibit_catalog_path(exhibit:)
+    helpers.search_tips_exhibit_catalog_path(exhibit_id: exhibit)
   end
 
   def exhibit


### PR DESCRIPTION
Fixes no route error when visiting the General admin page (try going to https://exhibits-stage.stanford.edu/david-rumsey-map-collection/edit on stage). The route helper expects the exhibit_id as an argument. This change matches other calls to `_exhibit_catalog_path` helpers:

https://github.com/sul-dlss/exhibits/blob/f56f45ad73e386f6eab29e0ae527590afdafa11e/app/views/catalog/_bibliography_default.html.erb#L4
https://github.com/sul-dlss/exhibits/blob/f56f45ad73e386f6eab29e0ae527590afdafa11e/app/views/catalog/_cited_documents_default.html.erb#L4