### PR TITLE
Remove unnecessary color style

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -56,7 +56,6 @@ body {
 }
 
 .item-count {
-  color: $cool-grey;
   font-size: 1.25rem;
 }
 

--- a/app/assets/stylesheets/sul_variables.scss
+++ b/app/assets/stylesheets/sul_variables.scss
@@ -1,3 +1,2 @@
 // Colors
-$cool-grey: #4d4f53;
 $fog-light-90: #f4f4f4e6;


### PR DESCRIPTION
This is always overridden by a more specific selector upstream in Spotlight