### PR TITLE
fix caret for full text search

### DIFF
--- a/app/assets/stylesheets/modules/caret.scss
+++ b/app/assets/stylesheets/modules/caret.scss
@@ -1,10 +1,13 @@
 .show-hide-toggle {
-  @include caret(right);
+  @include caret();
 
   &::after {
-    vertical-align: inherit;
+    vertical-align: middle;
+    transform: rotate(-90deg);
+    margin-left: 0;
   }
-  &[aria-expanded="true"] {
-    @include caret();
+
+  &[aria-expanded="true"]::after {
+    transform: rotate(0deg);
   }
 }


### PR DESCRIPTION
closes #2909 
I think the difference in icon size is probably down to my local instance because I can't quite see what would make the difference in the code I changed to make the font bigger.

Before:
![](https://private-user-images.githubusercontent.com/3269689/442880008-a7080c72-4d5d-4dbe-8e58-d9145f98230e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDg0NDk4NjEsIm5iZiI6MTc0ODQ0OTU2MSwicGF0aCI6Ii8zMjY5Njg5LzQ0Mjg4MDAwOC1hNzA4MGM3Mi00ZDVkLTRkYmUtOGU1OC1kOTE0NWY5ODIzMGUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDUyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA1MjhUMTYyNjAxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OTE4ZDEyMTA4NzNlMjc0ZWFlZjU4NTU3NTQ1ZjQ1MTNlYTZlMTAwNjkzZTA0YzE1ZGU0ZjMzN2Y3OWYzYTkzYiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.jQsFfcTjfxlIC6qLABuLIzDcFT9txiEmYCS-tU38aS0)

After:
![Screenshot 2025-05-28 at 12 23 24 PM](https://github.com/user-attachments/assets/55b41231-7196-4717-acfd-624dfa9011c2)

Before: 
![Screenshot 2025-05-28 at 12 26 41 PM](https://github.com/user-attachments/assets/c105ace0-8832-4e23-939a-d18fd30ddb79)

After:
![Screenshot 2025-05-28 at 12 23 29 PM](https://github.com/user-attachments/assets/cc07ccdd-c2d5-4915-a23d-be316e55b93b)
