### PR TITLE
Using standard emphasized link font weight

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -225,8 +225,3 @@ h5,
 #skip-link {
   position: relative !important;
 }
-
-// Allows for emphasized link weight for 'Spotlight at Stanford'
-.nav-link.emphasized {
-  font-weight: 500;
-}

--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -186,7 +186,7 @@ h5,
 
   &[href="/?tag=Social+justice"] {
     color: var(--stanford-cardinal);
-    font-weight: 700;
+    font-weight: 500;
 
     &::before {
       // Licensed (required to change color) from:
@@ -198,6 +198,11 @@ h5,
       vertical-align: top;
       width: 1rem;
     }
+
+    &.active {
+      font-weight: 600;
+    }
+    
   }
 }
 
@@ -219,4 +224,9 @@ h5,
 // instead of overlapping with the header. 
 #skip-link {
   position: relative !important;
+}
+
+// Allows for emphasized link weight for 'Spotlight at Stanford'
+.nav-link.emphasized {
+  font-weight: 500;
 }

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -12,7 +12,7 @@
 
 <ul class="navbar-nav">
   <li class="nav-item">
-    <%= link_to 'Spotlight at Stanford', main_app.root_path, class: 'nav-link fw-semibold' %>
+    <%= link_to 'Spotlight at Stanford', main_app.root_path, class: 'nav-link emphasized' %>
   </li>
   <%= render '/spotlight/shared/locale_picker' %>
   <% if current_user %>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -12,7 +12,7 @@
 
 <ul class="navbar-nav">
   <li class="nav-item">
-    <%= link_to 'Spotlight at Stanford', main_app.root_path, class: 'nav-link emphasized' %>
+    <%= link_to 'Spotlight at Stanford', main_app.root_path, class: 'nav-link fw-medium' %>
   </li>
   <%= render '/spotlight/shared/locale_picker' %>
   <% if current_user %>


### PR DESCRIPTION
Closes #2742 .
Note: The font weights for the other examples (regular links and menu links) seem to be consistent with what has been suggested so this PR focuses on emphasized links.

To conform with the font-weight requirements for emphasized links, this pull request does the following:
- For the "Social justice" tag, the inactive font weight is set to 500 (changing this from the previous value of 700).  The active font weight should be 600. 
- For the "Spotlight at Stanford" link, the font weight is set to 500.  There doesn't appear to be an "active" version required for this, but can easily be added if I am wrong.

**Before**:

Social Justice tag - inactive
<img width="476" alt="Screenshot 2025-01-08 at 3 22 45 PM" src="https://github.com/user-attachments/assets/789b5cee-7316-4b45-a204-71dcb6b6594c" />


Social Justice tag - active
<img width="495" alt="Screenshot 2025-01-08 at 3 23 14 PM" src="https://github.com/user-attachments/assets/86b94beb-7458-49b6-9969-dee43797dadc" />


Spotlight at Stanford link
<img width="174" alt="Screenshot 2025-01-08 at 3 23 31 PM" src="https://github.com/user-attachments/assets/e5f75e50-d2da-4bd3-a803-50e8e2d57d6d" />

<img width="470" alt="Screenshot 2025-01-08 at 3 23 37 PM" src="https://github.com/user-attachments/assets/42e7b8d5-db34-4083-b2a8-ebda30a8ccff" />


**After:**

Social Justice tag - inactive
<img width="433" alt="Screenshot 2025-01-08 at 3 26 57 PM" src="https://github.com/user-attachments/assets/d045617d-a878-4789-b9f1-33af9753239e" />

Social Justice tag - active
<img width="459" alt="Screenshot 2025-01-08 at 3 27 12 PM" src="https://github.com/user-attachments/assets/d1b542cc-7336-4588-97ec-2eb1a2cfb68b" />

Spotlight at Stanford link
<img width="168" alt="Screenshot 2025-01-08 at 3 27 19 PM" src="https://github.com/user-attachments/assets/a7e448b0-c199-4148-b083-4cbcb1f6f98f" />

<img width="259" alt="Screenshot 2025-01-08 at 3 27 23 PM" src="https://github.com/user-attachments/assets/74312896-6d3a-4196-894f-4583a622350e" />



