### PR TITLE
Update openseadragon styles

### DIFF
--- a/app/assets/stylesheets/modules/openseadragon.css
+++ b/app/assets/stylesheets/modules/openseadragon.css
@@ -1,5 +1,4 @@
-@import "openseadragon/openseadragon";
-
 .openseadragon-viewer {
   display: flex;
+  min-height: 500px;
 }

--- a/app/assets/stylesheets/modules/openseadragon.scss
+++ b/app/assets/stylesheets/modules/openseadragon.scss
@@ -1,4 +1,0 @@
-.openseadragon-viewer {
-  display: block;
-  min-height: 500px;
-}


### PR DESCRIPTION
I think we missed moving this tiny little style change during https://github.com/sul-dlss/exhibits/pull/2699.

Before:
<img width="996" alt="Screenshot 2025-01-16 at 2 26 43 PM" src="https://github.com/user-attachments/assets/bce6ce79-1d0c-4c04-ada9-a3af0e42f3dd" />

After:
<img width="1354" alt="Screenshot 2025-01-16 at 2 40 16 PM" src="https://github.com/user-attachments/assets/a1772553-1e74-408b-bd73-ef851745fc91" />
