### PR TITLE
Change site name to Spotlight Exhibits

### DIFF
--- a/app/assets/stylesheets/modules/home.scss
+++ b/app/assets/stylesheets/modules/home.scss
@@ -2,3 +2,13 @@
   padding-bottom: 6px;
   padding-left: 3px;
 }
+
+.rosette-icon {
+  background: url('https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-24/styles/icon.svg') no-repeat center left;
+  background-size: 24px;
+  padding-left: 28px;
+
+  @include media-breakpoint-up(md) {
+    padding-left: 20px;
+  }
+}

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <ul class="navbar-nav">
-  <li class="nav-item">
+  <li class="nav-item rosette-icon">
     <%= link_to 'Spotlight Exhibits', main_app.root_path, class: 'nav-link fw-medium' %>
   </li>
   <%= render '/spotlight/shared/locale_picker' %>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -12,7 +12,7 @@
 
 <ul class="navbar-nav">
   <li class="nav-item">
-    <%= link_to 'Spotlight at Stanford', main_app.root_path, class: 'nav-link fw-medium' %>
+    <%= link_to 'Spotlight Exhibits', main_app.root_path, class: 'nav-link fw-medium' %>
   </li>
   <%= render '/spotlight/shared/locale_picker' %>
   <% if current_user %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,6 @@
 en:
   blacklight:
-    application_name: Spotlight at Stanford
+    application_name: Spotlight Exhibits
     search:
       start_over: Start over
       form:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       confirmation_instructions:
         subject: "Confirmation instructions"
       invitation_instructions:
-        subject: 'Spotlight at Stanford Exhibits - Confirmation Instructions'
+        subject: 'Spotlight Exhibits - Confirmation Instructions'
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -12,27 +12,27 @@ en:
       login: Login
     invitation_mailer:
       invitation_instructions:
-        hello: Welcome to Spotlight at Stanford, an application for showcasing digital content in easy-to-produce exhibits.
-        someone_invited_you: The Spotlight at Stanford Exhibits Administrator has invited you to work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking on the link below.
+        hello: Welcome to Spotlight Exhibits, an application for showcasing digital content in easy-to-produce exhibits.
+        someone_invited_you: The Spotlight Exhibits Administrator has invited you to work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking on the link below.
         accept: Accept invitation
         ignore_html: If you don’t want to accept the invitation, just ignore this email. You won’t be added to the "%{exhibit_name}" exhibit team until you click the invitation link above.
-        spotlight_at_sul_html: For more information about Spotlight at Stanford, visit %{href}
-        all_exhibits_html: To view existing Spotlight at Stanford exhibits, visit %{href}
-        get_help_html: Questions? Contact the Spotlight at Stanford service team by sending an email to %{mailto}
-        closing_html: "Happy exhibit building! <p>Spotlight at Stanford Service Team<br>%{mailto}</p>"
+        spotlight_at_sul_html: For more information about Spotlight Exhibits, visit %{href}
+        all_exhibits_html: To view existing exhibits, visit %{href}
+        get_help_html: Questions? Contact the Spotlight Exhibits service team by sending an email to %{mailto}
+        closing_html: "Happy exhibit building! <p>Spotlight Exhibits Service Team<br>%{mailto}</p>"
         mail_to_href: "exhibits-feedback@lists.stanford.edu"
         all_exhibits_href: "https://exhibits.stanford.edu"
         spotlight_at_sul_href: "http://library.stanford.edu/research/spotlight"
     exhibits_admin_invitation_mailer:
       invitation_instructions:
-        hello: Welcome to Spotlight at Stanford, an application for showcasing digital content in easy-to-produce exhibits.
-        someone_invited_you: The Spotlight at Stanford Exhibits Administrator has invited you to work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking on the link below.
+        hello: Welcome to Spotlight Exhibits, an application for showcasing digital content in easy-to-produce exhibits.
+        someone_invited_you: The Spotlight Exhibits Administrator has invited you to work on the "%{exhibit_name}" exhibit. You can accept this invitation by clicking on the link below.
         accept: Accept invitation
         ignore_html: If you don’t want to accept the invitation, just ignore this email. You won’t be added to the "%{exhibit_name}" exhibit team until you click the invitation link above.
-        spotlight_at_sul_html: For more information about Spotlight at Stanford, visit %{href}
-        all_exhibits_html: To view existing Spotlight at Stanford exhibits, visit %{href}
-        get_help_html: Questions? Contact the Spotlight at Stanford service team by sending an email to %{mailto}
-        closing_html: "Happy exhibit building! <p>Spotlight at Stanford Service Team<br>%{mailto}</p>"
+        spotlight_at_sul_html: For more information about Spotlight Exhibits, visit %{href}
+        all_exhibits_html: To view existing exhibits, visit %{href}
+        get_help_html: Questions? Contact the Spotlight Exhibits service team by sending an email to %{mailto}
+        closing_html: "Happy exhibit building! <p>Spotlight Exhibits Service Team<br>%{mailto}</p>"
         mail_to_href: "exhibits-feedback@lists.stanford.edu"
         all_exhibits_href: "https://exhibits.stanford.edu"
         spotlight_at_sul_href: "http://library.stanford.edu/research/spotlight"


### PR DESCRIPTION
Closes #2896

We'll still need to change the site title here as well after merge:

https://exhibits.stanford.edu/site/edit