### PR TITLE
Configure collection_titles_ssim as the default collection field; deprecate collection_with_title

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -219,7 +219,14 @@ class CatalogController < ApplicationController
     config.add_facet_field 'folder_name_ssi', label: 'Folder Name', limit: true
     config.add_facet_field 'donor_tags_ssim', label: 'Donor tags', limit: true
     config.add_facet_field 'doc_subtype_ssi', label: 'Document Subtype', limit: true
-    config.add_facet_field 'collection_with_title', label: 'Collection', limit: true, helper_method: :collection_title
+    config.add_facet_field 'collection_titles_ssim', label: 'Collection', limit: true
+    # Deprecated collection title field. We must keep this field because some exhibits still use it
+    # and it was used to build saved searches for browse categories.
+    # It stores the collection title prefixed with the collection druid, which is not desirable.
+    # The collection_title method strips the druid from the title.
+    # Use collection_titles_ssim instead. See https://github.com/sul-dlss/exhibits/issues/810
+    config.add_facet_field 'collection_with_title', label: 'Collection (deprecated)', limit: true,
+                                                    helper_method: :collection_title
     config.add_facet_field 'related_document_id_ssim', original: false, if: false
 
     # Have BL send all facet field names to Solr, which has been the default
@@ -300,7 +307,15 @@ class CatalogController < ApplicationController
     # This was added for the Feigbenbaum exhibit.  It includes any general <note> from
     #  the MODs that do not have attributes.  It is used for display and is not facetable.
     config.add_index_field 'general_notes_ssim', label: 'Notes', helper_method: :notes_wrap
-    config.add_index_field 'collection_with_title', label: 'Collection', helper_method: :document_collection_title
+    config.add_index_field 'collection_titles_ssim', label: 'Collection'
+    # Deprecated collection title field. We must keep this field because some exhibits still use it.
+    # It stores the collection title prefixed with the collection druid, which is not desirable.
+    # The document_collection_title method strips the druid from the title.
+    # Use collection_titles_ssim instead. See https://github.com/sul-dlss/exhibits/issues/810
+    config.add_index_field 'collection_with_title', label: 'Collection (deprecated)',
+                                                    helper_method: :document_collection_title,
+                                                    show: false,
+                                                    enabled: false
     # Fields specific to Parker Exhibit
     config.add_index_field 'dimensions_ssim', label: 'Dimensions'
     config.add_index_field 'provenance_ssim', label: 'Provenance'

--- a/spec/fixtures/sample_solr_docs.json
+++ b/spec/fixtures/sample_solr_docs.json
@@ -291,6 +291,7 @@
     "collection_with_title": [
       "ct961sj2730-|-The Caroline Batchelor Map Collection"
     ],
+    "collection_titles_ssim": ["The Caroline Batchelor Map Collection"],
     "box_ssi": null,
     "coordinates_tesim": ["(W18°--E51°/N37°--S35°)."],
     "folder_ssi": null,


### PR DESCRIPTION
Fixes #810 

After this is deployed to production I will run a script from the Rails console to update all the custom configurations to use the new field:

```ruby
Spotlight::BlacklightConfiguration.find_each do |config|
  old_index_config = config.index_fields['collection_with_title'] || {"label"=>"Collection", "list"=>true, "gallery"=>false, "heatmaps"=>true, "masonry"=>false, "slideshow"=>false, "show"=>true, "enabled"=>true}
  config.update(
    index_fields: config.index_fields.merge({
      'collection_with_title' => { 'enabled' => false, 'show' => false },
      'collection_titles_ssim' => old_index_config
    })
  ) unless config.index_fields.blank?
  
  old_facet_config = config.facet_fields['collection_with_title'] || {"show"=>true, "label"=>"Collection", "sort"=>"count"}
  config.update(
    facet_fields: config.facet_fields.merge({
      'collection_with_title' => { 'show' => false },
      'collection_titles_ssim' => old_facet_config
    })
  ) unless config.facet_fields.blank?
end
```

Some exhibits will need to be manually configured either because they don't set a custom configuration or they need to continue to use the deprecated collection field (because they can't be re-indexed):

Manually configure to use the deprecated facet field:
- `views-portraying-place-space` (facet and index)
- `gordon-maps` (facet and index)
- `chinese-ngos` (index only, facet off)

Manually configure facet to use new field and turn off old field because they do no have a configuration set:
- `ai`
- `conservation`
- `awards`
- `calligraphy`
- `seaside`
- `dataviz`
