### PR TITLE
Remove overrides of variables defined by Bootstrap

### DIFF
--- a/app/assets/stylesheets/sul_variables.scss
+++ b/app/assets/stylesheets/sul_variables.scss
@@ -1,7 +1,5 @@
 // Colors
-$black: #000;
 $cardinal-red: #8c1515;
 $cool-grey: #4d4f53;
-$white: #fff;
 $fog: #dad7cb;
 $fog-light-90: #f4f4f4e6;


### PR DESCRIPTION
`$black` and `$white` are already identically defined in bootstrap.