### PR TITLE
Add visually-hidden-focusable to nav element

### DIFF
--- a/app/components/skip_link_component.html.erb
+++ b/app/components/skip_link_component.html.erb
@@ -1,4 +1,4 @@
-<nav id="skip" aria-label="<%= t('blacklight.skip_links.label') %>">
+<nav id="skip" class="visually-hidden-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
     <%= link_to_main %>
     <%= link_to_search %>
     <%= content %>


### PR DESCRIPTION
Fixes #2756 

I've lost the plot on what we're doing with skip links...but adding `visually-hidden-focusable` to the `nav` element fixes a production issue where the `Skip to first result` link displays on search results pages. Open to other fixes. This appears to be what Blacklight 8 does: https://github.com/projectblacklight/blacklight/blob/ab210bd3d5cf352d10a2a6052970d34306a6d17f/app/components/blacklight/skip_link_component.html.erb#L1