### PR TITLE
Display result header links as a block

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -56,6 +56,10 @@
   .index_title {
     font-size: 1rem;
     margin-top: 0;
+
+    a {
+      display: block;
+    }
   }
 
   .img-thumbnail,

--- a/app/assets/stylesheets/modules/home.scss
+++ b/app/assets/stylesheets/modules/home.scss
@@ -4,11 +4,20 @@
 }
 
 .rosette-icon {
-  background: url('https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-24/styles/icon.svg') no-repeat center left;
+  background: url("https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-24/styles/icon.svg")
+    no-repeat center left;
   background-size: 24px;
   padding-left: 28px;
 
   @include media-breakpoint-up(md) {
     padding-left: 20px;
+  }
+}
+
+.blacklight-exhibits-index {
+  .card-title {
+    a {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
Fixes #3010
So that when the link wraps to two lines, the focus ring circles the whole thing

Before
<img width="755" height="402" alt="Screenshot 2025-12-04 at 1 47 27 PM" src="https://github.com/user-attachments/assets/b64f84d9-3047-41ea-a159-bc1115d7e395" />

After
<img width="751" height="407" alt="Screenshot 2025-12-04 at 1 47 51 PM" src="https://github.com/user-attachments/assets/e988a3d1-03ea-4ba9-8886-440246f3253e" />
