### PR TITLE
Fix test warning

### DIFF
--- a/spec/components/search_tips_link_component_spec.rb
+++ b/spec/components/search_tips_link_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SearchTipsLinkComponent, type: :component do
   end
 
   it 'displays search tips links' do
-    expect(rendered).to have_link('Search tips'), href: '/search_tips'
+    expect(rendered).to have_link 'Search tips', href: '/search_tips'
   end
 
   it 'displays info icon' do


### PR DESCRIPTION
>WARNING: ignoring the provided expectation message argument({:href=>"/search_tips"}) since it is not a string or a proc.
