### PR TITLE
Fix homepage library collections link

### DIFF
--- a/app/components/masthead_navigation_component.html.erb
+++ b/app/components/masthead_navigation_component.html.erb
@@ -19,7 +19,7 @@
     </a>
     <div class="dropdown-menu dropdown-menu-md-end" aria-labelledby="navbarDropdownMenuLink">
       <%= link_to "Explore library collections at Stanford",
-                  "https://library.stanford.edu/explore-collections", class: 'dropdown-item' %>
+                  "https://library.stanford.edu/about-stanford-libraries/collection-highlights", class: 'dropdown-item' %>
       <%= link_to "Special Collections & University Archives",
                   "https://library.stanford.edu/libraries/special-collections", class: 'dropdown-item' %>
       <%= link_to "Support the Stanford Libraries",


### PR DESCRIPTION
## Summary
- update the "Explore library collections at Stanford" masthead link to the replacement URL suggested in #3127
- keep the existing link text and dropdown structure unchanged

## Checks
- confirmed `https://library.stanford.edu/explore-collections` returns HTTP 404
- confirmed `https://library.stanford.edu/about-stanford-libraries/collection-highlights` returns HTTP 200
- reviewed the one-line diff

Closes #3127