### PR TITLE
Allow configuration of multiple slack channels for messages

### DIFF
--- a/app/models/exhibit_bot.rb
+++ b/app/models/exhibit_bot.rb
@@ -9,14 +9,16 @@ class ExhibitBot
     delegate :message, to: :new
   end
 
-  def message(channel: default_channel, as_user: true, text:)
-    client.chat_postMessage(channel: channel, as_user: as_user, text: text)
+  def message(channels: default_channels, as_user: true, text:)
+    channels.each do |channel|
+      client.chat_postMessage(channel: channel, as_user: as_user, text: text)
+    end
   end
 
   private
 
-  def default_channel
-    Settings.slack_notifications.default_channel
+  def default_channels
+    Settings.slack_notifications.default_channels
   end
 
   def client

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,7 +59,9 @@ full_text_highlight:
   snippet_count: 5
 
 slack_notifications:
-  default_channel: "#spotlight-service-team"
+  default_channels:
+    - "#spotlight-svc-team"
+    - "#spotlight-exhibit-publication"
   api_token: "your-api-token-here"
 index_status_threshold: 10
 sidekiq_retry_queue_threshold: 100

--- a/spec/jobs/send_publish_state_change_notification_job_spec.rb
+++ b/spec/jobs/send_publish_state_change_notification_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SendPublishStateChangeNotificationJob do
   context 'when publishing' do
     let(:published) { true }
 
-    it 'sends a message indicating the exhbiti has been pusblshed' do
+    it 'sends a message indicating the exhibit has been published' do
       allow(ExhibitBot).to receive(:message)
 
       job
@@ -35,6 +35,28 @@ RSpec.describe SendPublishStateChangeNotificationJob do
           text: a_string_including("Spotlight exhibit un-published: #{exhibit.title}")
         )
       )
+    end
+  end
+
+  context 'when multiple default channels are configured' do
+    let(:published) { true }
+    let(:stub_client) { instance_spy(Slack::Web::Client) }
+    let(:bot) { ExhibitBot.new }
+
+    before do
+      allow(ExhibitBot).to receive(:new).and_return(bot)
+      allow(bot).to receive_messages(client: stub_client, default_channels: ['#channel-one', '#channel-two'])
+    end
+
+    it 'sends the same message text to each channel' do
+      job
+
+      expect(stub_client).to have_received(:chat_postMessage)
+        .with(hash_including(channel: '#channel-one',
+                             text: a_string_including("Spotlight exhibit published: #{exhibit.title}")))
+      expect(stub_client).to have_received(:chat_postMessage)
+        .with(hash_including(channel: '#channel-two',
+                             text: a_string_including("Spotlight exhibit published: #{exhibit.title}")))
     end
   end
 end

--- a/spec/models/exhibit_bot_spec.rb
+++ b/spec/models/exhibit_bot_spec.rb
@@ -17,22 +17,36 @@ RSpec.describe ExhibitBot do
 
       it 'sends text through to the client' do
         message
-        expect(stub_client).to have_received(:chat_postMessage).with(hash_including(text: 'Test text'))
+        expect(stub_client).to have_received(:chat_postMessage).at_least(:once).with(hash_including(text: 'Test text'))
       end
 
-      it 'allows defaults to be overridden' do
-        bot.message(text: 'Test text', channel: '#new-channel', as_user: false)
+      it 'allows channel list to be overridden' do
+        bot.message(text: 'Test text', channels: ['#new-channel'], as_user: false)
 
         expect(stub_client).to have_received(:chat_postMessage).with(
           hash_including(channel: '#new-channel', as_user: false)
         )
       end
 
-      it 'has a default channel and as_user option' do
+      it 'uses default channels and as_user option' do
         message
         expect(stub_client).to have_received(:chat_postMessage).with(
-          hash_including(channel: '#spotlight-service-team', as_user: true)
+          hash_including(channel: '#spotlight-svc-team', as_user: true)
         )
+      end
+
+      context 'when multiple default channels are configured' do
+        before do
+          allow(bot).to receive(:default_channels).and_return(['#channel-one', '#channel-two'])
+        end
+
+        it 'sends the same text to each channel' do
+          message
+          expect(stub_client).to have_received(:chat_postMessage)
+            .with(hash_including(channel: '#channel-one', text: 'Test text'))
+          expect(stub_client).to have_received(:chat_postMessage)
+            .with(hash_including(channel: '#channel-two', text: 'Test text'))
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #3122 

Depends on:

- https://github.com/sul-dlss/shared_configs/pull/2465

Related cleanup:

- https://github.com/sul-dlss/shared_configs/pull/2466
- https://github.com/sul-dlss/shared_configs/pull/2467
