### PR TITLE
Refactor related resource display for cocina_display 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ gem 'csl-styles', '~> 2.0'
 gem 'acts-as-taggable-on'
 gem 'slack-ruby-client'
 gem 'blacklight-oembed', '~> 1.0'
-gem 'cocina_display', '2.1.0' # Pinned until https://github.com/sul-dlss/exhibits/issues/3118 is resolved
+gem 'cocina_display', '~> 2.2'
 gem 'whenever', require: false
 gem 'rails_autolink'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 2.0)
       observer (< 1.0)
-    cocina_display (2.1.0)
+    cocina_display (2.2.0)
       activesupport (>= 7)
       edtf (~> 3.2)
       geo_coord (~> 0.2)
@@ -870,7 +870,7 @@ DEPENDENCIES
   capistrano-shared_configs
   capybara
   citeproc-ruby (~> 2.1)
-  cocina_display (= 2.1.0)
+  cocina_display (~> 2.2)
   config
   csl-styles (~> 2.0)
   cssbundling-rails (~> 1.4)

--- a/app/components/metadata/cocina/related_resource_component.html.erb
+++ b/app/components/metadata/cocina/related_resource_component.html.erb
@@ -1,10 +1,17 @@
 <dd>
-  <details data-details-container-target="detailItem" data-action="details-container#toggleButtonText">
-    <summary>
-      <%= summary %>
-    </summary>
+  <% if labeled_link %>
     <dl>
-      <%= render Metadata::Cocina::FieldComponent.with_collection(display_data) %>
+      <dt><%= labeled_link %></dt>
+      <dd>
+        <dl><%= render Metadata::Cocina::FieldComponent.with_collection(display_data) %></dl>
+      </dd>
     </dl>
-  </details>
+  <% elsif summary %>
+    <details data-details-container-target="detailItem" data-action="details-container#toggleButtonText">
+      <summary><%= summary %></summary>
+      <dl><%= render Metadata::Cocina::FieldComponent.with_collection(display_data) %></dl>
+    </details>
+  <% else %>
+    <dl><%= render Metadata::Cocina::FieldComponent.with_collection(display_data) %></dl>
+  <% end %>
 </dd>

--- a/app/components/metadata/cocina/related_resource_component.rb
+++ b/app/components/metadata/cocina/related_resource_component.rb
@@ -5,17 +5,27 @@ module Metadata
     # A component for rendering a resource related to the current object.
     class RelatedResourceComponent < ViewComponent::Base
       # @param related_resource [CocinaDisplay::RelatedResource]
-      def initialize(related_resource:)
+      # @param group_label [String, nil] the label of the enclosing field group; when the resource
+      #   has no title or URL its string representation falls back to this same label, so we suppress
+      #   the redundant <summary> and render display_data inline instead.
+      def initialize(related_resource:, group_label: nil)
         @related_resource = related_resource
+        @group_label = group_label
         super()
       end
 
+      delegate :display_data, to: :@related_resource
+
       def summary
-        @related_resource.display_data.first.values.join('; ')
+        return if @related_resource.url? || @related_resource.to_s == @group_label
+
+        @related_resource.to_s
       end
 
-      def display_data
-        @related_resource.display_data.drop(1)
+      def labeled_link
+        return unless @related_resource.url?
+
+        link_to(@related_resource.to_s, @related_resource.url)
       end
 
       def render?

--- a/app/components/metadata/cocina/related_resources_field_component.rb
+++ b/app/components/metadata/cocina/related_resources_field_component.rb
@@ -38,7 +38,7 @@ module Metadata
       end
 
       def toggle_button_visible?
-        related_resources.none? { it.url? || it.display_data.one? }
+        related_resources.none? { it.url? || it.display_data.none? || it.to_s == label }
       end
 
       # If the related resource has a URL, render it has a labeled link.
@@ -46,12 +46,12 @@ module Metadata
       # Otherwise, render it using the nested presentation (e.g. Parker citations).
       # @param [CocinaDisplay::RelatedResource] related_resource
       def child_component(related_resource)
-        if related_resource.url?
+        if related_resource.url? && related_resource.display_data.none?
           Metadata::Cocina::LabeledLinkComponent.new(url: related_resource.url, link_text: related_resource.to_s)
-        elsif related_resource.display_data.one?
-          Metadata::Cocina::ValueComponent.new(values: related_resource.display_data.first.values)
+        elsif related_resource.display_data.none?
+          Metadata::Cocina::ValueComponent.new(values: [related_resource.to_s])
         else
-          Metadata::Cocina::RelatedResourceComponent.new(related_resource: related_resource)
+          Metadata::Cocina::RelatedResourceComponent.new(related_resource: related_resource, group_label: label)
         end
       end
     end

--- a/spec/components/metadata/cocina/related_resource_component_spec.rb
+++ b/spec/components/metadata/cocina/related_resource_component_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Metadata::Cocina::RelatedResourceComponent, type: :component do
+  subject(:rendered) do
+    render_inline(described_class.new(related_resource:)).to_html
+  end
+
+  let(:related_resource) { CocinaDisplay::RelatedResource.new(cocina_doc) }
+
+  context 'when the related resource has a URL and additional display data' do
+    let(:cocina_doc) do
+      {
+        'type' => 'related to',
+        'title' => [{ 'value' => 'Companion Study Materials' }],
+        'access' => {
+          'url' => [{ 'value' => 'https://example.com/companion' }]
+        },
+        'contributor' => [
+          {
+            'name' => [{ 'value' => 'Smith, Jane' }],
+            'type' => 'person',
+            'role' => [{ 'value' => 'author' }]
+          }
+        ]
+      }
+    end
+
+    it 'renders the title as a link' do
+      expect(rendered).to have_link 'Companion Study Materials',
+                                    href: 'https://example.com/companion'
+    end
+
+    it 'renders the contributor in the nested display data' do
+      expect(rendered).to have_css 'dl dd', text: 'Smith, Jane'
+    end
+
+    it 'does not duplicate the URL in the nested display data' do
+      expect(rendered).to have_link(count: 1)
+    end
+
+    it 'does not render a details element' do
+      expect(rendered).not_to have_css 'details'
+    end
+  end
+
+  context 'when the resource string representation would duplicate the group label' do
+    subject(:rendered) do
+      render_inline(described_class.new(related_resource:,
+                                        group_label: 'United States of America v. Hiroshi Tamura')).to_html
+    end
+
+    let(:cocina_doc) do
+      {
+        'type' => 'part of',
+        'displayLabel' => 'United States of America v. Hiroshi Tamura',
+        'contributor' => [
+          {
+            'name' => [{ 'value' => 'Tamura, Hiroshi' }],
+            'role' => [{ 'value' => 'Defendant', 'code' => 'dfd' }]
+          }
+        ],
+        'event' => [
+          {
+            'date' => [{ 'value' => '1948-10-29' }],
+            'location' => [{ 'value' => 'Tokyo (Japan)' }]
+          }
+        ]
+      }
+    end
+
+    it 'renders display data inline without a details element' do
+      expect(rendered).not_to have_css 'details'
+    end
+
+    it 'does not render a redundant summary' do
+      expect(rendered).not_to have_css 'summary'
+    end
+
+    it 'renders the nested display data' do
+      expect(rendered).to have_css 'dl dd', text: 'Tamura, Hiroshi'
+    end
+  end
+
+  context 'when the related resource has no URL and has display data' do
+    let(:cocina_doc) do
+      {
+        'type' => 'has part',
+        'title' => [{ 'value' => 'Manuscript Fragment' }],
+        'contributor' => [
+          {
+            'name' => [{ 'value' => 'Nasmith, James' }],
+            'type' => 'person',
+            'role' => [{ 'value' => 'author' }]
+          }
+        ]
+      }
+    end
+
+    it 'renders the title as a summary (not a link)' do
+      expect(rendered).to have_css 'summary', text: 'Manuscript Fragment', visible: :all
+      expect(rendered).not_to have_link 'Manuscript Fragment'
+    end
+
+    it 'renders the contributor in the nested display data' do
+      expect(rendered).to have_css 'dl dd', text: 'Nasmith, James', visible: :all
+    end
+
+    it 'renders a details element for expansion' do
+      expect(rendered).to have_css 'details'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3118 

Takes advantage of the changes to related resource handling in cocina display 2.2 so we display the right thing in a variety of cases:

**summary/detail when the summary value doesn't duplicate the field label (retains expected display of Parker material)**
<img width="484" height="188" alt="Screenshot 2026-04-13 at 10 32 25 AM" src="https://github.com/user-attachments/assets/7f4f3cf6-4d69-4805-a75c-a809af9d2917" />

**nested definition lists when the summary would duplicate the label (typical of virtual tribunal and other records)**
<img width="227" height="90" alt="Screenshot 2026-04-13 at 10 32 51 AM" src="https://github.com/user-attachments/assets/8e016c76-5df0-4f5f-89ec-3f89d7855ab2" />

**labeled links that have additional contextual metadata to display (with nested definition list)**
<img width="742" height="185" alt="Screenshot 2026-04-13 at 10 27 39 AM" src="https://github.com/user-attachments/assets/0acf40f0-a412-4341-a27b-ca020c236bf5" />
