### PR TITLE
Set imagemagick commands for version 7

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -7,4 +7,9 @@ ActiveSupport::Reloader.to_prepare do
   # Riiif.not_found_image = 'app/assets/images/us_404.svg'
   #
   Riiif::Engine.config.cache_duration = 365.days
+
+  # ImageMagick 7 commands are prefixed with "magick". This is needed until
+  # we update the default commands set by the Riiif gem.
+  Riiif::ImagemagickCommandFactory.external_command = "magick convert"
+  Riiif::ImageMagickInfoExtractor.external_command  = "magick identify"
 end


### PR DESCRIPTION
Fixes https://app.honeybadger.io/projects/49092/faults/121433579

```
Riiif::ConversionError: Unable to execute command "identify -format '%h %w %m %[channels]' 'path/to/1280px-Nuremberg_Trials_retouched.jpg[0]'"
sh: 1: identify: not found
```

I'll write up an issue for the Riiif gem.