### PR TITLE
Set min recaptcha score to 0.5

### DIFF
--- a/app/controllers/spotlight/contact_forms_controller.rb
+++ b/app/controllers/spotlight/contact_forms_controller.rb
@@ -12,7 +12,7 @@ module Spotlight
     def create
       return render 'new' unless @contact_form.valid?
 
-      if verify_recaptcha(action: 'feedback')
+      if verify_recaptcha(action: 'feedback', minimum_score: 0.5)
         send_feedback
       else
         report_failure


### PR DESCRIPTION
We're getting some spam through the feedback form and I think it might be because we're not setting a min score.