### PR TITLE
Only show cocina metadata for documents from SDR (not uploaded to exhibits)

### DIFF
--- a/app/components/metadata/cocina_component.rb
+++ b/app/components/metadata/cocina_component.rb
@@ -10,10 +10,8 @@ module Metadata
 
     delegate :cocina_record, to: :purl
 
-    # TODO: In future work we will want something indexed to indicate whether
-    #       we should display metadata from Cocina.
     def render?
-      Settings.cocina.metadata_display_source
+      Settings.cocina.metadata_display_source && @document.dor_resource_type?
     end
 
     def purl

--- a/app/components/metadata_button_component.rb
+++ b/app/components/metadata_button_component.rb
@@ -8,9 +8,7 @@ class MetadataButtonComponent < ViewComponent::Base
     super()
   end
 
-  # TODO: In future work we will want something indexed to indicate whether
-  #       we should show this button for cocina records.
   def render?
-    @document.modsxml.present? || Settings.cocina.metadata_display_source
+    @document.modsxml.present? || (Settings.cocina.metadata_display_source && @document.dor_resource_type?)
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,6 +29,11 @@ class SolrDocument
     document[:modsxml]
   end
 
+  # document was harvested via dor_harvesters from Purl/SDR
+  def dor_resource_type?
+    self['spotlight_resource_type_ssim']&.include?('dor_harvesters')
+  end
+
   def full_text_highlights
     highlighting_response = response.dig('highlighting', id) || {}
 

--- a/spec/components/metadata/cocina_component_spec.rb
+++ b/spec/components/metadata/cocina_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metadata::CocinaComponent, type: :component do
   end
 
   let(:druid) { 'hp566jq8781' }
-  let(:document) { SolrDocument.new(id: druid) }
+  let(:document) { SolrDocument.new(id: druid, spotlight_resource_type_ssim: ['dor_harvesters']) }
 
   context 'when the document has Cocina' do
     it 'renders the component' do

--- a/spec/components/metadata_button_component_spec.rb
+++ b/spec/components/metadata_button_component_spec.rb
@@ -23,4 +23,26 @@ RSpec.describe MetadataButtonComponent, type: :component do
       expect(rendered).not_to have_css 'a', text: 'More details »'
     end
   end
+
+  context 'when cocina metadata display is enabled' do
+    before do
+      allow(Settings.cocina).to receive(:metadata_display_source).and_return(true)
+    end
+
+    context 'when document is a dor resource' do
+      let(:document) { SolrDocument.new(id: 'abc', spotlight_resource_type_ssim: ['dor_harvesters']) }
+
+      it 'displays the metadata button' do
+        expect(rendered).to have_css 'a', text: 'More details »'
+      end
+    end
+
+    context 'when document is not a dor resource' do
+      let(:document) { SolrDocument.new(id: 'abc') }
+
+      it 'does not display the metadata button' do
+        expect(rendered).not_to have_css 'a', text: 'More details »'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Part of #3054 