### PR TITLE
Remove `enableRemoteStreaming` configuration

### DIFF
--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -947,7 +947,7 @@
   <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
 
   <requestDispatcher handleSelect="true" >
-    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
+    <requestParsers multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />


### PR DESCRIPTION
This is no longer the default (as of Solr 7.x) and if we're not using it, we should turn it off.