### PR TITLE
Fix stale element reference errors

### DIFF
--- a/spec/features/embed_block_spec.rb
+++ b/spec/features/embed_block_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 # Gem::Specificationfind_by_name is not a rails dynamic finder
 require "#{Gem::Specification.find_by_name('blacklight-spotlight').gem_dir}/spec/support/features/test_features_helpers"
 
-RSpec.feature 'Solr Documents Embed Block', js: true do
-  include JavascriptFeatureHelpers
+RSpec.feature 'Solr Documents Embed Block', :js do
   include Spotlight::TestFeaturesHelpers
 
   let(:exhibit) { create(:exhibit) }
@@ -22,20 +21,21 @@ RSpec.feature 'Solr Documents Embed Block', js: true do
     stub_request(:get, 'http://purl.stanford.edu/embed.json')
       .with(query: hash_including({ 'url' => 'https://purl.stanford.edu/zy575vf8599', 'maxheight' => '300' }))
       .to_return(status: 200, body: File.read(File.join(FIXTURES_PATH, 'purl_embed/300/zy575vf8599.json')))
+
+    visit spotlight.edit_exhibit_home_page_path(exhibit)
+
+    wait_for_sir_trevor
+    add_widget('solr_documents_embed')
   end
 
   describe 'block editing form' do
     it 'has a number field to input the hight (with a default placeholder)' do
-      visit spotlight.edit_exhibit_home_page_path(exhibit)
-
-      add_widget('solr_documents_embed')
+      fill_in_solr_document_block_typeahead_field(with: 'zy575vf8599')
 
       expect(page).to have_css('label', text: 'Maximum height of viewer (in pixels)')
       number_input = page.find('input[type="number"][placeholder]')
       expect(number_input['placeholder']).to eq '600'
       expect(number_input.value).to eq ''
-
-      fill_in_solr_document_block_typeahead_field(with: 'zy575vf8599')
 
       save_page_changes
 
@@ -43,10 +43,6 @@ RSpec.feature 'Solr Documents Embed Block', js: true do
     end
 
     it 'allows curators to set the maxheight paramter sent to the Embed' do
-      visit spotlight.edit_exhibit_home_page_path(exhibit)
-
-      add_widget('solr_documents_embed')
-
       fill_in_solr_document_block_typeahead_field(with: 'zy575vf8599')
       fill_in 'Maximum height of viewer (in pixels)', with: 300
 
@@ -55,10 +51,6 @@ RSpec.feature 'Solr Documents Embed Block', js: true do
     end
 
     it 'allows curators to select the image area' do
-      visit spotlight.edit_exhibit_home_page_path(exhibit)
-
-      add_widget('solr_documents_embed')
-
       fill_in_solr_document_block_typeahead_field(with: 'zy575vf8599')
 
       expect(page).to have_css('.select-image-area')


### PR DESCRIPTION
After the selenium-webdriver (4.39.0) update these embed tests are almost always resulting in state element reference errors.