### PR TITLE
Fallback to default viewer without referencing a specific exhibit

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,8 @@ module ApplicationHelper
       render partial: current_exhibit.required_viewer.to_partial_path,
              locals: { document: document, block: block, canvas: canvas }
     else
-      render partial: current_exhibit.required_viewer.default_viewer_path,
+      # On the global catalog show or a feature page fall back to the default viewer
+      render partial: Viewer.new.default_viewer_path,
              locals: { document: document, block: block, canvas: canvas }
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#render_viewer_in_context' do
+    let(:document) { SolrDocument.new(druid: 'abc123') }
+
+    context 'outside an exhibit (e.g. the global catalog show)' do
+      before do
+        without_partial_double_verification do
+          allow(helper).to receive_messages(params: { controller: 'catalog' }, current_exhibit: nil)
+        end
+      end
+
+      it 'renders the default viewer' do
+        allow(helper).to receive(:render)
+        helper.render_viewer_in_context(document, nil)
+        expect(helper).to have_received(:render).with(
+          partial: 'oembed_default', locals: hash_including(document: document)
+        )
+      end
+    end
+  end
+
   describe '#choose_canvas_id' do
     context 'with a valid SirTrevor Block' do
       let(:canvas_index) { 4 }


### PR DESCRIPTION
I think this is mostly bots, but this should fix: https://app.honeybadger.io/projects/49092/faults/124769426