### PR TITLE
Use cocina display gem to render metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,7 @@ gem 'acts-as-taggable-on'
 gem 'mods_display', '~> 1.6'
 gem 'slack-ruby-client'
 gem 'blacklight-oembed', '~> 1.0'
+gem 'cocina_display', '~> 1.6'
 gem 'whenever', require: false
 
 # Used for shared reporting https://github.com/sul-dlss/exhibits/issues/2069

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,13 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 2.0)
       observer (< 1.0)
+    cocina_display (1.6.0)
+      activesupport (>= 7)
+      edtf (~> 3.2)
+      geo_coord (~> 0.2)
+      i18n
+      janeway-jsonpath (~> 0.6)
+      zeitwerk (~> 2.7)
     concurrent-ruby (1.3.6)
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -455,6 +462,7 @@ GEM
       reline (>= 0.4.2)
     iso-639 (0.3.8)
       csv
+    janeway-jsonpath (0.6.0)
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -964,6 +972,7 @@ DEPENDENCIES
   capistrano-shared_configs
   capybara
   citeproc-ruby
+  cocina_display (~> 1.6)
   config
   connection_pool (~> 2.5)
   csl-styles (= 2.0.1)

--- a/app/components/metadata/cocina/abstract_contents_component.rb
+++ b/app/components/metadata/cocina/abstract_contents_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina abstract and contents metadata
+    class AbstractContentsComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :abstract_display_data, :table_of_contents_display_data, to: :cocina_record
+
+      def call
+        render Metadata::SectionComponent.new(label: I18n.t('metadata.abstract')) do
+          render Metadata::Cocina::FieldComponent.with_collection(abstract_and_contents)
+        end
+      end
+
+      def render?
+        abstract_and_contents.present?
+      end
+
+      private
+
+      def abstract_and_contents
+        @abstract_and_contents ||= [abstract_display_data,
+                                    table_of_contents_display_data].compact.flatten
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/access_conditions_component.rb
+++ b/app/components/metadata/cocina/access_conditions_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina access conditions
+    class AccessConditionsComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :use_and_reproduction_display_data, :copyright_display_data,
+               :license_display_data, to: :cocina_record
+
+      def call
+        render Metadata::SectionComponent.new(label: I18n.t('metadata.access')) do
+          render Metadata::Cocina::FieldComponent.with_collection(access_conditions)
+        end
+      end
+
+      def render?
+        access_conditions.present?
+      end
+
+      private
+
+      def access_conditions
+        @access_conditions ||= [use_and_reproduction_display_data,
+                                copyright_display_data,
+                                license_display_data].compact.flatten
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/bibliographic_component.html.erb
+++ b/app/components/metadata/cocina/bibliographic_component.html.erb
@@ -1,0 +1,6 @@
+<%= render Metadata::SectionComponent.new(label: I18n.t('metadata.bibliographic')) do %>
+  <%= render Metadata::Cocina::FieldComponent.with_collection(general_note_display_data) %>
+  <%= render Metadata::Cocina::RelatedResourcesFieldComponent.with_collection(related_resource_display_data) %>
+  <%= render Metadata::Cocina::FieldComponent.with_collection(identifier_display_data) %>
+  <%= render Metadata::Cocina::FieldComponent.with_collection(access_display_data) %>
+<% end %>

--- a/app/components/metadata/cocina/bibliographic_component.rb
+++ b/app/components/metadata/cocina/bibliographic_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina bibliographic metadata
+    class BibliographicComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :general_note_display_data, :identifier_display_data,
+               :access_display_data, :related_resource_display_data, to: :cocina_record
+
+      def render?
+        general_note_display_data.present? ||
+          related_resource_display_data.present? ||
+          identifier_display_data.present? ||
+          access_display_data.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/contact_component.rb
+++ b/app/components/metadata/cocina/contact_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina contact
+    class ContactComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :contact_email_display_data, to: :cocina_record
+
+      def call
+        render Metadata::SectionComponent.new(label: I18n.t('metadata.contact')) do
+          render Metadata::Cocina::FieldComponent.with_collection(contact_email_display_data)
+        end
+      end
+
+      def render?
+        contact_email_display_data.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/contributor_component.rb
+++ b/app/components/metadata/cocina/contributor_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina contributor
+    class ContributorComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :contributor_display_data, to: :@cocina_record
+
+      def call
+        render Metadata::SectionComponent.new(label: I18n.t('metadata.contributors')) do
+          render Metadata::Cocina::FieldComponent.with_collection(contributor_display_data)
+        end
+      end
+
+      def render?
+        contributor_display_data.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/description_component.rb
+++ b/app/components/metadata/cocina/description_component.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina description
+    class DescriptionComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :form_display_data, :language_display_data,
+               :form_note_display_data, :map_display_data,
+               :event_note_display_data, :event_date_display_data, to: :cocina_record
+
+      def call
+        render Metadata::SectionComponent.new(label: I18n.t('metadata.description')) do
+          render Metadata::Cocina::FieldComponent.with_collection(description)
+        end
+      end
+
+      def render?
+        description.present?
+      end
+
+      private
+
+      def description
+        @description ||= [title_display_data,
+                          form_display_data,
+                          publication_places,
+                          publisher,
+                          event_date_display_data,
+                          event_note_display_data,
+                          language_display_data,
+                          form_note_display_data,
+                          map_display_data].compact.flatten
+      end
+
+      def title_display_data
+        cocina_record.title_display_data.reject { it.label == 'Title' }
+      end
+
+      def publication_places
+        CocinaDisplay::DisplayData.from_strings(@cocina_record.publication_places, label: 'Place').presence
+      end
+
+      def publisher
+        CocinaDisplay::DisplayData.from_strings(@cocina_record.publisher_names, label: 'Publisher').presence
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/field_component.rb
+++ b/app/components/metadata/cocina/field_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display a Cocina field with label and values
+    class FieldComponent < ViewComponent::Base
+      # @param field [CocinaDisplay::DisplayData]
+      def initialize(field:)
+        @field = field
+        super()
+      end
+
+      def call
+        tag.dt(@field.label) +
+          Metadata::Cocina::ValueComponent.new(values: @field.values).call
+      end
+
+      def render?
+        @field.present? && @field.values.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/labeled_link_component.rb
+++ b/app/components/metadata/cocina/labeled_link_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # A component for rendering an HTML link with custom link text.
+    class LabeledLinkComponent < ViewComponent::Base
+      # @param url [String] the URL for the link
+      # @param link_text [String] the text to display for the link
+      def initialize(url:, link_text:)
+        @url = url
+        @link_text = link_text
+        super()
+      end
+
+      def call
+        tag.dd link_to(@link_text, @url)
+      end
+
+      def render?
+        @url.present? && @link_text.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/related_resource_component.html.erb
+++ b/app/components/metadata/cocina/related_resource_component.html.erb
@@ -1,0 +1,10 @@
+<dd>
+  <details data-details-container-target="detailItem" data-action="details-container#toggleButtonText">
+    <summary>
+      <%= summary %>
+    </summary>
+    <dl>
+      <%= render Metadata::Cocina::FieldComponent.with_collection(display_data) %>
+    </dl>
+  </details>
+</dd>

--- a/app/components/metadata/cocina/related_resource_component.rb
+++ b/app/components/metadata/cocina/related_resource_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # A component for rendering a resource related to the current object.
+    class RelatedResourceComponent < ViewComponent::Base
+      # @param related_resource [CocinaDisplay::RelatedResource]
+      def initialize(related_resource:)
+        @related_resource = related_resource
+        super()
+      end
+
+      def summary
+        @related_resource.display_data.first.values.join('; ')
+      end
+
+      def display_data
+        @related_resource.display_data.drop(1)
+      end
+
+      def render?
+        @related_resource.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/related_resources_field_component.html.erb
+++ b/app/components/metadata/cocina/related_resources_field_component.html.erb
@@ -1,0 +1,9 @@
+<div data-controller="details-container">
+  <dt>
+    <%= label %>
+    <%= toggle_button %>
+  </dt>
+  <% child_components.each do |child_component| %>
+    <%= render child_component %>
+  <% end %>
+</div>

--- a/app/components/metadata/cocina/related_resources_field_component.rb
+++ b/app/components/metadata/cocina/related_resources_field_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # A component for rendering resources related to the current object.
+    class RelatedResourcesFieldComponent < ViewComponent::Base
+      # @param [CocinaDisplay::DisplayData] related_resources_field
+      def initialize(related_resources_field:)
+        @related_resources_field = related_resources_field
+        super()
+      end
+
+      attr_accessor :related_resources_field
+
+      delegate :label, to: :related_resources_field
+
+      def render?
+        related_resources_field.present?
+      end
+
+      def child_components
+        related_resources.map { |related_resource| child_component(related_resource) }
+      end
+
+      def toggle_button
+        return unless toggle_button_visible?
+
+        tag.button 'Expand all',
+                   class: 'btn btn-link text-uppercase align-baseline py-0',
+                   data: { action: 'details-container#toggleDetails',
+                           details_container_target: 'toggleButton' }
+      end
+
+      private
+
+      def related_resources
+        related_resources_field.objects
+      end
+
+      def toggle_button_visible?
+        related_resources.none? { it.url? || it.display_data.one? }
+      end
+
+      # If the related resource has a URL, render it has a labeled link.
+      # If it has only one display data entry, render it like regular values.
+      # Otherwise, render it using the nested presentation (e.g. Parker citations).
+      # @param [CocinaDisplay::RelatedResource] related_resource
+      def child_component(related_resource)
+        if related_resource.url?
+          Metadata::Cocina::LabeledLinkComponent.new(url: related_resource.url, link_text: related_resource.to_s)
+        elsif related_resource.display_data.one?
+          Metadata::Cocina::ValueComponent.new(values: related_resource.display_data.first.values)
+        else
+          Metadata::Cocina::RelatedResourceComponent.new(related_resource: related_resource)
+        end
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/subject_component.rb
+++ b/app/components/metadata/cocina/subject_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina abstract and contents metadata
+    class SubjectComponent < ViewComponent::Base
+      # @param cocina_record [CocinaDisplay::CocinaRecord]
+      def initialize(cocina_record:)
+        @cocina_record = cocina_record
+        super()
+      end
+
+      attr_reader :cocina_record
+
+      delegate :subject_display_data, :genre_display_data, to: :cocina_record
+
+      def call
+        render Metadata::SectionComponent.new(label: I18n.t('metadata.subjects')) do
+          render Metadata::Cocina::FieldComponent.with_collection(subjects_and_genres)
+        end
+      end
+
+      def render?
+        subjects_and_genres.present?
+      end
+
+      private
+
+      def subjects_and_genres
+        @subjects_and_genres ||= [subject_display_data, genre_display_data].compact.flatten
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina/value_component.rb
+++ b/app/components/metadata/cocina/value_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Metadata
+  module Cocina
+    # Component to display Cocina values
+    class ValueComponent < ViewComponent::Base
+      # @param values [Array<String>] the values to display
+      def initialize(values:)
+        @values = values
+        super()
+      end
+
+      def call
+        @values.map do |value|
+          tag.dd auto_link(value)
+        end.join.html_safe # rubocop:disable Rails/OutputSafety
+      end
+
+      def render?
+        @values.present?
+      end
+    end
+  end
+end

--- a/app/components/metadata/cocina_component.html.erb
+++ b/app/components/metadata/cocina_component.html.erb
@@ -1,0 +1,7 @@
+<%= render Metadata::Cocina::ContributorComponent.new(cocina_record:) %>
+<%= render Metadata::Cocina::DescriptionComponent.new(cocina_record:) %>
+<%= render Metadata::Cocina::AbstractContentsComponent.new(cocina_record:) %>
+<%= render Metadata::Cocina::SubjectComponent.new(cocina_record:) %>
+<%= render Metadata::Cocina::BibliographicComponent.new(cocina_record:) %>
+<%= render Metadata::Cocina::ContactComponent.new(cocina_record:) %>
+<%= render Metadata::Cocina::AccessConditionsComponent.new(cocina_record:) %>

--- a/app/components/metadata/cocina_component.rb
+++ b/app/components/metadata/cocina_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metadata
+  # Component for displaying Cocina metadata sections
+  class CocinaComponent < ViewComponent::Base
+    def initialize(document:)
+      @document = document
+      super()
+    end
+
+    delegate :cocina_record, to: :purl
+
+    # TODO: In future work we will want something indexed to indicate whether
+    #       we should display metadata from Cocina.
+    def render?
+      Settings.cocina.metadata_display_source
+    end
+
+    def purl
+      @purl || Purl.new(@document.id)
+    end
+  end
+end

--- a/app/components/metadata/mods_component.rb
+++ b/app/components/metadata/mods_component.rb
@@ -11,7 +11,7 @@ module Metadata
     delegate :mods, to: :@document
 
     def render?
-      @document.modsxml.present?
+      @document.modsxml.present? && !Settings.cocina.metadata_display_source
     end
   end
 end

--- a/app/components/metadata/section_component.html.erb
+++ b/app/components/metadata/section_component.html.erb
@@ -1,4 +1,3 @@
-
 <div class="section">
   <div class="section-heading">
     <h4><%= label %></h4>

--- a/app/components/metadata_button_component.rb
+++ b/app/components/metadata_button_component.rb
@@ -8,7 +8,9 @@ class MetadataButtonComponent < ViewComponent::Base
     super()
   end
 
+  # TODO: In future work we will want something indexed to indicate whether
+  #       we should show this button for cocina records.
   def render?
-    @document.modsxml.present?
+    @document.modsxml.present? || Settings.cocina.metadata_display_source
   end
 end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -51,6 +51,12 @@ class Purl
     end
   end
 
+  # @return [CocinaDisplay::CocinaRecord] an object from the cocina-display gem that provides
+  # methods for accessing Cocina metadata for indexing and display
+  def cocina_record
+    @cocina_record ||= CocinaDisplay::CocinaRecord.new(JSON.parse(purl_cocina_service.response_body.presence || '{}'))
+  end
+
   # @return [String] the value of the type attribute for a DOR object's contentMetadata
   #  more info about these values is here:
   #  https://consul.stanford.edu/display/chimera/DOR+content+types%2C+resource+types+and+interpretive+metadata
@@ -95,6 +101,10 @@ class Purl
 
   def purl_service
     @purl_service ||= PurlService.new(bare_druid, format: :xml)
+  end
+
+  def purl_cocina_service
+    @purl_cocina_service ||= PurlService.new(bare_druid, format: :json)
   end
 
   def mods_xml

--- a/app/views/metadata/show.html.erb
+++ b/app/views/metadata/show.html.erb
@@ -11,6 +11,7 @@
     </div>
     <div class="modal-body">
       <%= render Metadata::ModsComponent.new(document: @document) %>
+      <%= render Metadata::CocinaComponent.new(document: @document) %>
     </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-outline-primary view-in-modal" data-bl-dismiss="modal">Close</button>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,9 @@ GOOGLE_SITE_VERIFICATION: "654321sitever"
 # in shared_configs for exhibits-prod, we set this value to false.
 analytics_debug: true
 
+cocina:
+  metadata_display_source: false
+
 purl:
   url: "https://purl.stanford.edu/%{druid}"
   uat_url: "https://sul-purl-uat.stanford.edu/%{druid}"

--- a/spec/components/metadata/cocina/bibliographic_component_spec.rb
+++ b/spec/components/metadata/cocina/bibliographic_component_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Metadata::Cocina::BibliographicComponent, type: :component do
+  subject(:rendered) do
+    render_inline(described_class.new(cocina_record:)).to_html
+  end
+
+  let(:cocina_record) do
+    CocinaDisplay::CocinaRecord.new(JSON.parse(File.read(File.join(FIXTURES_PATH, "/cocina/#{druid}.json"))))
+  end
+  let(:druid) { 'hp566jq8781' }
+
+  context 'when the record has multiple nested related resources' do
+    it 'renders the related resources using nested presentation' do
+      expect(rendered).to have_css 'h4', text: 'Bibliographic information'
+      expect(rendered).to have_css 'dt', text: 'Contains'
+      expect(rendered).to have_css 'dt button', text: 'Expand all'
+      within 'dd details' do
+        expect(rendered).to have_css 'dl dt', text: 'Nasmith'
+        expect(rendered).to have_css 'dl dd', text: 'Epitome chronicae Cicestrensis, sed extractum ' \
+                                                    'e Polychronico, usque ad annum Christi 1429. 1r-29v'
+      end
+    end
+  end
+
+  context 'when the record has a related resource with a labeled URL' do
+    let(:druid) { 'vc287zp9960' }
+
+    it 'renders the related resource as a labeled link' do
+      expect(rendered).to have_css 'h4', text: 'Bibliographic information'
+      expect(rendered).to have_css 'dt', text: 'Related item'
+      expect(rendered).to have_link text: 'Link to SearchWorks record for conserved item',
+                                    href: 'https://searchworks.stanford.edu/view/513014'
+    end
+  end
+
+  context 'when the record has related resources with a single value' do
+    let(:druid) { 'hm136qv0310' }
+
+    it 'renders the related resource without nesting' do
+      expect(rendered).to have_css 'h4', text: 'Bibliographic information'
+      expect(rendered).to have_css 'dt', text: 'Part of'
+      expect(rendered).to have_css 'dd', text: 'Bibliographie de Manon Lescaut: ' \
+                                               "et notes pour servir a l'histoire du livre"
+    end
+  end
+end

--- a/spec/components/metadata/cocina_component_spec.rb
+++ b/spec/components/metadata/cocina_component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Metadata::CocinaComponent, type: :component do
+  subject(:rendered) do
+    render_inline(described_class.new(document: document)).to_html
+  end
+
+  before do
+    allow(Settings.cocina).to receive(:metadata_display_source).and_return(true)
+    stub_request(:get, "https://purl.stanford.edu/#{druid}.json").to_return(
+      body: File.new(File.join(FIXTURES_PATH, "/cocina/#{druid}.json")), status: 200
+    )
+  end
+
+  let(:druid) { 'hp566jq8781' }
+  let(:document) { SolrDocument.new(id: druid) }
+
+  context 'when the document has Cocina' do
+    it 'renders the component' do
+      expect(rendered).not_to be_empty
+    end
+
+    it 'includes a Description section' do
+      expect(rendered).to have_css 'h4', text: 'Description'
+      expect(rendered).to have_css 'dt', text: 'Alternative title'
+      expect(rendered).to have_css 'dd', text: 'Chronica. Anglo-Saxon fragments, etc.'
+    end
+
+    it 'includes an Abstract/Contents section' do
+      expect(rendered).to have_css 'h4', text: 'Abstract/Contents'
+      expect(rendered).to have_css 'dt', text: 'Contents'
+      expect(rendered).to have_css 'dd', text: 'Polychronicon (epitome and continuation to 1429) '
+    end
+
+    it 'includes a Bibliographic information section' do
+      expect(rendered).to have_css 'h4', text: 'Bibliographic information'
+      expect(rendered).to have_css 'dt', text: 'Downloadable James Catalogue Record'
+      expect(rendered).to have_link text: 'https://stacks.stanford.edu/file/druid:vz744tc9861/MS_367.pdf',
+                                    href: 'https://stacks.stanford.edu/file/druid:vz744tc9861/MS_367.pdf'
+    end
+
+    it 'includes an Access conditions section' do
+      expect(rendered).to have_css 'h4', text: 'Access conditions'
+      expect(rendered).to have_css 'dt', text: 'License'
+      expect(rendered).to have_css 'dd', text: 'This work is licensed under a Creative Commons Attribution Non ' \
+                                               'Commercial 4.0 International license (CC BY-NC).'
+    end
+
+    context 'when the document has contacts' do
+      let(:druid) { 'zb733jx3137' }
+
+      it 'includes a Contacts section' do
+        expect(rendered).to have_css 'h4', text: 'Contact information'
+        expect(rendered).to have_css 'dt', text: 'Contact'
+        expect(rendered).to have_link text: 'testing@me.com', href: 'mailto:testing@me.com'
+      end
+    end
+
+    context 'when the document has subjects and contributors' do
+      let(:druid) { 'gf752kr0559' }
+
+      it 'includes a Contributors section' do
+        expect(rendered).to have_css 'h4', text: 'Creators/Contributors'
+        expect(rendered).to have_css 'dt', text: 'Interviewee'
+        expect(rendered).to have_css 'dd', text: 'Osula, Anna Maria'
+      end
+
+      it 'includes a Subjects section' do
+        expect(rendered).to have_css 'h4', text: 'Subjects'
+        expect(rendered).to have_css 'dt', text: 'Subject'
+        expect(rendered).to have_css 'dd', text: 'Estonia > Politics and government'
+      end
+    end
+  end
+end

--- a/spec/fixtures/cocina/gf752kr0559.json
+++ b/spec/fixtures/cocina/gf752kr0559.json
@@ -1,0 +1,738 @@
+{
+  "cocinaVersion": "0.99.0",
+  "type": "https://cocina.sul.stanford.edu/models/media",
+  "externalIdentifier": "druid:gf752kr0559",
+  "label": "Oral history with Anna Maria Osula",
+  "version": 5,
+  "access": {
+    "view": "world",
+    "download": "none",
+    "controlledDigitalLending": false,
+    "copyright": "Materials may be subject to copyright.",
+    "useAndReproductionStatement": "While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, their heir(s) or assigns. When required, it is the researcher's responsibility to obtain such permissions."
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:yd614vy3131"
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Oral history with Anna Maria Osula",
+        "status": "primary",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Velmet, Aro",
+            "uri": "http://id.loc.gov/authorities/names/no2020053050",
+            "identifier": [],
+            "source": {
+              "code": "naf",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "interviewee",
+            "code": "ive",
+            "uri": "/ive",
+            "identifier": [],
+            "source": {
+              "code": "marcrelator",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "affiliation": [],
+        "note": [],
+        "parallelContributor": []
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Osula, Anna Maria",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "interviewee",
+            "code": "ive",
+            "uri": "/ive",
+            "identifier": [],
+            "source": {
+              "code": "marcrelator",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "affiliation": [],
+        "note": [],
+        "parallelContributor": []
+      }
+    ],
+    "event": [
+      {
+        "structuredValue": [],
+        "type": "creation",
+        "date": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "2024-05-14",
+            "type": "creation",
+            "status": "primary",
+            "encoding": {
+              "value": "w3cdtf",
+              "note": []
+            },
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [],
+        "identifier": [],
+        "note": [],
+        "parallelEvent": []
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "moving image",
+        "type": "resource type",
+        "identifier": [],
+        "source": {
+          "value": "MODS resource types",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "other computer carrier",
+        "type": "form",
+        "uri": "https://id.loc.gov/vocabulary/carriers/cz",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "2 video files",
+        "type": "extent",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Oral histories",
+        "type": "genre",
+        "uri": "http://id.loc.gov/authorities/genreForms/gf2011026431",
+        "identifier": [],
+        "source": {
+          "code": "lcgft",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "access",
+        "type": "reformatting quality",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "born digital",
+        "type": "digital origin",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "video/mp4",
+        "type": "media type",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "image/jpeg",
+        "type": "media type",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Sound",
+            "identifier": [],
+            "displayLabel": "Sound content",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Color",
+            "identifier": [],
+            "displayLabel": "Color content",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      }
+    ],
+    "geographic": [],
+    "language": [
+      {
+        "appliesTo": [],
+        "code": "eng",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": {
+          "code": "iso632-2b",
+          "note": []
+        },
+        "structuredValue": [],
+        "uri": "/eng",
+        "value": "English"
+      }
+    ],
+    "note": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Dr. Anna-Maria Osula is a senior policy officer at Guardtime, with a focus on cybersecurity policy and regulation and supporting international research and development projects. She previously worked as a legal researcher at the NATO Cooperative Cyber Defence Centre of Excellence (NATO CCD COE), focusing on national cybersecurity strategies, international organisations and norms, and international criminal cooperation. She is interviewed by Aro Velmet, who is a historian of modern Europe, colonialism, science, technology, and medicine. In the interview, the interviewee talks about her involvement with the field of cybersecurity. She started working at the NATO cybersecurity center in 2008 and moved from there to the private sector. Initially, she had studied law at Tartu University and found information technology law particularly interesting; it made sense to move from there to work on cybersecurity. The interviewer asks about the 2007 cyberattacks against Estonia, which prompted several cybersecurity initiatives. Osula talks about how Estonia faced coordinated cyberattacks on government, banks, news portals, and other institutions, which at the time were substantial, but today do not seem particularly big. These were the first coordinated cyberattacks against a nation-state. Later developments were often reactions to this event. Estonia adopted its first cybersecurity strategy in 2008, notable for the fact that it did not treat cybersecurity as a purely technical issue. It is now revising its fourth strategy. Cybersecurity became a topic discussed on the international stage, at NATO and the European Union. Osula discusses her experience of the 2007 riots, the following cyberattacks, and the resulting confusion and disbelief. At the time, the response was ad hoc; since then, coordination plans, strategies, and gamed-out scenarios have been put in place. Estonia’s role in the UN Security Council (SC) was to bring attention and start a more detailed discussion about cybersecurity, partly by bringing this topic to the SC’s official agenda. One important question is responsible state behavior in cyberspace. Are the rules the same as in real life? How can states cooperate in times of crisis? One complicated issue is attribution: how do you define who is responsible for a certain action? Osula notes there are different kinds of attribution: technical attribution, political attribution, legal attribution. Countries approach this issue in different ways; some countries say that they have enough technical footprints, but the problem is a political willingness. Another complicated issue is consequences for cyberattacks. It is understood that international law applies to cyberspace as well as physical space, but how does this understanding translate to a court case, and how enforceable would a possible decision be? Osula talks about various challenges to cybersecurity, including technological and coordination challenges, and thinks about responsible state behavior, including how to talk openly about threats and share knowledge. Using confidence-building measures may prevent conflict before it even starts, bolstered by treaties between states who want to have more stability in cyberspace. Osula concludes plans can only be fulfilled when we raise capacity.",
+        "type": "abstract",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "This interview was produced as part of a joint project between Vabamu Museum of Occupations and Freedom and Stanford Libraries, in conjuctions with an exhibit on e-Estonia.",
+        "type": "provenance",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Dr Anna-Maria Osula is a senior policy officer at Guardtime, with a focus on cybersecurity policy and regulation and supporting international R&D projects. She previously worked as a legal researcher at the NATO CCD COE, focusing on national cybersecurity strategies, international organisations, and international criminal cooperation and norms.",
+        "type": "biographical/historical",
+        "identifier": [],
+        "displayLabel": "Interviewee biography",
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Aro Velmet is a historian of modern Europe, colonialism, science, technology, and medicine. He is interested in how utopias of technological progress are put in the service of statecraft, how experts, interest groups, and subalterns use political technologies, and in the unintended consequences of technological development.",
+        "type": "biographical/historical",
+        "identifier": [],
+        "displayLabel": "Interviewer biography",
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "identifier": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "sul:m3032_2024-218_osula",
+        "type": "local",
+        "identifier": [],
+        "displayLabel": "Source ID",
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "subject": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Internet in public administration",
+        "type": "topic",
+        "uri": "http://id.loc.gov/authorities/subjects/sh2001002285",
+        "identifier": [],
+        "source": {
+          "code": "lcsh",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Estonia",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Politics and government",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Computer security",
+        "type": "topic",
+        "uri": "http://id.loc.gov/authorities/subjects/sh90001862",
+        "identifier": [],
+        "source": {
+          "code": "lcsh",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "access": {
+      "url": [],
+      "physicalLocation": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "M3032",
+          "type": "shelf locator",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "digitalLocation": [],
+      "accessContact": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Stanford University. Libraries. Department of Special Collections and University Archives",
+          "type": "repository",
+          "uri": "http://id.loc.gov/authorities/names/no2014019980",
+          "identifier": [],
+          "source": {
+            "code": "naf",
+            "note": []
+          },
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "digitalRepository": [],
+      "note": []
+    },
+    "relatedResource": [],
+    "marcEncodedData": [],
+    "adminMetadata": {
+      "contributor": [
+        {
+          "name": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "code": "CSt",
+              "uri": "http://id.loc.gov/vocabulary/organizations/cst",
+              "identifier": [],
+              "source": {
+                "code": "marcorg",
+                "note": []
+              },
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "type": "organization",
+          "role": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "original cataloging agency",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "identifier": [],
+          "affiliation": [],
+          "note": [],
+          "parallelContributor": []
+        }
+      ],
+      "event": [],
+      "language": [
+        {
+          "appliesTo": [],
+          "code": "eng",
+          "groupedValue": [],
+          "note": [],
+          "parallelValue": [],
+          "structuredValue": [],
+          "uri": "http://id.loc.gov/vocabulary/iso639-2/eng",
+          "value": "English"
+        }
+      ],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "human prepared",
+          "type": "record origin",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "metadataStandard": [],
+      "identifier": []
+    },
+    "purl": "https://purl.stanford.edu/gf752kr0559"
+  },
+  "identification": {
+    "catalogLinks": [],
+    "sourceId": "sul:m3032_2024-218_osula"
+  },
+  "structural": {
+    "contains": [
+      {
+        "type": "https://cocina.sul.stanford.edu/models/resources/video",
+        "externalIdentifier": "gf752kr0559_1",
+        "label": "Video file (short)",
+        "version": 1,
+        "structural": {
+          "contains": [
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/a94063d4-042e-4dba-9955-305c679657e3",
+              "label": "gf752kr0559_Anna-Maria_Osula_short_sl.mp4",
+              "filename": "gf752kr0559_Anna-Maria_Osula_short_sl.mp4",
+              "size": 80261444,
+              "version": 1,
+              "hasMimeType": "video/mp4",
+              "languageTag": null,
+              "use": null,
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "md5",
+                  "digest": "4dc9ec8854cf90c4372c0f47823fad2d"
+                },
+                {
+                  "type": "sha1",
+                  "digest": "b3bc332abb5d72cacca2e0bd4511c27ff0269feb"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "none",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": true,
+                "shelve": true
+              }
+            },
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/759e63a3-dad0-4d68-bcff-b3044adfbb55",
+              "label": "gf752kr0559_Anna-Maria_Osula_short_thumb.jp2",
+              "filename": "gf752kr0559_Anna-Maria_Osula_short_thumb.jp2",
+              "size": 457096,
+              "version": 1,
+              "hasMimeType": "image/jp2",
+              "languageTag": null,
+              "use": null,
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "md5",
+                  "digest": "c6aede444caea36a3ecf02d2b799a02d"
+                },
+                {
+                  "type": "sha1",
+                  "digest": "859f8e82b16ff12c1159ba37356cd06a3679e9db"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "none",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": true,
+                "shelve": true
+              },
+              "presentation": {
+                "height": 720,
+                "width": 1280
+              }
+            },
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/9bbb82b2-f3c5-4319-a3d8-e8f7c966acbf",
+              "label": "gf752kr0559_Anna-Maria_Osula_short_cap.vtt",
+              "filename": "gf752kr0559_Anna-Maria_Osula_short_cap.vtt",
+              "size": 4269,
+              "version": 1,
+              "hasMimeType": "text/vtt",
+              "languageTag": "en",
+              "use": "caption",
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "md5",
+                  "digest": "e681af2dd480d6ba41b90dd40cff1b1c"
+                },
+                {
+                  "type": "sha1",
+                  "digest": "e460177f7176aaaaf55f2a4249c7e715096a6581"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "world",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": true,
+                "shelve": true
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "https://cocina.sul.stanford.edu/models/resources/video",
+        "externalIdentifier": "gf752kr0559_2",
+        "label": "Video file",
+        "version": 1,
+        "structural": {
+          "contains": [
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/e84510b7-9809-4207-9634-d39e64e1dcf4",
+              "label": "gf752kr0559_Anna-Maria_Osula_sl.mp4",
+              "filename": "gf752kr0559_Anna-Maria_Osula_sl.mp4",
+              "size": 532005258,
+              "version": 1,
+              "hasMimeType": "video/mp4",
+              "languageTag": null,
+              "use": null,
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "md5",
+                  "digest": "b71eaeabeafed185be35dc33cb9260a3"
+                },
+                {
+                  "type": "sha1",
+                  "digest": "f52468be3ad422c33cca5e4ed8779fd5648d891e"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "none",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": true,
+                "shelve": true
+              }
+            },
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/f491bd7c-60da-4e4f-a958-a58bba525ba0",
+              "label": "gf752kr0559_Anna-Maria_Osula_thumb.jp2",
+              "filename": "gf752kr0559_Anna-Maria_Osula_thumb.jp2",
+              "size": 463344,
+              "version": 1,
+              "hasMimeType": "image/jp2",
+              "languageTag": null,
+              "use": null,
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "md5",
+                  "digest": "0d81ecbbb7c11693eba11cd702c4a9b4"
+                },
+                {
+                  "type": "sha1",
+                  "digest": "12380c1e64923d7e0ea3a66a8ed9c20cfcad9da5"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "none",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": true,
+                "shelve": true
+              },
+              "presentation": {
+                "height": 720,
+                "width": 1280
+              }
+            },
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/29ad3706-a919-4ff6-b14a-b2412c189b01",
+              "label": "gf752kr0559_Anna-Maria_Osula_cap.vtt",
+              "filename": "gf752kr0559_Anna-Maria_Osula_cap.vtt",
+              "size": 26072,
+              "version": 1,
+              "hasMimeType": "text/vtt",
+              "languageTag": "en",
+              "use": "caption",
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "md5",
+                  "digest": "e10d83b37a43feb001d5e81037894c81"
+                },
+                {
+                  "type": "sha1",
+                  "digest": "5d957dabdc1fcdd7e2cea7928eca89c2b5ae49c0"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "world",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": true,
+                "shelve": true
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "hasMemberOrders": [],
+    "isMemberOf": [
+      "druid:gp217cm8336"
+    ]
+  },
+  "created": "2024-11-19T00:18:44.000+00:00",
+  "modified": "2024-11-19T00:19:54.000+00:00",
+  "lock": "druid:gf752kr0559=10=2"
+}

--- a/spec/fixtures/cocina/hm136qv0310.json
+++ b/spec/fixtures/cocina/hm136qv0310.json
@@ -1,0 +1,426 @@
+{
+  "cocinaVersion": "0.75.0",
+  "type": "https://cocina.sul.stanford.edu/models/book",
+  "externalIdentifier": "druid:hm136qv0310",
+  "label": "Bibliographie de Manon Lescaut : et notes pour servir a l'histoire du livre",
+  "version": 7,
+  "access": {
+    "view": "world",
+    "download": "world",
+    "controlledDigitalLending": false,
+    "copyright": null,
+    "useAndReproductionStatement": "This material is believed to be in the public domain. There are no restrictions on use of public domain materials. For questions, please contact spec-rarebooks@lists.stanford.edu.",
+    "license": null
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:zw808bc8730",
+    "releaseTags": [
+      {
+        "who": "blalbrit",
+        "what": "self",
+        "date": "2022-12-12T22:07:20.000+00:00",
+        "to": "Searchworks",
+        "release": false
+      }
+    ]
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Bibliographie de Manon Lescaut",
+            "type": "main title",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "et notes pour servir a l'histoire du livre",
+            "type": "subtitle",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Harrisse, Henry",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [],
+        "identifier": [],
+        "note": [],
+        "parallelContributor": []
+      }
+    ],
+    "event": [
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "1877",
+            "type": "publication",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "D. Margand et C. Fatout",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "organization",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "publisher",
+                "code": "pbl",
+                "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "uri": "http://id.loc.gov/vocabulary/relators/",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "location": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "fr",
+            "identifier": [],
+            "source": {
+              "code": "marccountry",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "monographic",
+            "type": "issuance",
+            "identifier": [],
+            "source": {
+              "value": "MODS issuance terms",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "2. éd., rev. et augm.",
+            "type": "edition",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelEvent": []
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "bibliography",
+        "type": "genre",
+        "identifier": [],
+        "source": {
+          "code": "marcgt",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "bibliography",
+        "type": "genre",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "text",
+        "type": "resource type",
+        "identifier": [],
+        "source": {
+          "value": "MODS resource types",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "print",
+        "type": "form",
+        "identifier": [],
+        "source": {
+          "code": "marcform",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "geographic": [],
+    "language": [
+      {
+        "appliesTo": [],
+        "code": "fre",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": {
+          "code": "iso639-2b",
+          "uri": "http://id.loc.gov/vocabulary/iso639-2",
+          "note": []
+        },
+        "structuredValue": [],
+        "uri": "http://id.loc.gov/vocabulary/iso639-2/fre",
+        "value": "French"
+      }
+    ],
+    "note": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "par M. Henry Harrisse.",
+        "type": "statement of responsibility",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Half-title:Bibliographie de Manon Lescaut, 1728-1731-1753.",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "identifier": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "f 01003181",
+        "type": "LCCN",
+        "identifier": [],
+        "source": {
+          "code": "lccn",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "RBT0046",
+        "identifier": [],
+        "displayLabel": "Title ID",
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Harrisse, Henry (1829-1910)",
+        "identifier": [],
+        "displayLabel": "Name",
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "subject": [
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Prévost",
+            "type": "person",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Manon Lescaut",
+            "type": "title",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Bibliography",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "lcsh",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Literature",
+        "type": "topic",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "relatedResource": [
+      {
+        "type": "part of",
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Bibliographie de Manon Lescaut: et notes pour servir a l'histoire du livre",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      }
+    ],
+    "marcEncodedData": [],
+    "adminMetadata": {
+      "contributor": [],
+      "event": [],
+      "language": [],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Converted from MARCXML to MODS version 3.6 using MARC21slim2MODS3-6_SDR.xsl (SUL version 1 2018/06/13; LC Revision 1.118 2018/01/31)",
+          "type": "record origin",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "metadataStandard": [],
+      "identifier": []
+    },
+    "purl": "https://purl.stanford.edu/hm136qv0310"
+  },
+  "identification": {
+    "catalogLinks": [
+      {
+        "catalog": "folio",
+        "refresh": true,
+        "catalogRecordId": "a1518292"
+      },
+      {
+        "catalog": "symphony",
+        "refresh": true,
+        "catalogRecordId": "1518292"
+      }
+    ],
+    "sourceId": "rbi:BHARRISS"
+  },
+  "structural": {},
+  "created": "2022-12-12T19:28:43.000+00:00",
+  "modified": "2022-12-12T19:28:43.000+00:00",
+  "lock": "druid:hm136qv0310=0"
+}

--- a/spec/fixtures/cocina/hp566jq8781.json
+++ b/spec/fixtures/cocina/hp566jq8781.json
@@ -1,0 +1,2816 @@
+{
+  "cocinaVersion": "0.75.0",
+  "type": "https://cocina.sul.stanford.edu/models/book",
+  "externalIdentifier": "druid:hp566jq8781",
+  "label": "Cambridge, Corpus Christi College, MS 367: Miscellaneous Compilation including Old English Material and Historical and Philosophical Works",
+  "version": 10,
+  "access": {
+    "view": "world",
+    "download": "world",
+    "controlledDigitalLending": false,
+    "useAndReproductionStatement": "Images courtesy of The Parker Library, Corpus Christi College, Cambridge. Licensed under a Creative Commons Attribution-NonCommercial 4.0 International License. For higher resolution images suitable for scholarly or commercial publication, either in print or in an electronic format, please contact the Parker Library directly at parker-library@corpus.cam.ac.uk",
+    "license": "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:bm077td6448",
+    "releaseTags": []
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Cambridge, Corpus Christi College, MS 367: Miscellaneous Compilation including Old English Material and Historical and Philosophical Works",
+        "identifier": [],
+        "source": {
+          "code": "Corpus Christi College",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Chronica. Anglo-Saxon fragments, etc.",
+        "type": "alternative",
+        "identifier": [],
+        "source": {
+          "code": "James Catalog",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [],
+    "event": [
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1400",
+                "type": "start",
+                "status": "primary",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1499",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "creation",
+            "encoding": {
+              "code": "w3cdtf",
+              "note": []
+            },
+            "identifier": [],
+            "qualifier": "approximate",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [],
+        "identifier": [],
+        "note": [],
+        "parallelEvent": []
+      },
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1300",
+                "type": "start",
+                "status": "primary",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1399",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "creation",
+            "encoding": {
+              "code": "w3cdtf",
+              "note": []
+            },
+            "identifier": [],
+            "qualifier": "approximate",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [],
+        "identifier": [],
+        "note": [],
+        "parallelEvent": []
+      },
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1000",
+                "type": "start",
+                "status": "primary",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1099",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "creation",
+            "encoding": {
+              "code": "w3cdtf",
+              "note": []
+            },
+            "identifier": [],
+            "qualifier": "approximate",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [],
+        "identifier": [],
+        "note": [],
+        "parallelEvent": []
+      },
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1000",
+                "type": "start",
+                "status": "primary",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1099",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "creation",
+            "encoding": {
+              "code": "w3cdtf",
+              "note": []
+            },
+            "identifier": [],
+            "qualifier": "approximate",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [],
+        "identifier": [],
+        "note": [],
+        "parallelEvent": []
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "mixed material",
+        "type": "resource type",
+        "identifier": [],
+        "source": {
+          "value": "MODS resource types",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "manuscript",
+        "identifier": [],
+        "source": {
+          "value": "MODS resource types",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "ff. 53 + 52",
+        "type": "extent",
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Paper and vellum",
+            "type": "material",
+            "identifier": [],
+            "displayLabel": "Material",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "five volumes",
+            "type": "layout",
+            "identifier": [],
+            "displayLabel": "Layout",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "220",
+            "type": "dimensions",
+            "identifier": [],
+            "displayLabel": "Height (mm)",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "145",
+            "type": "dimensions",
+            "identifier": [],
+            "displayLabel": "Width (mm)",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Paper: 1(10) 2(10) 3(12) (wants 10-12) 4(14) 5(10). Vellum: a(2) b(2) c(2) d(4) e(2) (2 canc.) f(6) (6 canc.) 8(14) (10 canc.)? A(12). B (three). I(8) (wants 1, 7, 8) II(2) (+1).",
+            "type": "collation",
+            "identifier": [],
+            "displayLabel": "Collation",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "in a smallish hand of cent. xi-xii",
+            "type": "handNote",
+            "identifier": [],
+            "displayLabel": "Writing",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "ff. i-ii + 1-105 + iii-iv",
+            "type": "foliation",
+            "identifier": [],
+            "displayLabel": "Foliation",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Part of the volume seems to be certainly from Worcester.",
+            "type": "provenance",
+            "identifier": [],
+            "displayLabel": "Provenance",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The Anglo-Saxon portions were not described by Wanley and have escaped the notice of subsequent students.",
+            "type": "research",
+            "identifier": [],
+            "displayLabel": "Research",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      }
+    ],
+    "geographic": [],
+    "language": [
+      {
+        "appliesTo": [],
+        "code": "lat",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": {
+          "code": "iso639-2b",
+          "note": []
+        },
+        "structuredValue": []
+      },
+      {
+        "appliesTo": [],
+        "code": "ang",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": {
+          "code": "iso639-2b",
+          "note": []
+        },
+        "structuredValue": []
+      }
+    ],
+    "note": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "CCCC MS 367 consists of five small volumes bound together, probably because Parker wished to protect a number of small items by placing them between covers. The first contains two chronicles, copied in the fifteenth century, an epitome of the Polychronicon by Ranulf Higden OSB (d. 1364), and a chronicle attributed to Thomas Harpsfield. The second consists of a number of fragments of Old English material, copied in the second half of the eleventh or the early twelfth century, and probably to be associated with Worcester: they contain the De temporibus anni by Ælfric of Eynsham OSB (d. 1010), and some homiletic fragments, now out of order. The third volume is a thirteenth- or fourteenth-century copy of Robert Kilwardby OP (d. 1279), De natura relationis. The fourth is a thirteenth-century copy of the Apocalypsis Goliae, a satirical Latin poem sometimes associated with Walter Map (c. 1140-1210), but best considered anonymous. The fifth contains an eleventh-century copy of the Vita breuior of St Kenelm, with a short booklist which has been associated with Worcester, and an Old English account of a vision had by Earl Leofric.",
+        "type": "summary",
+        "identifier": [],
+        "displayLabel": "Summary",
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "xv, xi-xii, xiv, xi",
+        "type": "date",
+        "identifier": [],
+        "displayLabel": "M.R. James Date",
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Polychronicon (epitome and continuation to 1429)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Gesta regum ad Henricum VI",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "De temporibus anni (incomplete)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Fragments of Old English homilies",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "De natura relationis",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Apocalypsis Goliae",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Vita breuior Sancti Kenelmi (incomplete)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Old English Visio Leofrici",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "type": "table of contents",
+        "identifier": [],
+        "displayLabel": "Contents",
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "identifier": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "342",
+        "identifier": [],
+        "displayLabel": "TJames",
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "19. 9",
+        "identifier": [],
+        "displayLabel": "Stanley",
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "subject": [],
+    "access": {
+      "url": [],
+      "physicalLocation": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "MS 367",
+          "type": "shelf locator",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "digitalLocation": [],
+      "accessContact": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "UK, Cambridge, Corpus Christi College, Parker Library",
+          "type": "repository",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "digitalRepository": [],
+      "note": []
+    },
+    "relatedResource": [
+      {
+        "type": "referenced by",
+        "displayLabel": "Downloadable James Catalogue Record",
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "https://stacks.stanford.edu/file/druid:vz744tc9861/MS_367.pdf",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "referenced by",
+        "displayLabel": "Superseded Interim Catalogue Record",
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "https://stacks.stanford.edu/file/druid:pw577ky6421/367.pdf",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Ranulf Higden OSB, Polychronicon (epitome and continuation to 1429)",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1r-29v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Epitome chronicae Cicestrensis, sed extractum e Polychronico, usque ad annum Christi 1429",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1r-29v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Ranulf Higden OSB",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "person",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "author",
+                "uri": "http://id.loc.gov/vocabulary/relators/aut",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(1r) Ieronimus ad eugenium in epistola 43a dicit quod decime leguntur primum date ab abraham",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Dates are marked in the margin",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends with the coronation of Henry VI at St Denis",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(29v) videlicet nono die mensis decembris ano etatis sue 10o",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Thomas Harsfield, Gesta regum ad Henricum VI",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "30r-53r",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Breviarium historiae Angliae ad annum quartum Henrici IV. viz. 1402",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "30r-53r",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Breuiarium",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "30r-53r",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "James",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Thomas Harsfield",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "person",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "author",
+                "uri": "http://id.loc.gov/vocabulary/relators/aut",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Another hand",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "begins with 19 lines",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(30r) IAlbion est terra constans in finibus orbisQuam dedit albina grecorum filia regis...",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(30r) IISuccedunt Reges ab eodem pace fruentesUsque dies nostres ut pandunt scripta legentesNomina scriptorum (tu) [iam] suscipe care RoberteEx libris quorum labor hic monstratur aperteGalifridus gesta Britonum scripsit sapienterAnglorum facta conscripsit Beda patenterWillelmus quondam monachus MalmisberiensisTryuet Martinushenricus huntidonensisPetrus pictauis dat cistrensis monachusque",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(30r) Et quia confrater carissime non solum audiendo sacre scripture verbis aurem sedulus auditor accomodatur (!) tenetur",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(See P. de Yckham)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends with verses (14) on the Battle of Shrewsbury",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(52v) de isto bello quidam versificator sic infert versus",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(52v) In magdalene saturni vespere pleneHenrico IIIIto sunt hec anno sibi iiijto... Nomina cunctorum nescio monstrare virorumNescio plus quorum Christus miseretur eorum",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(53r) Tempore huius regis Owynus quidam Wallensis erigens se in principem Wallie toto vite sue tempore cum Wallensibus rebellauit",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(53r) Explicit",
+            "type": "rubric",
+            "identifier": [],
+            "displayLabel": "Rubric",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(53r) Lower part of leaf cut off. f. 53v blank",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Ælfric OSB, De temporibus anni (incomplete)",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "54r-55v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "De die, mense, de XII signis, &c. (Saxonice)",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "54r-55v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Ælfric OSB",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "person",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "author",
+                "uri": "http://id.loc.gov/vocabulary/relators/aut",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(54r) Þone forman dæg þyssere ƿorulde ƿe magon afindan þurh þes lenctenlices emnihtes dæg. Forþan ðe se emnihtes dæg is se feorða dæg þyssere ƿorulde gesceapennysse",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Treats de luna, de ebdomada, de anno solis, de xii signis, de anno, de diuersis mensibus, de luna, communis annus, embolismus, IIIIor tempora",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "On f. 2v the writing is crowded towards the end. Ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(55v) Eft on langiendum dagum he ofer geð þone suðran sunsted · 7 forþi he byð norþur geseƿen þonne seo sunne on ƿintra · sƿa þeah ne gæð heora",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "It continues on ff. 7r-10r",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(60r) naðor ænne pricon ofer þam þe him geset is. ne dagas ne synd nu naþor lengran ne scyrtran þonne hi æt fruman ƿæron. en Egyptaland ne cymð næfre nan ƿinter",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends f. 10r (on hail, snow, thunder, etc.)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(63r) se bið hlud for þære lyfte bradnysse. frecen ful for þæs fyres sceotugum. beo þeos gesetnyss þus her ge endod",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 10v blank",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "This is Ælfric's extract from Beda de temporibus. Cockayne, Leechdoms III 238",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Fragments of Old English homilies",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "56r-82v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Homeliae quaedam Saxonica, imperfectae",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "56r-82v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Fragments of Homilies",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "56r-82v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "James",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "a.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "A good hand of cent. xii, 30 lines to a page",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(56r) Homily on the Assumption",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "ff. 6r-6v should precede ff. 3r-3v (Thorpe II 436)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(59r) be þisse heofenlican cƿene upstige",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 6v ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(59v) þæt heo un asecgendlice mid criste up",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(56r) ahafen on ecnysse rixige",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends f. 5r. f. 23r has the beginning",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "b.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(58r) viii kalends Septembris. Passio Sancti Bartholomei apostoli",
+            "type": "rubric",
+            "identifier": [],
+            "displayLabel": "Rubric",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(58v) Ƿyrd ƿryteras secgað þæt þre leod scipas",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(Thorpe II 454)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "One page only",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(58v) oþer deofol ƿæs geƿurðod þæs",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(Thorpe II 454)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Continued after break on f. 24r",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "On the margin of f. 30r is a copy of a document (xiii)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(56r) Omnibus ... Walt. de La Fort (?) ... Noueritis me dedisse ... Philipp. filio meo quatuor croppos ... in camp de Henton ... ao v. v. H. Liiio ... Test. Joh. Jokyn. Le FraunkeJoh. Wace ...Wace ...Le fraunke ...",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "c.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(64r) Sexta Idus Septembris. Nativitas Sancte Marie Virginis",
+            "type": "rubric",
+            "identifier": [],
+            "displayLabel": "Rubric",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(64r) Men þa leofestan ƿeorðiat ƿe nu on andƿeardnysse þa gebyr tide",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(Wanley, p. 17, Bodl. NEF. 4. 12)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends imperfectly",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(69v) He þa ioseph aros of þam slæpe. sƿy þe ge",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Assmann, A.-S. Homilien etc. p. 117",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "d.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "In a less good hand, 27 lines to a page",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(70r) On the Lord's Prayer, continued on f. 29r",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(70r) ure rice gif ƿe hit geearnian ƿyllan",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(Thorpe I 264)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "17v ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(70v) Ðæt fifte gebed is. Et dimitte nobis debita nostra sicut et nos dimittimus (29r) debitoribus nostris",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(82v) Sƿa he oftor on þære fandunge",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "e.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 18r follows f. 27v. Homily on Dedication of St Michael's Church. Thorpe II 502 (fragments)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 19r follows f. 28r. Homily on St Matthew. Thorpe II 468",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "g.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 20r-20v, the end of a Homily and beginning of another",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(73r) Feria Secunda",
+            "type": "rubric",
+            "identifier": [],
+            "displayLabel": "Rubric",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(73r) Hit is sƿyðe ged(a)fenlic",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Thorpe I 282. f. 26r continues this",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "h.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 21r-21v single leaf",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(74r) fram þroƿunge to æriste. fra deðe to life",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(74v) þa þa heo ƿearð a þys troð on cristes þroƿunge fram middæge oð non. stanas on",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(Morris, Legends of the Holy Rood, p. 167)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "i.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(75r) gafol oððe tol. æt heora gesiblingum oððe æt fræmdum. Petrus cƿæð æt fræmdum. Se hælend cƿæð, etc.",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(75v) him for godes lufan big ƿiste fore sceaƿað. Ðon hæfð he sƿa miccle",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(On Matt. xvii 24, the fish and tribute-money)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Apparently not found elsewhere: not known to Professor Napier",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "k.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(76r) see a. Homily on the Assumption",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "l.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(77r) see b. On St Bartholomew",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "m.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(78r) I append a copy of the fragment m.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(78r) fram gode · to þe cumen · ; Ic ƿes þine ƿlite · 7 þineƿynsumnesse · 7 þine spæc 7 þin haƿung · 7 þine gehyrnys · 7 þine glednesse; Ic ƿæs þin geþanc · 7þine fægernes · 7 þine lufu · 7 þin gestæþþignes7 þin ge treoƿnes · gif þu ænige treoƿa hæfdest; 7 icƿæs þin gamon · 7 þin gladung · 7 þin hleahtor · 7 þinemyrhþ. Eall þæt þu ƿære. eall ic ƿæs þis on þe 7siþ þan ic ana ƿæs of þe · eall þe lofode · þæt ic nusæde; 7 naht þu ƿære butan me · 7 þu me mid enigumgode ne ge þohtest. ne þinne drihten. þe me þesealde. Ladlice eardunge hæfde ic on þe · æghƿætþæs þe þu hogedest mid þinum flæsce æghƿæt meƿæs þæs earfodlic · on to ge þroƿianne Eall þæt þulufodest. eall þæt ic hatode nære ƿit næfre gletane tid on anum ƿillan. For þan þe þu hyrƿdestgodes bebodu · 7 his haligra lare; Eala eala hreoƿlice · 7 dreorlice. stent þonne þæt deade flesc asmórodne mæg þonne nan andƿyrde syllan. þam his gaste.7 sƿæst sƿiþe ladlicum sƿate · 7 him feallað of. | unfægere dropan · 7 bret on menige fealdumhiƿe. Hƿilum he bið sƿiðe ladlicum men gelice · þonneƿannaþ he 7 doxað · oþre hƿile he bið blac · 7 æm /heoƿe · 7 hƿilum coll sƿeart · 7 gelic þam seo saƿul. heoƿað on yfelan bleon sƿa same · sƿa se lichama ·7 bið gyt ƿyrsan heoƿes; 7 standað butu · sƿiþeforhte · 7 afærede · 7 bifiende on bidat domes; Ðonne clypað se deofol to þam déman · 7 cƿiþ to himþes ƿes min agen · fram hire geogoðe oð hireylde · heo hyrdon me georne 7 ælce dæg icheo lærde unriht to donne · 7 hi me simblelustlice hyrdon. And þonne þin lareoƿ com to hym 7hym ƿolde hyra saƿla hælo · tetan · þonne ƿæs icf. 25vsimle ær æt heom · 7 æft leng · 7 sƿette heom heora / unriht · la hƿi ne mot ic habban · þæt ic ær me sylfbegeat mid minum lyðrum ƿrencum · oft ic gedyde ·þæt he geƿorhte þussende synna ƿið ðe · 7 nanege betan nolde · Ðonne cƿæð þæs reðan ciningesstef · gang þu saƿel in þæt forlorene hus. þa gitæt somne syngodon. git eac æt somne sƿelton; Donne cƿið æft se dema to þam saƿlum. Disceditea me maledicti in ignem eternum qui preparatusest (a) diabolo. Geƿitaþ ge aƿirgydan on þæt ecefyr · þæt gegearƿode min fæder deofle 7 hisenglum. Ðonne hæfð se deofol geƿorht bogan7 stræla. 7 se boga biþ geƿoht of ofer mettum ·7 þa strela beoð sƿa manigra cynna sƿa sƿa mannes synna beoð. Sum stræl biþ geƿorht ofniþe sum of æfeste. sum of eþ belige · sumof hat heortnæsse · sum of stale · sum ofdrucennesse · sum of dyrnum geligere · sumof æƿ bryce · sum of sib legere sum of dƿolcræfte · sum of lyblacc · sum of gitsunge · sumof gifernesse · sum of reaflac · sum of scincræftesum of mord cƿale · sum of strudunge. Andsƿa manega stræla hæfd se deofol sƿa nis nanman þæt hy ealle atellan magon. And ælce dægþæs deofoles ƿilla bið þæt his strelena nan ·ne sy unafæstnod · gif he findan mæg hƿærhe hy on afæstnian mæge. 7 on hælle þadeofla scotigað mid þam strælum · 7 sƿa sa hehæfð ælce dæg his bogan to us gebendne7 ƿile us scotian mid þam strælum · þe ic ær / nemde; Ðonne is us micel þearf leofan menþæt ƿe habban þa scyldas þær ongean · þe /",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "n.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 26r follows 20v: see g.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "o.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "f. 27r-27v precedes 18r (on St Matthew and St Michael): see e., f.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "p.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(81r) Exaltation of the Cross (fragments). Morris, Legends of the Holy Rood, E. E. T. S., pp. 105, 107. Also on 28v the beginning of the Homily on St Matthew. p. thus precedes f. 18r",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "q.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(82r) On the Lord's Prayer: see d.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Robert Kilwardby OP, De natura relationis",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "83r-94v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Logica quaedam",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "83r-94v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Robert Kilwardby OP",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "person",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "author",
+                "uri": "http://id.loc.gov/vocabulary/relators/aut",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(83r) Que sit res predicamenti relationis per se",
+            "type": "rubric",
+            "identifier": [],
+            "displayLabel": "Rubric",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(83r) De predicamento relationis querunt aliqui que sit res huius generis",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends imperfectly in chapter 31",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Apocalypsis Goliae",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "95r-97v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Versus quidam",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "95r-97v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Apocalypsis Goliae",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "95r-97v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "James",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(Wright, Poems of W. Mapes, p. 1)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(95r) A tauro torrida lampade cinthii",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ending",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(97v) Dux meus manibus me capit insitis",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(l. 410)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Vita breuior Sancti Kenelmi (incomplete)",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "98r-101v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Historia (imperfecta) Kenelmi principis Merciorum",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "98r-101v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Life of St Kenelm",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "98r-101v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "James",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(98r) beginning imperfectly in c. ii",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(98r) forma. perfusus diuina dilectione et gratia deo et hominibus amabilis erat aetatula",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(101r) The original hand ends in c. viii: diuinorum miracula beneficiorum commendant. A hand of cent. xii continues and, writing very close, ends on the same page. It begins: martirem suum quem et ab humana noticia abscidere nitebatur: and ends: occubuerit. ad laudem et gloriam dei patris omnipotentis qui uiuit et regnat per omnia secula seculorum. Amen",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(101r) Under this is a scribble of a maze in pencil",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The same Life (abridged in Acta Sanctorum July IV 380, and in Horstmann, Nova Legenda Angliae II 110) is in MS. Douce 368 and Bodley 285",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(101v) On the verso a line and a half in a small hand giving a list of books. .i. Ðeo englissce passionale · 7 .ii. ·ii· englissce dialogas · 7 .iii. oddan boc · 7 .iiii. þe englisca martirlogium · / 7 .vi. · ii · englisce · salteras 7 · ii · pastorales · englisce · 7 þe englisca regol. / 7 barontus. (Printed in my Sources of Archbishop Parker's Collection and in Floyer and Hamilton's Catalogue of the MSS. at Worcester Cathedral, p. 166, note 3.) Barontus is the Vision of Barontus of Pistoia Acta Sanctorum Mart. 24",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "has part",
+        "title": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Old English Visio Leofrici",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "101v-105v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Homelia Saxonica sive passionale",
+                "type": "main title",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "101v-105v",
+                "type": "part number",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "alternative",
+            "identifier": [],
+            "displayLabel": "Nasmith",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "In a hand similar to that of the booklist in item 7 but larger",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(101v) Title in faint pencil",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(101v) Uisio Leofrici",
+            "type": "rubric",
+            "identifier": [],
+            "displayLabel": "Rubric",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(101v) Her gesutelað ða gesihðe ðe Leofric eorl gesæh. him þuhte to soðan on healf slapendon lichaman na eallinga sƿylce on sƿefne ac gyt geƿisslicor þæt he sceolde nede ofer ane sƿiðe smale bricge · 7 seo ƿær sƿiþe lang",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(103v) hit þa gesƿac þæra bletsunga þæt ƿæs neh þam þes godspel ƿæs gerædd. Feoƿertyne nihton ær his forð siðe he foresæde þonne dæg þe he sceolde cuman to cofantreo to his langan hame þær he on restet · 7 hit à eode eall sƿa he sæde. Requiescat in pace",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "This document, which had remained unnoticed, has been printed by Professor Napier in the Philological Journal, 1908",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "A note (xiii)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(103v) Vesperus est grandis interpolatio nubium inter nos et solem",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(104r) In a hand like that of no. 8 with neumes. Sequence for Epiphany",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(104r) Letabundus exultet fidelis chorus alleluiaRegem regum intacte profudit thorus res miranda",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(104v) Sanctus namque spiritus ipsa nobis prebuit bene mentis naribus odoranda",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Smaller hand",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(104v) Ad ultimum laus est uincta. Psalat chorus alia. Amen dicant omnia",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Another hand, xii",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105r) Hubertus (l. Herbertus) Abbas Westmon. 7 Edwius prior eiusdem loci. uenerabili priori Wigornie / Warino et domino Vhtredo cantori ceterisque fratribus ecclesie eiusdem. salutem in christo et perpet(uam) / pacem. Sciatis istum fratrem nostrum et monachum Benedictum ad nos uenisse et causa(s) / recessurus (!) sui de Maluernia sicut nobis uidetur rationabiliter ostendisse",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Asks that he be well treated till the writer's coming",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105r) dixit nobis quoddam opus scilicet missale apud uos / incepisse et antequam ad Maluerniam rediret sua uoluntate perficeret",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The monk in question has left Malvern and gone to Westminster",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Ends",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105r) laudando creatorem qui ouem suam reduxit ad gregem. Vale",
+            "type": "explicit",
+            "identifier": [],
+            "displayLabel": "Explicit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Herbertus was Abbot of Westminster from 1121 till shortly before 1140. Warinus prior of Worcester cir. 1130-40",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Charm (xii?)",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105r) + In nomine p. et f. et s. sci amen + Ire + arex + Christe + rauex + filiax + / arafax + N. Medicina contra febres",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "On f. 52v in a neat small hand, beginning and margin cut: Constitutions affecting monks, etc.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The last begins",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105v) Monachis et canonicis regularibus tam uestimenta quam coopertoria interdicimus colorata",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105v) Viri religiosi quibus non est cura animarum commissa nullos ad penitentiam recipere audeant",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(105v) Decimas uel in canonicas sanctiones ecclesiis ad quas pertinent precipimus cum integritate persolui",
+            "type": "incipit",
+            "identifier": [],
+            "displayLabel": "Incipit",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      }
+    ],
+    "marcEncodedData": [],
+    "purl": "https://purl.stanford.edu/hp566jq8781"
+  },
+  "identification": {
+    "catalogLinks": [],
+    "sourceId": "CCCC:367"
+  },
+  "structural": {},
+  "created": "2023-03-30T17:11:15.000+00:00",
+  "modified": "2023-03-30T17:11:15.000+00:00",
+  "lock": "druid:hp566jq8781=0"
+}

--- a/spec/fixtures/cocina/kj040zn0537.json
+++ b/spec/fixtures/cocina/kj040zn0537.json
@@ -1,0 +1,1356 @@
+{
+  "cocinaVersion": "0.75.0",
+  "type": "https://cocina.sul.stanford.edu/models/image",
+  "externalIdentifier": "druid:kj040zn0537",
+  "label": "Le Dauphin enlevè à sa mere : après le decret du Comité de sureté publique le 1, Juillet 1793 les Commissaires en exercice viennent le notifier a la Reine, et la somment de s'y conformer : [estampe]",
+  "version": 1,
+  "access": {
+    "view": "world",
+    "download": "world",
+    "controlledDigitalLending": false,
+    "useAndReproductionStatement": "This image(s) is a digital reproduction of works from the collections of the Bibliothèque nationale de France that are no longer protected by intellectual property rights. The use of these contents for commercial purposes is subject to payment and covered by a license. Commercial use includes the resale of the contents in the form of prepared products or the supply of services. For commercial use, contact: utilisation.commerciale@bnf.fr. The use of these contents for non-commercial purposes is free of charge, subject to compliance with applicable French legislation and notably the inclusion of the source’s statement."
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:ht275vw4351",
+    "releaseTags": []
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Le",
+            "type": "nonsorting characters",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Dauphin enlevè à sa mere",
+            "type": "main title",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "après le decret du Comité de sureté publique le 1, Juillet 1793 les Commissaires en exercice viennent le notifier a la Reine, et la somment de s'y conformer : [estampe]",
+            "type": "subtitle",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "3",
+            "type": "nonsorting character count",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Lasinio, Carlo",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1759-1838",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "egr",
+            "identifier": [],
+            "source": {
+              "code": "marcrelator",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [],
+        "parallelContributor": []
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Pellegrini, Domenico",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1759-1840",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "role": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "art",
+            "identifier": [],
+            "source": {
+              "code": "marcrelator",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "ant",
+            "identifier": [],
+            "source": {
+              "code": "marcrelator",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [],
+        "parallelContributor": []
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Vinck, Carl de",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1859-19",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "role": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "col",
+            "identifier": [],
+            "source": {
+              "code": "marcrelator",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [],
+        "parallelContributor": []
+      }
+    ],
+    "event": [
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "[1794 ou 1795]",
+            "type": "publication",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1794",
+                "type": "start",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1795",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "publication",
+            "encoding": {
+              "code": "marc",
+              "note": []
+            },
+            "identifier": [],
+            "qualifier": "questionable",
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "[s.n.]",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "type": "organization",
+            "role": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "publisher",
+                "code": "pbl",
+                "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+                "identifier": [],
+                "source": {
+                  "code": "marcrelator",
+                  "uri": "http://id.loc.gov/vocabulary/relators/",
+                  "note": []
+                },
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "identifier": [],
+            "note": [],
+            "parallelContributor": []
+          }
+        ],
+        "location": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "[London ?]",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "xxk",
+            "identifier": [],
+            "source": {
+              "code": "marccountry",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "monographic",
+            "type": "issuance",
+            "identifier": [],
+            "source": {
+              "value": "MODS issuance terms",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelEvent": []
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "picture",
+        "type": "genre",
+        "identifier": [],
+        "source": {
+          "code": "marcgt",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Scènes historiques-1789-1799.",
+        "type": "genre",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "still image",
+        "type": "resource type",
+        "identifier": [],
+        "source": {
+          "value": "MODS resource types",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "estampe",
+        "type": "technique",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "eau-forte",
+        "type": "material",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "gravure au pointillé",
+        "type": "material",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Image fixe",
+        "type": "form",
+        "identifier": [],
+        "source": {
+          "code": "gmd",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "nonprojected graphic",
+        "type": "form",
+        "identifier": [],
+        "source": {
+          "code": "marccategory",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "print",
+        "type": "form",
+        "identifier": [],
+        "source": {
+          "code": "marcsmd",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "1 est. : eau-forte, pointillé ; 34,5 x 46 cm (élt d'impr.)",
+        "type": "extent",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "geographic": [],
+    "language": [
+      {
+        "appliesTo": [],
+        "code": "fre",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": {
+          "code": "iso639-2b",
+          "note": []
+        },
+        "structuredValue": []
+      }
+    ],
+    "note": [],
+    "identifier": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "693238044",
+        "type": "OCLC",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "subject": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "1793-07-03",
+        "type": "time",
+        "encoding": {
+          "code": "w3cdtf",
+          "note": []
+        },
+        "identifier": [],
+        "displayLabel": "Event date",
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "reine de France",
+                "type": "term of address",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Marie-Antoinette",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1755-1793",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "person",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Emprisonnement",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "XVII, roi titulaire de France",
+                "type": "term of address",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Louis",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1785-1795",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "person",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Emprisonnement",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Élisabeth de France",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1764-1794",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "person",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Emprisonnement",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "duchesse d'",
+                "type": "term of address",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Angoulême, Marie-Thérèse Charlotte de France",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1778-1851",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "person",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Emprisonnement",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "XVI, roi de France",
+                "type": "term of address",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Louis",
+                "type": "name",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1754-1793",
+                "type": "life dates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "person",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Portraits",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Séparation (psychologie)",
+        "type": "topic",
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Mères et fils",
+        "type": "topic",
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Fonctionnaires communaux",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "France",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Paris (France)",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": {
+          "code": "ram",
+          "note": []
+        },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Paris (France) -- Enclos du Temple -- Vues d'intérieur",
+        "type": "place",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Les événements de la Révolution",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Le Roi et la famille royale",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "La soeur et les enfants du Roi",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "La séparation du Dauphin et de sa mère (3 juillet 1793)",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "displayLabel": "Catalog heading",
+        "note": [],
+        "valueLanguage": {
+          "code": "fre",
+          "note": [],
+          "source": {
+            "code": "iso639-2b",
+            "note": []
+          }
+        },
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The events of the Revolution",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The King and the Royal Family",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The sister and children of Louis XVI",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "The Dauphin is separated from his mother (3 July 1793)",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "displayLabel": "Catalog heading",
+        "note": [],
+        "valueLanguage": {
+          "code": "eng",
+          "note": [],
+          "source": {
+            "code": "iso639-2b",
+            "note": []
+          }
+        },
+        "appliesTo": []
+      }
+    ],
+    "relatedResource": [
+      {
+        "type": "referenced by",
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "De Vinck, 5436",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "referenced by",
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Images de la Révolution française : catalogue du vidéodisque, 1990, 6584-6586",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Vidéodisque, 6584-6586",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "type": "part of",
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "[Recueil. Collection de Vinck. Un siècle d'histoire de France par l'estampe, 1770-1870. Vol. 33 (pièces 5395-5522), Ancien Régime et Révolution]",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "(FrPBN)38793037",
+            "type": "local",
+            "identifier": [],
+            "source": {
+              "code": "local",
+              "note": []
+            },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "subject": [],
+        "relatedResource": []
+      },
+      {
+        "title": [],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "access": {
+          "url": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "http://catalogue.bnf.fr/ark:/12148/cb40248180b",
+              "identifier": [],
+              "displayLabel": "Notice et cote du catalogue de la Bibliothèque nationale de France",
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "physicalLocation": [],
+          "digitalLocation": [],
+          "accessContact": [],
+          "digitalRepository": [],
+          "note": []
+        },
+        "relatedResource": []
+      }
+    ],
+    "marcEncodedData": [],
+    "adminMetadata": {
+      "contributor": [
+        {
+          "name": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "code": "BDF",
+              "identifier": [],
+              "source": {
+                "code": "marcorg",
+                "note": []
+              },
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "type": "organization",
+          "role": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "original cataloging agency",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "identifier": [],
+          "note": [],
+          "parallelContributor": []
+        }
+      ],
+      "event": [
+        {
+          "structuredValue": [],
+          "type": "creation",
+          "date": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "871024",
+              "encoding": {
+                "code": "marc",
+                "note": []
+              },
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "contributor": [],
+          "location": [],
+          "identifier": [],
+          "note": [],
+          "parallelEvent": []
+        },
+        {
+          "structuredValue": [],
+          "type": "modification",
+          "date": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "20130116122053.0",
+              "encoding": {
+                "code": "iso8601",
+                "note": []
+              },
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "contributor": [],
+          "location": [],
+          "identifier": [],
+          "note": [],
+          "parallelEvent": []
+        }
+      ],
+      "language": [
+        {
+          "appliesTo": [],
+          "code": "fre",
+          "groupedValue": [],
+          "note": [],
+          "parallelValue": [],
+          "source": {
+            "code": "iso639-2b",
+            "note": []
+          },
+          "structuredValue": []
+        }
+      ],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4.xsl\n\t\t\t\t(Revision 1.83 2013/01/18)",
+          "type": "record origin",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "metadataStandard": [
+        {
+          "code": "ncafnor",
+          "note": []
+        }
+      ],
+      "identifier": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "ocn693238044",
+          "type": "OCoLC",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ]
+    },
+    "purl": "https://purl.stanford.edu/kj040zn0537"
+  },
+  "identification": {
+    "catalogLinks": [],
+    "sourceId": "French Revolution Digital Archive:BNF:06949912"
+  },
+  "structural": {
+    "contains": [
+      {
+        "type": "https://cocina.sul.stanford.edu/models/resources/image",
+        "externalIdentifier": "https://cocina.sul.stanford.edu/fileSet/kj040zn0537-kj040zn0537_1",
+        "label": "Image 1",
+        "version": 1,
+        "structural": {
+          "contains": [
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/kj040zn0537-kj040zn0537_1/T0000001.jp2",
+              "label": "T0000001.jp2",
+              "filename": "T0000001.jp2",
+              "size": 9542137,
+              "version": 1,
+              "hasMimeType": "image/jp2",
+              "hasMessageDigests": [
+                {
+                  "type": "sha1",
+                  "digest": "bd18165e5eaedb39e7e59d327e405a8f8fae8937"
+                },
+                {
+                  "type": "md5",
+                  "digest": "5bd7baa3243c042349990691afd7a2e8"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "world",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": false,
+                "shelve": true
+              },
+              "presentation": {
+                "height": 6128,
+                "width": 8272
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "hasMemberOrders": [],
+    "isMemberOf": [
+      "druid:jh957jy1101"
+    ]
+  },
+  "created": "2022-04-28T23:42:30.000+00:00",
+  "modified": "2022-04-28T23:42:30.000+00:00",
+  "lock": "druid:kj040zn0537=0"
+}

--- a/spec/fixtures/cocina/vc287zp9960.json
+++ b/spec/fixtures/cocina/vc287zp9960.json
@@ -1,0 +1,378 @@
+{
+  "cocinaVersion": "0.103.2",
+  "type": "https://cocina.sul.stanford.edu/models/book",
+  "externalIdentifier": "druid:vc287zp9960",
+  "label": "Conservation documentation for treatment #7635 of \"Seismic section WG-3, Tamaulipas Shelf to Campeche Scarp, Gulf of Mexico\"",
+  "version": 4,
+  "access": {
+    "view": "world",
+    "download": "world",
+    "controlledDigitalLending": false,
+    "copyright": "Copyright © Stanford University. All Rights Reserved.",
+    "useAndReproductionStatement": "User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.",
+    "license": "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:hr471gd9602"
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [
+          {
+            "value": "Conservation documentation for treatment #7635 of \"Seismic section WG-3, Tamaulipas Shelf to Campeche Scarp, Gulf of Mexico\"",
+            "type": "main title"
+          }
+        ]
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "value": "Wahab, Aisha"
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [
+          {
+            "value": "author",
+            "code": "aut",
+            "uri": "http://id.loc.gov/vocabulary/relators/aut",
+            "source": {
+              "code": "marcrelator",
+              "uri": "http://id.loc.gov/vocabulary/relators/"
+            }
+          },
+          {
+            "value": "conservator",
+            "code": "con",
+            "uri": "https://id.loc.gov/vocabulary/relators/con",
+            "source": {
+              "code": "marcrelator",
+              "uri": "http://id.loc.gov/vocabulary/relators/"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "type": "ORCID",
+            "uri": "https://orcid.org/0000-0002-3320-8655",
+            "source": {
+              "code": "orcid"
+            }
+          }
+        ]
+      },
+      {
+        "name": [
+          {
+            "value": "Stanford University. Libraries"
+          }
+        ],
+        "type": "organization",
+        "role": [
+          {
+            "value": "repository",
+            "code": "rps",
+            "source": {
+              "code": "marcrelator"
+            }
+          }
+        ]
+      },
+      {
+        "name": [
+          {
+            "value": "Stanford University. Libraries. Conservation Services",
+            "source": {
+              "code": "naf",
+              "uri": "http://id.loc.gov/authorities/names/no2021067473"
+            }
+          }
+        ],
+        "type": "organization",
+        "role": [
+          {
+            "value": "issuing body"
+          }
+        ]
+      }
+    ],
+    "event": [
+      {
+        "date": [
+          {
+            "value": "2020",
+            "type": "publication"
+          }
+        ],
+        "location": [
+          {
+            "code": "cau",
+            "source": {
+              "code": "marccountry"
+            }
+          }
+        ],
+        "note": [
+          {
+            "value": "monographic",
+            "type": "issuance",
+            "source": {
+              "value": "MODS issuance terms"
+            }
+          }
+        ]
+      },
+      {
+        "type": "publication",
+        "date": [
+          {
+            "value": "2020",
+            "type": "publication"
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "value": "Stanford University. Libraries. Conservation Services"
+              }
+            ],
+            "type": "organization",
+            "role": [
+              {
+                "value": "publisher",
+                "code": "pbl",
+                "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+                "source": {
+                  "code": "marcrelator",
+                  "uri": "http://id.loc.gov/vocabulary/relators/"
+                }
+              }
+            ]
+          }
+        ],
+        "location": [
+          {
+            "value": "Stanford, California"
+          }
+        ]
+      },
+      {
+        "displayLabel": "Place of creation",
+        "date": [
+          {
+            "value": "2020-11-17",
+            "type": "creation",
+            "status": "primary",
+            "encoding": {
+              "code": "w3cdtf"
+            }
+          }
+        ],
+        "location": [
+          {
+            "value": "Stanford (Calif.)",
+            "uri": "http://id.loc.gov/authorities/names/n50046557",
+            "source": {
+              "uri": "http://id.loc.gov/authorities/names/"
+            }
+          },
+          {
+            "code": "xxu",
+            "source": {
+              "code": "marccountry"
+            }
+          }
+        ]
+      }
+    ],
+    "form": [
+      {
+        "value": "Condition reports",
+        "type": "genre",
+        "uri": "http://vocab.getty.edu/aat/300266009",
+        "source": {
+          "code": "aat",
+          "uri": "http://vocab.getty.edu/aat"
+        },
+        "note": [
+          {
+            "value": "form",
+            "type": "genre type"
+          }
+        ]
+      },
+      {
+        "value": "Photodocumentation",
+        "type": "genre",
+        "uri": "http://vocab.getty.edu/page/aat/300379366",
+        "source": {
+          "code": "aat",
+          "uri": "http://vocab.getty.edu/aat"
+        },
+        "note": [
+          {
+            "value": "form",
+            "type": "genre type"
+          }
+        ]
+      },
+      {
+        "value": "electronic resource",
+        "type": "form",
+        "source": {
+          "code": "marccategory"
+        }
+      },
+      {
+        "value": "remote",
+        "type": "form",
+        "source": {
+          "code": "marcsmd"
+        }
+      },
+      {
+        "value": "still image",
+        "type": "resource type",
+        "source": {
+          "value": "MODS resource types"
+        }
+      },
+      {
+        "value": "born digital",
+        "type": "digital origin",
+        "source": {
+          "value": "MODS digital origin terms"
+        }
+      },
+      {
+        "value": "computer",
+        "type": "media",
+        "source": {
+          "code": "rdamedia"
+        }
+      },
+      {
+        "value": "online resource",
+        "type": "carrier",
+        "source": {
+          "code": "rdacarrier"
+        }
+      },
+      {
+        "value": "1 online resource",
+        "type": "extent"
+      },
+      {
+        "value": "preservation",
+        "type": "reformatting quality",
+        "source": {
+          "value": "MODS reformatting quality terms"
+        }
+      },
+      {
+        "value": "manuscript",
+        "source": {
+          "value": "MODS resource types"
+        }
+      }
+    ],
+    "note": [
+      {
+        "value": "These photographs document the state of a collection item before conservation treatment.",
+        "type": "abstract",
+        "displayLabel": "Description"
+      },
+      {
+        "value": "Description based on information from Conservation Services."
+      }
+    ],
+    "identifier": [
+      {
+        "value": "7635",
+        "type": "local",
+        "source": {
+          "code": "local"
+        },
+        "displayLabel": "Conservation transaction registration number"
+      }
+    ],
+    "subject": [
+      {
+        "value": "Branner Earth Sciences Library and Map Collections",
+        "type": "organization",
+        "uri": "http://id.loc.gov/authorities/names/no98101531",
+        "source": {
+          "code": "naf",
+          "uri": "http://id.loc.gov/authorities/names/"
+        },
+        "displayLabel": "Subject"
+      },
+      {
+        "structuredValue": [
+          {
+            "value": "Paper",
+            "type": "topic",
+            "uri": "http://id.loc.gov/authorities/subjects/sh85097578",
+            "source": {
+              "code": "lcsh",
+              "uri": "http://id.loc.gov/authorities/subjects/"
+            }
+          },
+          {
+            "value": "Conservation and restoration",
+            "type": "topic",
+            "uri": "http://id.loc.gov/authorities/subjects/sh99005331",
+            "source": {
+              "code": "lcsh",
+              "uri": "http://id.loc.gov/authorities/subjects/"
+            }
+          }
+        ],
+        "uri": "http://id.loc.gov/authorities/subjects/sh85097586",
+        "source": {
+          "code": "lcsh",
+          "uri": "http://id.loc.gov/authorities/subjects/"
+        },
+        "displayLabel": "Subject"
+      }
+    ],
+    "relatedResource": [
+      {
+        "title": [
+          {
+            "value": "Link to SearchWorks record for conserved item"
+          }
+        ],
+        "access": {
+          "url": [
+            {
+              "value": "https://searchworks.stanford.edu/view/513014"
+            }
+          ]
+        }
+      }
+    ],
+    "purl": "https://purl.stanford.edu/vc287zp9960"
+  },
+  "identification": {
+    "catalogLinks": [
+      {
+        "catalog": "folio",
+        "refresh": false,
+        "catalogRecordId": "a14663140",
+        "partLabel": "Before treatment photos",
+        "sortKey": "2"
+      }
+    ],
+    "sourceId": "sulcons:7635-BR_2090_SeismicMap_awahab,Before treatment photos"
+  },
+  "structural": {},
+  "created": "2025-05-21T19:54:57.000+00:00",
+  "modified": "2025-06-03T21:20:06.000+00:00",
+  "lock": "druid:vc287zp9960=2=2"
+}

--- a/spec/fixtures/cocina/zb733jx3137.json
+++ b/spec/fixtures/cocina/zb733jx3137.json
@@ -1,0 +1,349 @@
+{
+  "cocinaVersion": "0.105.0",
+  "type": "https://cocina.sul.stanford.edu/models/object",
+  "externalIdentifier": "druid:zb733jx3137",
+  "label": "Testing versioning issue with the review workflow in the new application again",
+  "version": 18,
+  "access": {
+    "view": "world",
+    "download": "world",
+    "controlledDigitalLending": false,
+    "useAndReproductionStatement": "User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.",
+    "license": "https://opendatacommons.org/licenses/pddl/1-0/"
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:zw306xn5593"
+  },
+  "description": {
+    "title": [
+      {
+        "value": "Testing versioning issue with the review workflow in the new application again"
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "value": "Chester",
+                "type": "forename"
+              },
+              {
+                "value": "Testerton",
+                "type": "surname"
+              }
+            ]
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [
+          {
+            "value": "author",
+            "code": "aut",
+            "uri": "http://id.loc.gov/vocabulary/relators/aut",
+            "source": {
+              "code": "marcrelator",
+              "uri": "http://id.loc.gov/vocabulary/relators/"
+            }
+          }
+        ],
+        "affiliation": [
+          {
+            "structuredValue": [
+              {
+                "value": "(education, funder)",
+                "identifier": [
+                  {
+                    "type": "ROR",
+                    "uri": "https://ror.org/00f54p054",
+                    "source": {
+                      "code": "ror"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "value": "Cited",
+                "type": "forename"
+              },
+              {
+                "value": "NewAdvisor",
+                "type": "surname"
+              }
+            ]
+          }
+        ],
+        "type": "person",
+        "role": [
+          {
+            "value": "advisor"
+          }
+        ]
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "value": "Interesting",
+                "type": "forename"
+              },
+              {
+                "value": "Speaker",
+                "type": "surname"
+              }
+            ]
+          }
+        ],
+        "type": "person",
+        "role": [
+          {
+            "value": "speaker",
+            "code": "spk",
+            "uri": "http://id.loc.gov/vocabulary/relators/spk",
+            "source": {
+              "code": "marcrelator",
+              "uri": "http://id.loc.gov/vocabulary/relators/"
+            }
+          }
+        ]
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "value": "Primary",
+                "type": "forename"
+              },
+              {
+                "value": "Advisor",
+                "type": "surname"
+              }
+            ]
+          }
+        ],
+        "type": "person",
+        "role": [
+          {
+            "value": "advisor"
+          }
+        ]
+      },
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "value": "Amy E.",
+                "type": "forename"
+              },
+              {
+                "value": "Hodge",
+                "type": "surname"
+              }
+            ]
+          }
+        ],
+        "type": "person",
+        "role": [
+          {
+            "value": "author",
+            "code": "aut",
+            "uri": "http://id.loc.gov/vocabulary/relators/aut",
+            "source": {
+              "code": "marcrelator",
+              "uri": "http://id.loc.gov/vocabulary/relators/"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "value": "0000-0002-5902-3077",
+            "type": "ORCID",
+            "source": {
+              "uri": "https://orcid.org"
+            }
+          }
+        ]
+      }
+    ],
+    "event": [
+      {
+        "type": "deposit",
+        "date": [
+          {
+            "value": "2025-08-05",
+            "type": "publication",
+            "encoding": {
+              "code": "edtf"
+            }
+          }
+        ]
+      },
+      {
+        "type": "publication",
+        "date": [
+          {
+            "value": "2024-06-11",
+            "type": "publication",
+            "status": "primary",
+            "encoding": {
+              "code": "edtf"
+            }
+          }
+        ]
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [
+          {
+            "value": "Text",
+            "type": "type"
+          },
+          {
+            "value": "Preprint",
+            "type": "subtype"
+          },
+          {
+            "value": "Thesis",
+            "type": "subtype"
+          }
+        ],
+        "type": "resource type",
+        "source": {
+          "value": "Stanford self-deposit resource types"
+        }
+      },
+      {
+        "value": "grey literature",
+        "type": "genre",
+        "uri": "http://vocab.getty.edu/page/aat/300256200",
+        "source": {
+          "code": "aat"
+        }
+      },
+      {
+        "value": "text",
+        "type": "resource type",
+        "source": {
+          "value": "MODS resource types"
+        }
+      },
+      {
+        "value": "Text",
+        "type": "resource type",
+        "source": {
+          "value": "DataCite resource types"
+        }
+      }
+    ],
+    "note": [
+      {
+        "value": "This is a test to see where the issue is with versioning with the review workflow on. Something is not quite right here.",
+        "type": "abstract"
+      },
+      {
+        "value": "Testerton, C., NewAdvisor, C., Speaker, I., and Advisor, P. (2025). Testing versioning issue with the review workflow. Version 1. Stanford Digital Repository. Available at https://purl.stanford.edu/zb733jx3137/version/1.",
+        "type": "preferred citation"
+      }
+    ],
+    "subject": [
+      {
+        "value": "Tests",
+        "type": "genre",
+        "uri": "http://id.worldcat.org/fast/1423780/",
+        "source": {
+          "code": "fast",
+          "uri": "http://id.worldcat.org/fast/"
+        }
+      },
+      {
+        "value": "Web-based Distributed Authoring and Versioning (Standard)",
+        "type": "topic",
+        "uri": "http://id.worldcat.org/fast/1173274/",
+        "source": {
+          "code": "fast",
+          "uri": "http://id.worldcat.org/fast/"
+        }
+      }
+    ],
+    "access": {
+      "accessContact": [
+        {
+          "value": "testing@me.com",
+          "type": "email",
+          "displayLabel": "Contact"
+        }
+      ]
+    },
+    "relatedResource": [
+      {
+        "type": "source of",
+        "dataCiteRelationType": "IsSourceOf",
+        "access": {
+          "url": [
+            {
+              "value": "https://app.honeybadger.io/projects/128495/faults/122573092"
+            }
+          ]
+        }
+      },
+      {
+        "type": "references",
+        "dataCiteRelationType": "References",
+        "note": [
+          {
+            "value": "Hodge A, Mendenhall M. The cyclin-dependent kinase inhibitory domain of the yeast Sic1 protein is contained within the C-terminal 70 amino acids. Mol Gen Genet. 1999 Aug;262(1):55-64. doi: 10.1007/s004380051059. PMID: 10503536.",
+            "type": "preferred citation"
+          }
+        ]
+      }
+    ],
+    "adminMetadata": {
+      "event": [
+        {
+          "type": "creation",
+          "date": [
+            {
+              "value": "2024-09-12",
+              "encoding": {
+                "code": "edtf"
+              }
+            }
+          ]
+        }
+      ],
+      "note": [
+        {
+          "value": "Metadata created by user via Stanford self-deposit application",
+          "type": "record origin"
+        }
+      ]
+    },
+    "purl": "https://purl.stanford.edu/zb733jx3137"
+  },
+  "identification": {
+    "doi": "10.25740/zb733jx3137",
+    "sourceId": "h3:object-6671"
+  },
+  "structural": {
+    "isMemberOf": [
+      "druid:bz912dc0085"
+    ]
+  },
+  "created": "2025-08-05T21:31:27.000+00:00",
+  "modified": "2025-08-05T21:31:28.000+00:00",
+  "lock": "druid:zb733jx3137=39=2"
+}

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -74,6 +74,18 @@ describe Purl do
     end
   end
 
+  describe '#cocina_record' do
+    before do
+      stub_request(:get, "https://purl.stanford.edu/#{druid}.json").to_return(
+        body: File.new(File.join(FIXTURES_PATH, "/cocina/#{druid}.json")), status: 200
+      )
+    end
+
+    it 'returns a CocinaDisplay::CocinaRecord object' do
+      expect(purl.cocina_record).to be_a(CocinaDisplay::CocinaRecord)
+    end
+  end
+
   describe '#dor_content_type' do
     it 'returns the content type from contentMetadata' do
       expect(purl.dor_content_type).to eq('image')


### PR DESCRIPTION
This is feature flagged until we're ready to use it in production. There's some concern about whether Cocina simplification will remove metadata we care about. I'll work on getting more details from Arcadia about the timeline for cocina simplification and the possible impact.