### PR TITLE
Remove navbar classes so popper will place the dropdown the correct way

### DIFF
--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -21,7 +21,7 @@
     </div>
 
     <div class="align-self-md-end align-self-start">
-      <div class="navbar collapse navbar-collapse d-md-flex me-md-2"
+      <div class="collapse d-md-flex me-md-2"
         aria-label="browse" id="user-util-collapse">
           <div>
             <% if current_exhibit %>


### PR DESCRIPTION
Before:
<img width="1201" alt="Screenshot 2025-02-14 at 5 27 57 PM" src="https://github.com/user-attachments/assets/bee3f8c5-3d83-4a50-bd0c-833c48701219" />

After:
<img width="1206" alt="Screenshot 2025-02-14 at 5 27 41 PM" src="https://github.com/user-attachments/assets/6231f6cc-04e3-41c7-9522-c91b13c96c9d" />
