### PR TITLE
Remove deprecated blacklight document extensions

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -19,12 +19,6 @@ class SolrDocument
 
   # self.unique_key = 'id'
 
-  # Email uses the semantic field mappings below to generate the body of an email.
-  SolrDocument.use_extension(Blacklight::Document::Email)
-
-  # SMS uses the semantic field mappings below to generate the body of an SMS email.
-  SolrDocument.use_extension(Blacklight::Document::Sms)
-
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
   # Semantic mappings of solr stored fields. Fields may be multi or
   # single valued. See Blacklight::Solr::Document::ExtendableClassMethods#field_semantics


### PR DESCRIPTION
They don't do anything currently:

https://github.com/projectblacklight/blacklight/blob/v8.8.2/app/models/concerns/blacklight/document.rb#L34-L43