### PR TITLE
Unpin connection_pool version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,5 +136,3 @@ gem 'cssbundling-rails', '~> 1.4'
 gem 'jsbundling-rails', '~> 1.3'
 
 gem 'rack-cors', '~> 2.0'
-
-gem 'connection_pool', '~> 2.5' # pinned until fix for https://github.com/rails/rails/issues/56291 is released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -979,7 +979,6 @@ DEPENDENCIES
   citeproc-ruby
   cocina_display (~> 1.6)
   config
-  connection_pool (~> 2.5)
   csl-styles (= 2.0.1)
   cssbundling-rails (~> 1.4)
   database_cleaner


### PR DESCRIPTION
The fix was included in Rails 8.1.2 so we can unpin this now: https://github.com/rails/rails/pull/56292