### PR TITLE
Remove unnecessary style

### DIFF
--- a/app/assets/stylesheets/modules/layout.scss
+++ b/app/assets/stylesheets/modules/layout.scss
@@ -47,12 +47,6 @@
 }
 
 .masthead {
-  @media screen and (max-width: 576px) {
-    small {
-      @include rfs(1.25rem!important, font-size);
-    }
-  }
-
   .masthead-navigation {
     li {
       --sul-link-font-weight: 700;


### PR DESCRIPTION
This style was intended to override styles in spotlight that hid the subtitle on small sizes. This is no longer present post https://github.com/projectblacklight/spotlight/pull/3374