### PR TITLE
Use *_path helper for embeds so they work on vanity URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
     url = context_specific_oembed_url(document)
 
     content_tag :div, '', data: {
-      embed_url: blacklight_oembed_engine.embed_url(
+      embed_url: blacklight_oembed_engine.embed_path(
         url: url,
         iiif_initial_viewer_config: choose_initial_viewer_config(block) || params[:iiif_initial_viewer_config],
         canvas_id: canvas_id || params[:canvas_id],

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ApplicationHelper do
           feature_flags: FeatureFlags.for(create(:exhibit))
         )
         rendered = helper.custom_render_oembed_tag_async(document, 3, nil)
-        expect(rendered).to have_css '[data-embed-url="http://test.host/oembed/e'\
+        expect(rendered).to have_css '[data-embed-url="/oembed/e'\
           'mbed?canvas_id=3&maxheight=600&url=http%3A%2F%2Fexample.com%2Fstuff"]'
       end
 
@@ -56,7 +56,7 @@ RSpec.describe ApplicationHelper do
           document, 3, sir_trevor_block.new(maxheight: 300)
         )
 
-        expect(rendered).to have_css '[data-embed-url="http://test.host/oembed/e'\
+        expect(rendered).to have_css '[data-embed-url="/oembed/e'\
           'mbed?canvas_id=3&maxheight=300&url=http%3A%2F%2Fexample.com%2Fstuff"]'
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe ApplicationHelper do
         )
         rendered = helper.custom_render_oembed_tag_async(document, 3, nil)
 
-        expect(rendered).to have_css '[data-embed-url="http://test.host/oembed/e'\
+        expect(rendered).to have_css '[data-embed-url="/oembed/e'\
           'mbed?canvas_id=3&maxheight=600&url=https%3A%2F%2Fsul-purl-uat.stanford.edu%2Fabc123"]'
       end
     end


### PR DESCRIPTION
When accessed via vanity URLs (parker.stanford.edu, etc.) widget embeds on pages won't load because the url helper returns the exhibits.stanford.edu path. Using the path helper allows the embeds to work from vanity URLs.