### PR TITLE
Disable active storage variants to avoid warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,10 @@ module Exhibits
     #
     config.time_zone = 'Pacific Time (US & Canada)'
 
+    # We don't use Active Storage variants.
+    # Disabling avoids a boot warning about the missing libvips library.
+    config.active_storage.variant_processor = :disabled
+
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
Fixes cron warning:

```
Using vips to process variants requires the libvips library. Please install libvips using the instructions on the libvips website.
```