### PR TITLE
Removed unused methods from PublicXmlRecord

### DIFF
--- a/app/models/public_xml_record.rb
+++ b/app/models/public_xml_record.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Retrieves and represents the public xml file from PURL
-class PublicXmlRecord # rubocop:disable Metrics/ClassLength
+class PublicXmlRecord
   attr_reader :druid, :options
 
   COLLECTION_TYPES = %w(collection set).freeze
@@ -16,30 +16,13 @@ class PublicXmlRecord # rubocop:disable Metrics/ClassLength
     @options = options
   end
 
-  def searchworks_id
-    catkey.nil? ? druid : catkey
-  end
-
-  # @return catkey value from the DOR identity_metadata, or nil if there is no catkey
-  def catkey
-    get_value(public_xml_doc.xpath("/publicObject/identityMetadata/otherId[@name='catkey']"))
-  end
-
   # @return objectLabel value from the DOR identity_metadata, or nil if there is no barcode
   def label
-    get_value(public_xml_doc.xpath('/publicObject/identityMetadata/objectLabel'))
-  end
-
-  def get_value(node)
-    node.first&.content
+    public_xml_doc.xpath('/publicObject/identityMetadata/objectLabel').first&.content
   end
 
   def public_xml
     @public_xml ||= self.class.fetch("#{purl_base_url}.xml")
-  end
-
-  def public_xml?
-    !!public_xml
   end
 
   def public_xml_doc
@@ -67,15 +50,6 @@ class PublicXmlRecord # rubocop:disable Metrics/ClassLength
     object_type_nodes.find_index { |n| COLLECTION_TYPES.include? n.text.downcase }
   end
 
-  # value is used to tell SearchWorks UI app of specific display needs for objects
-  # this comes from the <thumb> element in publicXML or the first image found (as parsed by discovery-indexer)
-  # @return [String] filename or nil if none found
-  def thumb
-    return if collection?
-
-    encoded_thumb if %w(book image manuscript map webarchive-seed).include?(dor_content_type)
-  end
-
   # the value of the type attribute for a DOR object's contentMetadata
   #  more info about these values is here:
   #    https://consul.stanford.edu/display/chimera/DOR+content+types%2C+resource+types+and+interpretive+metadata
@@ -85,42 +59,8 @@ class PublicXmlRecord # rubocop:disable Metrics/ClassLength
     public_xml_doc.xpath('//contentMetadata/@type').text
   end
 
-  # the thumbnail in publicXML, falling back to the first image if no thumb node is found
-  # @return [String] thumb filename with druid prepended, e.g. oo000oo0001/filename withspace.jp2
-  def parse_thumb
-    return if public_xml_doc.nil?
-
-    thumb = public_xml_doc.xpath('//thumb')
-    # first try and parse what is in the thumb node of publicXML, but fallback to the first image if needed
-    if thumb.size == 1
-      thumb.first.content
-    elsif thumb.empty? && parse_sw_image_ids.size.positive?
-      parse_sw_image_ids.first
-    end
-  end
-
-  # the druid and id attribute of resource/file and objectId and fileId of the
-  # resource/externalFile elements that match the image, page, or thumb resource type, including extension
-  # Also, prepends the corresponding druid and / specifically for Searchworks use
-  # @return [Array<String>] filenames
-  def parse_sw_image_ids
-    public_xml_doc.xpath('//resource[@type="page" or @type="image" or @type="thumb"]').map do |node|
-      node.xpath('./file[@mimetype="image/jp2"]/@id').map do |x|
-        "#{@druid.gsub('druid:', '')}/" + x
-      end << node.xpath('./externalFile[@mimetype="image/jp2"]').map do |y|
-               "#{y.attributes['objectId'].text.split(':').last}/#{y.attributes['fileId']}"
-             end
-    end.flatten
-  end
-
   def collections
     @collections ||= predicate_druids('isMemberOfCollection').map do |druid|
-      PublicXmlRecord.new(druid, options)
-    end
-  end
-
-  def constituents
-    @constituents ||= predicate_druids('isConstituentOf').map do |druid|
       PublicXmlRecord.new(druid, options)
     end
   end
@@ -129,17 +69,6 @@ class PublicXmlRecord # rubocop:disable Metrics/ClassLength
     return [] unless collection?
 
     purl_fetcher_client.collection_members(druid)
-  end
-
-  # the thumbnail in publicXML properly URI encoded, including the slash separator
-  # @return [String] thumb filename with druid prepended, e.g. oo000oo0001%2Ffilename%20withspace.jp2
-  def encoded_thumb
-    thumb = parse_thumb
-    return unless thumb
-
-    thumb_druid = thumb.split('/').first # the druid (before the first slash)
-    thumb_filename = thumb.split(%r{[a-zA-Z]{2}[0-9]{3}[a-zA-Z]{2}[0-9]{4}[/]}).last # everything after the druid
-    "#{thumb_druid}%2F#{ERB::Util.url_encode(thumb_filename)}"
   end
 
   # get the druids from predicate relationships in rels-ext from public_xml


### PR DESCRIPTION
These were brought over from purl-fetcher in https://github.com/sul-dlss/exhibits/pull/2416/commits/a52a9d26fe371a41fd844d4852df6d671ba5fc2d but are not used by exhibits so they can be removed.