### PR TITLE
Remove style for .callout-danger

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -160,10 +160,6 @@ h5,
   padding-top: 0;
 }
 
-.callout-danger .btn-secondary {
-  @extend .btn-danger;
-}
-
 .st__content-block--image {
   text-align: center;
 


### PR DESCRIPTION
This class is no longer used in exhibits or spotlight