### PR TITLE
Prevent cross-host redirect

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -10,7 +10,7 @@ class LoginController < ApplicationController
 
   def login
     if params[:referrer]
-      redirect_to params[:referrer]
+      redirect_to url_from(params[:referrer]) || root_url
     else
       redirect_back_or_to(root_url)
     end

--- a/spec/controllers/login_controller_spec.rb
+++ b/spec/controllers/login_controller_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe LoginController do
       expect(response).to redirect_to '/home'
       expect(user).to have_received(:accept_invitation!)
     end
+
+    it 'redirects to the home page when the referrer is on another host' do
+      get :login, params: {
+        referrer: 'https://exhibits-lb.stanford.edu/zh/saytheirnames/catalog?f%5Bpub_year_w_approx_isi%5D%5B%5D=2018'
+      }
+
+      expect(response).to redirect_to '/'
+    end
   end
 
   context 'with a referrer header' do


### PR DESCRIPTION
This handles a cross-host redirection attempt instead of raising an error in Honeybadger

Fixes #3160 