### PR TITLE
remove default turbo.drive enabling

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
+Turbo.session.drive = false
 import "./controllers"
 
 // Required by Blacklight


### PR DESCRIPTION
closes #2988 

I really don't understand what is going on. This fixes the issue but I don't really understand Turbo drive and could use pairing on this.