### PR TITLE
fix sul-embed id

### DIFF
--- a/app/javascript/image_viewer_state_modal.js
+++ b/app/javascript/image_viewer_state_modal.js
@@ -68,7 +68,7 @@ class ImageViewerStateModal {
       console.error('Failed to parse the data from the image viewer')
       return null
     }
-    if (parsedData.type !== "stateResponse" || parsedData.source !== "sul-embed-m3") return null
+    if (parsedData.type !== "stateResponse" || parsedData.source !== "sul-embed-mirador") return null
     return parsedData.data
   }
 }


### PR DESCRIPTION
The id got changed when we switched from mirador 3 to mirador4. The reason for the switch is do we wouldn't have to fix it for new releases so this should stay the same and not change again 🤞