### PR TITLE
Prevent cron from sending emails about the db collation

### DIFF
--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,1 +1,5 @@
-ActsAsTaggableOn.force_binary_collation = true
+# frozen_string_literal: true
+
+ActiveRecord::Migration.suppress_messages do
+  ActsAsTaggableOn.force_binary_collation = true
+end


### PR DESCRIPTION
We get messages every day from cron just with a warning about setting the collation for mysql. This are annoying.