### PR TITLE
left align feedback form labels

### DIFF
--- a/app/assets/stylesheets/modules/spotlight_overrides.scss
+++ b/app/assets/stylesheets/modules/spotlight_overrides.scss
@@ -233,3 +233,9 @@ h5,
 #skip-link {
   position: relative !important;
 }
+
+// !important is needed to override
+// https://github.com/sul-dlss/exhibits/blob/main/app/assets/stylesheets/modules/bootstrap_overrides.scss#L42-L46
+#new_contact_form .mb-3 .col-form-label {
+  text-align: left!important;
+}


### PR DESCRIPTION
closes #2737 

Before:
![Screenshot 2025-05-29 at 1 08 29 PM](https://github.com/user-attachments/assets/1fb8653f-6b53-4486-8b04-d8aed9c66b3d)

After:
![Screenshot 2025-05-29 at 1 02 47 PM](https://github.com/user-attachments/assets/202b8e2c-3a34-4343-83ae-db5ebbc67269)

Before:
![Screenshot 2025-05-29 at 1 08 36 PM](https://github.com/user-attachments/assets/4cfe000c-ab60-41db-9c22-599c4d859290)

After:

![Screenshot 2025-05-29 at 1 02 41 PM](https://github.com/user-attachments/assets/60f48177-f691-40b0-a886-0951332ed5e9)

