### PR TITLE
Set up mechanism to retire and redirect an exhibit slug

### DIFF
--- a/app/models/concerns/exhibit_extension.rb
+++ b/app/models/concerns/exhibit_extension.rb
@@ -6,7 +6,21 @@
 module ExhibitExtension
   extend ActiveSupport::Concern
 
+  class_methods do
+    # Slugs of retired exhibits that now 301-rdirect (see
+    # Settings.retired_exhibit_slugs and config/routes.rb). They must never be
+    # reassigned to a new exhibit, or the redirect would shadow it and
+    # make the new exhibit unreachable.
+    def retired_slugs
+      Settings.retired_exhibit_slugs.to_h.keys.map(&:to_s)
+    end
+  end
+
   included do
+    # Reserve retired slugs so the admin slug form rejects them ("is reserved"),
+    # the same mechanism Spotlight uses to reserve "site".
+    friendly_id_config.reserved_words.concat(retired_slugs - friendly_id_config.reserved_words)
+
     has_one :viewer, dependent: :delete
 
     after_update :send_publish_state_change_notification

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,14 @@ Exhibits::Application.routes.draw do
     # This should be switched back to RangeSearchable when blacklight_range_limit removes the deprecated 'range_limit_panel/:id' route.
     concern :range_searchable, BlacklightRangeLimit::Routes::ExhibitsRangeSearchable.new
 
+    # Retired exhibits: each old slug 301s to its replacement (see
+    # Settings.retired_exhibit_slugs). Content may differ, so all sub-paths map to
+    # to the new exhibit root rather than mapping path-for-path.
+    (Settings.retired_exhibit_slugs&.to_h || {}).each do |old_slug, new_slug|
+      get "/#{old_slug}", to: redirect("/#{new_slug}", status: 301)
+      get "/#{old_slug}/*path", to: redirect("/#{new_slug}", status: 301)
+    end
+
     # this has to come before the Blacklight + Spotlight routes to avoid getting routed as
     # a document request.
     resources :exhibits, path: '/', only: [] do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,6 +43,13 @@ throttling:
 nondiscoverable_exhibit_slugs:
   - exhibits-documentation
 
+# Exhibit slugs that have been retired. Each key is the old slug and its value is
+# the replacement exhibit slug it should 301-redirect to. This setting drives
+# both the redirect (config/routes.rb) and slug reservation (ExhibitExtension),
+# so a retired slug can never be reassigned to a new exhibit and shadowed by the redirect.
+retired_exhibit_slugs:
+  supra: piano-roll-program
+
 exhibit_themes:
   default:
     - default

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Spotlight::Exhibit do
       end
     end
 
+    describe 'retired slugs' do
+      it 'rejects a retired slug so it cannot be reassigned to a new exhibit' do
+        exhibit = build(:exhibit)
+        exhibit.slug = 'supra'
+
+        expect(exhibit).not_to be_valid
+        expect(exhibit.errors[:slug]).to include('is reserved')
+      end
+    end
+
     describe 'discoverable scope' do
       it 'blacklists exhibits based on their slug via config' do
         exhibit1 = create(:exhibit)

--- a/spec/requests/retired_slug_redirect_spec.rb
+++ b/spec/requests/retired_slug_redirect_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Retired exhibit redirect' do
+  it 'redirects the base slug to the replacement exhibit with a 301 status' do
+    get '/supra'
+
+    expect(response).to redirect_to('/piano-roll-program')
+    expect(response).to have_http_status(:moved_permanently)
+  end
+
+  it 'redirects sub-paths to the new exhibit root' do
+    get '/supra/feature/some-page'
+
+    expect(response).to redirect_to('/piano-roll-program')
+    expect(response).to have_http_status(:moved_permanently)
+  end
+
+  it 'redirects the slug when a locale is specified' do
+    get '/en/supra'
+
+    expect(response).to redirect_to('/piano-roll-program')
+    expect(response).to have_http_status(:moved_permanently)
+  end
+end


### PR DESCRIPTION
I'm not sure if this has ever come up before, but we have the need to retire an existing exhibit (https://exhibits.stanford.edu/supra) which is being replaced by https://exhibits.stanford.edu/piano-roll-program. The exhibit creator wants to redirect from /supra to the new exhibit. The plan is to unpublish `supra` and change its slug to `supra-backup` or `supra-retired`.

This PR makes it possible to configure a retired slug to redirect to its replacement exhibit and reserves the old slug so no one tries to use it in the future.