### PR TITLE
Add job to import alt text spreadsheet

### DIFF
--- a/app/jobs/import_page_alt_text_job.rb
+++ b/app/jobs/import_page_alt_text_job.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+# A job to import alt text for home/about/feature pages from the AI alt text experiments.
+class ImportPageAltTextJob < ApplicationJob
+  def perform(csv_path:, dry_run: false)
+    update = !dry_run
+
+    CSV.foreach(csv_path, headers: true) do |csv_row|
+      row = AltTextSpreadsheetRow.new(csv_row)
+
+      unless row.valid?
+        Rails.logger.error "Skipping invalid row: #{row.inspect}"
+        next
+      end
+
+      if row.decorative?
+        set_page_image_as_decorative!(row:, update:)
+      else
+        update_page_image_alt_text!(row:, update:)
+      end
+    end
+  end
+
+  private
+
+  def set_page_image_as_decorative!(row:, update: true)
+    item = find_item_to_update(row:)
+    return unless item
+
+    if update
+      item['alt_text_backup'] = item['alt_text']
+      item['alt_text'] = ''
+      item['decorative'] = 'on'
+      row.page.update!(content: row.page.content)
+    end
+    Rails.logger.info "Set image '#{row.image_url}' as decorative on page '#{row.page.title}'"
+  end
+
+  def update_page_image_alt_text!(row:, update: true)
+    item = find_item_to_update(row:)
+    return unless item
+
+    if update
+      item.delete('decorative')
+      item['alt_text'] = row.alt_text
+      row.page.update!(content: row.page.content)
+    end
+    Rails.logger.info "Updated alt text for image #{row.image_url} on page #{row.page.title}"
+  end
+
+  def find_item_to_update(row:)
+    items = if row.uploaded_image?
+              uploaded_items_with_image(page: row.page, uploaded_image_url: row.uploaded_image_url)
+            elsif row.druid
+              solrdocument_items_with_image(page: row.page, druid: row.druid)
+            end
+
+    unless items&.count&.positive?
+      Rails.logger.error "Failed to find block/item that uses image from row: #{row.inspect}"
+      return
+    end
+
+    return items.first if items.count == 1
+
+    Rails.logger.error "Ambiguous match for '#{row.image_url}', row skipped: #{row.inspect}"
+  end
+
+  def solrdocument_items_with_image(page:, druid:)
+    return nil if page.content.blank?
+
+    items = page.content.flat_map do |block|
+      next [] unless block.supports_alt_text? && block.items.present?
+
+      # It might be tempting to check if the thumbnail urls match, but thumbnail_image_url isn't always set...
+      block.items&.select { |item| item['id'] == druid }
+    end
+
+    items.compact
+  end
+
+  def uploaded_items_with_image(page:, uploaded_image_url:)
+    return nil if page.content.blank?
+
+    items = page.content.flat_map do |block|
+      next [] unless block.supports_alt_text? && block.item.present?
+
+      block.item.select { |_id, item| item['url'] == uploaded_image_url }.map { |_id, item| item }
+    end
+
+    items.compact
+  end
+
+  # Model the existing Alt Text spreadsheet. If we keep this workflow it could be a real model but this is
+  # supposedly a short-lived process, so let's keep it all in one place.
+  class AltTextSpreadsheetRow
+    module Headers
+      EXHIBIT = 'Exhibit'
+      PAGE_URL = 'Page URL'
+      IMAGE_URL = 'Image URL'
+      DECORATIVE = 'Image is DECORATIVE, no description required (mark with an "X" if so)'
+      AI_ALT_TEXT = 'AI Generated Description (gemini-2.0-flash)'
+      HUMAN_ALT_TEXT = 'New OR edited description (when needed)'
+      NOT_USEFUL = 'AI description NOT useful and new, accurate alt text must be created (mark with an "X" if so)'
+      USEFUL_AS_IS = 'AI description useful AS IS (mark with an "X" if so)'
+      PARTIALLY_USEFUL = 'AI description partially useful with EDITS NEEDED (mark with an "X" if so)'
+    end
+    attr_reader :row
+
+    def initialize(row)
+      @row = row
+    end
+
+    def exhibit
+      @exhibit ||= Spotlight::Exhibit.find_by(title: exhibit_title)
+    end
+
+    def page
+      @page ||= case page_type
+                when :home
+                  exhibit.home_page
+                when :about
+                  exhibit.about_pages.find_by(slug: page_slug)
+                else
+                  exhibit.feature_pages.find_by(slug: page_slug)
+                end
+    end
+
+    def decorative?
+      row[Headers::DECORATIVE].to_s.strip.downcase == 'x'
+    end
+
+    def druid
+      image_url[%r{image/iiif/([^%]+?)/}, 1] if image_url.present?
+    end
+
+    def uploaded_image_url
+      image_url[%r{(/uploads/spotlight/attachment/.*)}, 1] if image_url.present?
+    end
+
+    def uploaded_image?
+      uploaded_image_url.present?
+    end
+
+    def alt_text
+      if useful_as_is?
+        ai_alt_text
+      elsif not_useful? || partially_useful?
+        human_alt_text.presence
+      end
+    end
+
+    def valid?
+      return false unless exhibit.present? && page.present?
+
+      single_selection? && (druid.present? || uploaded_image?) && (alt_text.present? || decorative?)
+    end
+
+    def image_url
+      url = row[Headers::IMAGE_URL]&.strip
+      URI.decode_uri_component(url) if url.present?
+    end
+
+    private
+
+    def ai_alt_text
+      row[Headers::AI_ALT_TEXT]&.strip
+    end
+
+    def human_alt_text
+      row[Headers::HUMAN_ALT_TEXT]&.strip
+    end
+
+    def not_useful?
+      row[Headers::NOT_USEFUL].to_s.strip.downcase == 'x'
+    end
+
+    def useful_as_is?
+      row[Headers::USEFUL_AS_IS].to_s.strip.downcase == 'x'
+    end
+
+    def partially_useful?
+      row[Headers::PARTIALLY_USEFUL]
+        .to_s.strip.downcase == 'x'
+    end
+
+    def single_selection?
+      [not_useful?, useful_as_is?, partially_useful?, decorative?].count(true) == 1
+    end
+
+    def exhibit_path
+      Spotlight::Engine.routes.url_helpers.exhibit_path(exhibit)
+    end
+
+    def exhibit_title
+      row[Headers::EXHIBIT]
+    end
+
+    def page_slug
+      page_path.split('/').last
+    end
+
+    def page_type
+      if page_path == exhibit_path
+        :home
+      elsif page_path.include? "#{exhibit_path}/about/"
+        :about
+      else
+        :feature
+      end
+    end
+
+    def page_path
+      URI(page_url).path if page_url.present?
+    end
+
+    def page_url
+      row[Headers::PAGE_URL]
+    end
+  end
+end

--- a/spec/jobs/import_page_alt_text_job_spec.rb
+++ b/spec/jobs/import_page_alt_text_job_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ImportPageAltTextJob do
+  let(:job) { described_class.new }
+  let(:csv_path) { '/path/to/alt_text.csv' }
+  let(:dry_run) { false }
+  let(:exhibit) { create(:exhibit, title: 'Test Exhibit', slug: 'test-exhibit') }
+  let(:druid_item_id) { 'cy496ky1984' }
+  let(:another_druid) { 'wj977xb5593' }
+  let(:item_id) { 'item_0' }
+  let(:solr_block_data) do
+    {
+      type: 'solr_documents',
+      data: {
+        format: 'html',
+        item: { item_id => { 'id' => druid_item_id, 'alt_text' => 'Original alt text', 'display' => 'true' },
+                'item_1' => { 'id' => another_druid, 'alt_text' => 'Original alt text', 'display' => 'true' } }
+      }
+    }
+  end
+  let(:uploaded_images_data) do
+    {
+      type: 'uploaded_items',
+      data: {
+        format: 'html',
+        item: { 'file_0' => {
+          'id' => 'st-block-8-1748552059346-raw', 'alt_text' => 'Original uploaded image alt text',
+          'display' => 'true',
+          'url' => '/uploads/spotlight/attachment/file/9287/SC0487_1995_040_B6_UGS22_Report_01_Page_1.jpg'
+        } }
+      }
+    }
+  end
+  let(:feature_page) { create(:feature_page, exhibit:, title: 'Test Page', slug: 'test-page') }
+  let(:ai_description) { 'AI generated description' }
+  let(:image_url) { 'https://stacks.stanford.edu/image/iiif/cy496ky1984%2F36105115938321_0002/full/!400,400/0/default.jpg' }
+  let(:human_description) { '' }
+  let(:not_useful) { '' }
+  let(:useful_as_is) { '' }
+  let(:partially_useful) { '' }
+  let(:decorative) { '' }
+  let(:csv_row) do
+    {
+      'Exhibit' => 'Test Exhibit',
+      'Page URL' => 'http://example.com/test-exhibit/feature/test-page',
+      'Image URL' => image_url,
+      'AI Generated Description (gemini-2.0-flash)' => ai_description,
+      'AI description NOT useful and new, accurate alt text must be created (mark with an "X" if so)' => not_useful,
+      'AI description useful AS IS (mark with an "X" if so)' => useful_as_is,
+      'AI description partially useful with EDITS NEEDED (mark with an "X" if so)' => partially_useful,
+      'New OR edited description (when needed)' => human_description,
+      'Image is DECORATIVE, no description required (mark with an "X" if so)' => decorative
+    }
+  end
+
+  before do
+    solr_block = SirTrevorRails::Blocks::SolrDocumentsBlock.from_hash(solr_block_data)
+    uploaded_items_block = SirTrevorRails::Blocks::UploadedItemsBlock.from_hash(uploaded_images_data)
+    feature_page.content = [solr_block, uploaded_items_block]
+    feature_page.save!
+    feature_page.reload
+    allow(Spotlight::Exhibit).to receive(:find_by).with(title: 'Test Exhibit').and_return(exhibit)
+    allow(CSV).to receive(:foreach).with(csv_path, headers: true).and_yield(csv_row)
+    allow(Rails.logger).to receive(:error)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  describe '#perform' do
+    context 'when image is marked as decorative' do
+      let(:decorative) { 'X' }
+
+      it 'marks the item alt text as decorative' do
+        job.perform(csv_path:)
+        updated_page = Spotlight::FeaturePage.find(feature_page.id)
+        updated_item = updated_page.content.first.item[item_id]
+        expect(updated_item['decorative']).to eq('on')
+        expect(updated_item['alt_text']).to eq('')
+        expect(updated_item['alt_text_backup']).to eq('Original alt text')
+      end
+    end
+
+    context 'when AI description is marked as useful as-is' do
+      let(:useful_as_is) { 'x' }
+      let(:ai_description) { 'This is a useful AI description' }
+
+      it 'updates the item alt text to use the AI-generated alt text' do
+        job.perform(csv_path:, dry_run:)
+        updated_page = Spotlight::FeaturePage.find(feature_page.id)
+        updated_item = updated_page.content.first.item[item_id]
+        expect(updated_item).not_to have_key('decorative')
+        expect(updated_item['alt_text']).to eq('This is a useful AI description')
+      end
+    end
+
+    context 'when AI description is marked partially useful and human edits are provided' do
+      let(:partially_useful) { 'X' }
+      let(:human_description) { 'This is an improved human-edited description' }
+
+      it 'updates the item alt text to use the human-edited description' do
+        job.perform(csv_path:, dry_run:)
+        updated_page = Spotlight::FeaturePage.find(feature_page.id)
+        updated_item = updated_page.content.first.item[item_id]
+        expect(updated_item).not_to have_key('decorative')
+        expect(updated_item['alt_text']).to eq('This is an improved human-edited description')
+      end
+    end
+
+    context 'when AI description is marked as not useful and human description is provided' do
+      let(:not_useful) { 'X' }
+      let(:human_description) { 'This is a human-written description' }
+
+      it 'updates the item alt text to use the human-written description' do
+        job.perform(csv_path:, dry_run:)
+        updated_page = Spotlight::FeaturePage.find(feature_page.id)
+        updated_item = updated_page.content.first.item[item_id]
+        expect(updated_item).not_to have_key('decorative')
+        expect(updated_item['alt_text']).to eq('This is a human-written description')
+      end
+    end
+
+    context 'when a row has no alt text selection' do
+      let(:not_useful) { '' }
+      let(:useful_as_is) { '' }
+      let(:partially_useful) { '' }
+      let(:decorative) { '' }
+
+      it 'logs an error and skips the row' do
+        job.perform(csv_path:, dry_run:)
+        unchanged_page = Spotlight::FeaturePage.find(feature_page.id)
+        unchanged_item = unchanged_page.content.first.item[item_id]
+        expect(unchanged_item['alt_text']).to eq('Original alt text')
+        expect(Rails.logger).to have_received(:error).with(/Skipping invalid row/)
+      end
+    end
+
+    context 'when a row has a non-decorative selection but empty alt text' do
+      let(:partially_useful) { 'x' }
+      let(:human_description) { '' }
+
+      it 'logs an error and skips the row' do
+        job.perform(csv_path:, dry_run:)
+        unchanged_page = Spotlight::FeaturePage.find(feature_page.id)
+        unchanged_item = unchanged_page.content.first.item[item_id]
+        expect(unchanged_item['alt_text']).to eq('Original alt text')
+        expect(Rails.logger).to have_received(:error).with(/Skipping invalid row/)
+      end
+    end
+
+    context 'when the image is an uploaded attachment, not a druid' do
+      let(:image_url) { 'https://exhibits.stanford.edu/uploads/spotlight/attachment/file/9287/SC0487_1995_040_B6_UGS22_Report_01_Page_1.jpg' }
+      let(:ai_description) { 'This is a useful AI description' }
+      let(:useful_as_is) { 'x' }
+
+      it 'updates the alt text' do
+        job.perform(csv_path:, dry_run:)
+        updated_page = Spotlight::FeaturePage.find(feature_page.id)
+        updated_item = updated_page.content.last.item['file_0']
+        expect(updated_item).not_to have_key('decorative')
+        expect(updated_item['alt_text']).to eq('This is a useful AI description')
+      end
+    end
+
+    context 'when a matching image is not found in the page' do
+      let(:ai_description) { 'This is a useful AI description' }
+      let(:useful_as_is) { 'x' }
+      let(:image_url) { 'https://stacks.stanford.edu/image/iiif/NONMATCHINGDRUID%2F36105115938321_0002/full/!400,400/0/default.jpg' }
+
+      it 'logs an error and skips the row' do
+        job.perform(csv_path:, dry_run:)
+        unchanged_page = Spotlight::FeaturePage.find(feature_page.id)
+        unchanged_item = unchanged_page.content.first.item[item_id]
+        expect(unchanged_item['alt_text']).to eq('Original alt text')
+        expect(Rails.logger).to have_received(:error).with(/Failed to find/)
+      end
+    end
+
+    context 'when the row image is used by more than one item in the page' do
+      let(:ai_description) { 'This is a useful AI description' }
+      let(:useful_as_is) { 'x' }
+      let(:another_druid) { druid_item_id }
+
+      it 'logs an error and skips the row' do
+        job.perform(csv_path:, dry_run:)
+        unchanged_page = Spotlight::FeaturePage.find(feature_page.id)
+        unchanged_item = unchanged_page.content.first.item[item_id]
+        expect(unchanged_item['alt_text']).to eq('Original alt text')
+        expect(Rails.logger).to have_received(:error).with(/Ambiguous match/)
+      end
+    end
+
+    context 'when the row has multiple alt text selections' do
+      let(:not_useful) { 'X' }
+      let(:useful_as_is) { 'X' }
+
+      it 'logs an error and skips the row' do
+        job.perform(csv_path:, dry_run:)
+        unchanged_page = Spotlight::FeaturePage.find(feature_page.id)
+        unchanged_item = unchanged_page.content.first.item[item_id]
+        expect(unchanged_item['alt_text']).to eq('Original alt text')
+        expect(Rails.logger).to have_received(:error).with(/Skipping invalid row/)
+      end
+    end
+
+    context 'when a page has no content' do
+      before do
+        feature_page.content = nil
+        feature_page.save!
+        feature_page.reload
+      end
+
+      let(:partially_useful) { 'X' }
+      let(:human_description) { 'This is an improved human-edited description' }
+
+      it 'logs an error and skips the row' do
+        job.perform(csv_path:, dry_run:)
+        expect(Rails.logger).to have_received(:error).with(/Failed to find/)
+      end
+    end
+
+    context 'when performing a dry run with a valid row' do
+      let(:dry_run) { true }
+      let(:partially_useful) { 'X' }
+      let(:human_description) { 'This is an improved human-edited description' }
+
+      it 'does not update the item' do
+        job.perform(csv_path:, dry_run:)
+        unchanged_page = Spotlight::FeaturePage.find(feature_page.id)
+        unchanged_item = unchanged_page.content.first.item[item_id]
+        expect(unchanged_item['alt_text']).to eq('Original alt text')
+        expect(Rails.logger).to have_received(:info).with(/Updated alt text for image/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a job to import the AI Alt Text Experiment spreadsheets.

### Why are we doing this?
In summary I was told:
* We need a way to import these sheets
* A developer will be doing the imports, not the end-users
* We might do these imports periodically for a while, but if AI alt text proves useful we would be moving away from spreadsheets to some more streamlined (in-app?) process.

Given that, and that I don't know of any other good ways to inject Sir Trevor data, I felt a self-contained job would be a fine method.

### What does this actually do?
In short it:
* tries to pluck an ID from the image URL from the sheet (e.g., druid for solr docs, relative URL for uploaded images)
* tries to find the exhibit and the page
* looks at every item in each Sir Trevor block on the page and matches the image ID
* If there is a singular match, it updates the alt text for that particular image based on the spreadsheet logic

### Notes
* This doesn't cover all block cases. For example, Spotlight/Exhibits *can* use the solr document blocks with uploaded files but none of the current spreadsheets are targeting this case. Nothing bad would happen if somebody ran one later, it would fail to match.
* Manipulating the Sir Trevor data is not fun.